### PR TITLE
Configure alertmanager for ephemeral storage

### DIFF
--- a/deploy/configs/quicklab.bash
+++ b/deploy/configs/quicklab.bash
@@ -7,6 +7,20 @@ metadata:
 spec:
   metricsEnabled: true
   eventsEnabled: true
+  alertmanager_manifest: |
+    apiVersion: monitoring.coreos.com/v1
+    kind: Alertmanager
+    metadata:
+      labels:
+        alertmanager: stf-default
+      name: stf-default
+      namespace: service-telemetry
+    spec:
+      replicas: 1
+      serviceAccountName: prometheus-k8s
+      serviceMonitorSelector:
+        matchLabels:
+          app: smart-gateway
   prometheus_manifest: |
     apiVersion: monitoring.coreos.com/v1
     kind: Prometheus


### PR DESCRIPTION
Modify the quicklab.bash configuration to override the default storage for
alertmanager to be ephemeral vs persistent so that alertmanager can start
up without issues in a QuickLAB environment.

Closes #52