### PR TITLE
Migrate to using camelCase instead of snake_case

### DIFF
--- a/roles/servicetelemetry/tasks/component_events_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/component_events_smartgateway.yml
@@ -23,18 +23,18 @@
         size: 1
         amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notify'
         serviceType: 'events'
-        debug: 'false'
+        debug: false
         elasticUrl: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
-        useBasicAuth: 'true'
+        useBasicAuth: true
         elasticUser: '{{ elastic_user }}'
         elasticPass: '{{ elastic_pass }}'
         containerImagePath: 'quay.io/infrawatch/smart-gateway:latest'
-        useTls: 'true'
+        useTls: true
         tlsClientCert: /config/certs/tls.crt
         tlsClientKey: /config/certs/tls.key
         tlsCaCert: /config/certs/ca.crt
         tlsServerName: 'elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local'
-        resetIndex: 'false'
+        resetIndex: false
   when: smartgateway_events_manifest is not defined
 
 - name: Deploy instance of Smart Gateway for Events

--- a/roles/servicetelemetry/tasks/component_events_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/component_events_smartgateway.yml
@@ -21,20 +21,20 @@
         namespace: '{{ meta.namespace }}'
       spec:
         size: 1
-        amqp_url: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notify'
-        service_type: 'events'
+        amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notify'
+        serviceType: 'events'
         debug: 'false'
-        elastic_url: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
-        use_basic_auth: 'true'
-        elastic_user: '{{ elastic_user }}'
-        elastic_pass: '{{ elastic_pass }}'
-        container_image_path: 'quay.io/infrawatch/smart-gateway:latest'
-        use_tls: 'true'
-        tls_client_cert: /config/certs/tls.crt
-        tls_client_key: /config/certs/tls.key
-        tls_ca_cert: /config/certs/ca.crt
-        tls_server_name: 'elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local'
-        reset_index: 'false'
+        elasticUrl: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
+        useBasicAuth: 'true'
+        elasticUser: '{{ elastic_user }}'
+        elasticPass: '{{ elastic_pass }}'
+        containerImagePath: 'quay.io/infrawatch/smart-gateway:latest'
+        useTls: 'true'
+        tlsClientCert: /config/certs/tls.crt
+        tlsClientKey: /config/certs/tls.key
+        tlsCaCert: /config/certs/ca.crt
+        tlsServerName: 'elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local'
+        resetIndex: 'false'
   when: smartgateway_events_manifest is not defined
 
 - name: Deploy instance of Smart Gateway for Events

--- a/roles/servicetelemetry/tasks/component_metrics_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/component_metrics_smartgateway.yml
@@ -9,11 +9,11 @@
       spec:
         amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/telemetry'
         containerImagePath: 'quay.io/infrawatch/smart-gateway:latest'
-        debug: 'false'
+        debug: false
         serviceType: 'metrics'
         size: 1
         prefetch: 15000
-        useTimestamp: 'true'
+        useTimestamp: true
   when: smartgateway_metrics_manifest is not defined
 
 - name: Deploy instance of Smart Gateway for Metrics

--- a/roles/servicetelemetry/tasks/component_metrics_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/component_metrics_smartgateway.yml
@@ -7,13 +7,13 @@
         name: '{{ meta.name }}-telemetry'
         namespace: '{{ meta.namespace }}'
       spec:
-        amqp_url: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/telemetry'
-        container_image_path: 'quay.io/infrawatch/smart-gateway:latest'
+        amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/telemetry'
+        containerImagePath: 'quay.io/infrawatch/smart-gateway:latest'
         debug: 'false'
-        service_type: 'metrics'
+        serviceType: 'metrics'
         size: 1
         prefetch: 15000
-        use_timestamp: 'true'
+        useTimestamp: 'true'
   when: smartgateway_metrics_manifest is not defined
 
 - name: Deploy instance of Smart Gateway for Metrics


### PR DESCRIPTION
Migrate to using camelCase for the SmartGateway object creation instead of
using snake_case directly. This is primarily a vanity fix so that we're
consistently using the same casing model across the deployment.

Depends on https://github.com/infrawatch/smart-gateway-operator/pull/39