### PR TITLE
Slight reorg of build/deploy scripts

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -3,7 +3,7 @@ script:
         - oc login -u kubeadmin -p mhk2X-Y8ozE-9icYb-uLCdV --insecure-skip-tls-verify=true https://api.crc.testing:6443
         - oc new-project "${OCP_PROJECT}"
         - ./build/build.sh
-        - ./build/deploy_ci.sh
+        - ./deploy/deploy_ci.sh
         - ./tests/smoketest/smoketest.sh
 after_script:
         - export HOME=$(dirname "$PWD")

--- a/deploy/deploy_ci.sh
+++ b/deploy/deploy_ci.sh
@@ -3,7 +3,7 @@
 # Entrypoint to build and deploy for CI
 #
 set -e
-REL=$(dirname "$0"); source "${REL}/metadata.sh"
+REL=$(dirname "$0"); source "${REL}/../build/metadata.sh"
 
 # Running quickstart triggers an initial install via a subscription.
 # OLM satisfies dependencies via the subscription, allowing us to test our deps
@@ -12,7 +12,7 @@ REL=$(dirname "$0"); source "${REL}/metadata.sh"
 # object itself, effectively preventing the original operator from doing
 # "anything" (except establishing the CRD.... and...?)
 echo -e "\n* [info] Running quickstart...\n"
-QUICKSTART_CONFIG="configs/nostf.bash" "${REL}/../deploy/quickstart.sh"
+QUICKSTART_CONFIG="configs/nostf.bash" "${REL}/quickstart.sh"
 
 # After quickstart, a CSV pointing at the upstream SAO image will be installed.
 # This script removes it and replaces it with the patched version
@@ -20,7 +20,7 @@ echo -e "\n* [info] Re-deploying with local build...\n"
 "${REL}/deploy_local_build.sh"
 
 # Now we can install an SAF object for the locally built operator to work on
-source "${REL}/../deploy/${QUICKSTART_CONFIG}"
+source "${REL}/${QUICKSTART_CONFIG}"
 oc create -f - <<< "${KIND_SERVICEASSURANCE}"
 
 # Play the (automated!) waiting game

--- a/deploy/deploy_local_build.sh
+++ b/deploy/deploy_local_build.sh
@@ -6,7 +6,7 @@
 # in the OCP registry. See build/push_container2ocp.sh for more information
 #
 set -e
-REL=$(dirname "$0"); source "${REL}/metadata.sh"
+REL=$(dirname "$0"); source "${REL}/../build/metadata.sh"
 
 CSV_NAME="${OPERATOR_NAME}.v${CSV_VERSION}"
 
@@ -29,9 +29,9 @@ for kind in serviceaccount role rolebinding; do
         sleep 3
     done
 done
-oc create -f "${REL}/../deploy/service_account.yaml"
-oc create -f "${REL}/../deploy/role.yaml"
-oc create -f "${REL}/../deploy/role_binding.yaml"
+oc create -f "${REL}/service_account.yaml"
+oc create -f "${REL}/role.yaml"
+oc create -f "${REL}/role_binding.yaml"
 
 # Mutate the CSV to pull the image from the OCP registry and install it
 oc create -f <(sed "\

--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-REL=$(dirname "$0");
-OCP_PROJECT=${OCP_PROJECT:-service-telemetry}
-QUICKSTART_CONFIG=${QUICKSTART_CONFIG:-configs/default.bash}
+REL=$(dirname "$0"); source "${REL}/../build/metadata.sh"
+
 source "${REL}/${QUICKSTART_CONFIG}"
 
 oc new-project "${OCP_PROJECT}"

--- a/deploy/remove_stf.sh
+++ b/deploy/remove_stf.sh
@@ -2,7 +2,7 @@
 #
 # Removes SAF and (optionally) amq7 certmanager from your cluster
 #
-OCP_PROJECT=${OCP_PROJECT:-service-telemetry}
+REL=$(dirname "$0"); . "${REL}/../build/metadata.sh"
 REMOVE_CERTMANAGER=${REMOVE_CERTMANAGER:-true}
 
 # The whole SAF project (start this first since it's slow)


### PR DESCRIPTION
* More clear delineation between build/deploy/test
* A bit more DRY, but moves "deploy" defaults into the "build" directory
  * In practice these were the same
  * Your actual envvars always win anyways
* 100% of this change should be tested by the CI Bot