### PR TITLE
Quickstart on quicklab was broken

### DIFF
--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -104,5 +104,5 @@ spec:
 EOF
 while ! oc get csv | grep service-telemetry-operator | grep Succeeded; do echo "waiting for SAO..."; sleep 3; done
 if [ ! -z "${KIND_SERVICEASSURANCE}" ]; then
-  oc create -f - <<< ${KIND_SERVICEASSURANCE}
+  oc create -f - <<< "${KIND_SERVICEASSURANCE}"
 fi


### PR DESCRIPTION
# Bug

```
$ QUICKSTART_CONFIG=configs/quicklab.bash ./deploy/quickstart.sh
[...]
waiting for SAO...
service-telemetry-operator.v0.1.1   Service Telemetry Operator    0.1.1                                      Succeeded
error: error parsing STDIN: error converting YAML to JSON: yaml: mapping values are not allowed in this context

$ source ./deploy/configs/quicklab.bash

$ oc create -f - <<< ${KIND_SERVICEASSURANCE}
error: error parsing STDIN: error converting YAML to JSON: yaml: mapping values are not allowed in this context
```

Huh.

# Fix

```
$ echo "$KIND_SERVICEASSURANCE" > t.yml

$ oc create -f t.yml 
servicetelemetry.infra.watch/stf-default created

$ oc delete servicetelemetry --all
servicetelemetry.infra.watch "stf-default" deleted

$ oc create -f - <<< "${KIND_SERVICEASSURANCE}"
servicetelemetry.infra.watch/stf-default created
```

Note the quotes.

# Testing

This is not covered by CI because the only QUICKSTART_CONFIG override we test with is a blank one.

```
$ oc delete servicetelemetry --all
servicetelemetry.infra.watch "stf-default" deleted

$ QUICKSTART_CONFIG=configs/quicklab.bash ./deploy/quickstart.sh 
[...]
service-telemetry-operator.v0.1.1   Service Telemetry Operator    0.1.1                                 Succeeded
servicetelemetry.infra.watch/stf-default created
```
