### PR TITLE
ir script was not working with ceph, removed ceph

### DIFF
--- a/tests/infrared/16/infrared-openstack.sh
+++ b/tests/infrared/16/infrared-openstack.sh
@@ -30,7 +30,7 @@ infrared virsh \
 infrared virsh \
     -vvv \
     -o outputs/provision.yml \
-    --topology-nodes undercloud:1,controller:1,compute:1,ceph:1 \
+    --topology-nodes undercloud:1,controller:1,compute:1 \
     --host-address "${VIRTHOST}" \
     --host-key "${SSH_KEY}" \
     --image-url "${VM_IMAGE}" \
@@ -62,8 +62,6 @@ infrared tripleo-overcloud \
     --network-backend geneve \
     --network-protocol ipv4 \
     --network-dvr yes \
-    --storage-backend ceph \
-    --storage-external no \
     --overcloud-ssl no \
     --introspect yes \
     --tagging yes \


### PR DESCRIPTION
Not 100% sure we should merge this, since ceph **should** work, but this was in my way.

```
Feb 27 02:55:33 puppet-user: Error: Evaluation Error: Error while evaluating a Function Call, Lookup of key 'tripleo::profile::base::metrics::collectd::amqp_host' failed: Syntax error in string: %{hiera(hiera('ceph_storage_hostname_resolve_network'))} (file: /etc/config.pp, line: 2, column: 1) on node ceph-0.redhat.local
```

We can either document the workaround on the wiki until it's fixed, or fix it here and remember to unfix it later.

Credit to @pleimer for showing me the workaround.