### PR TITLE
ci.yml homedir bug fix

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,5 +1,5 @@
 global:
-        timeout: 60
+        timeout: 2400
 script:
         - oc login -u kubeadmin -p mhk2X-Y8ozE-9icYb-uLCdV --insecure-skip-tls-verify=true https://api.crc.testing:6443
         - oc delete project "${OCP_PROJECT}" || true

--- a/ci.yml
+++ b/ci.yml
@@ -2,6 +2,7 @@ global:
         timeout: 60
 script:
         - oc login -u kubeadmin -p mhk2X-Y8ozE-9icYb-uLCdV --insecure-skip-tls-verify=true https://api.crc.testing:6443
+        - oc delete project "${OCP_PROJECT}" || true
         - oc new-project "${OCP_PROJECT}"
         - ./build/build.sh
         - ./deploy/deploy_ci.sh

--- a/ci.yml
+++ b/ci.yml
@@ -1,10 +1,10 @@
+global:
+        timeout: 60
 script:
-        - export HOME=$(dirname "$PWD")
         - oc login -u kubeadmin -p mhk2X-Y8ozE-9icYb-uLCdV --insecure-skip-tls-verify=true https://api.crc.testing:6443
         - oc new-project "${OCP_PROJECT}"
         - ./build/build.sh
         - ./deploy/deploy_ci.sh
         - ./tests/smoketest/smoketest.sh
 after_script:
-        - export HOME=$(dirname "$PWD")
         - ./deploy/remove_stf.sh


### PR DESCRIPTION
There was a change made to ci.yml that would swap the home directories that stopped the STF CR from being launched after the build of the operator completed. $HOME is set to the root directory of the repository by default and as a result the ci.yml script adjusting that home location, some of the script commands could not find the proper resources.

A time out option was exposed to the ci.yml and included in this PR for demonstration purposes.