### PR TITLE
Include Tripleo templates for placing ceilometer events on interonnect bus

### DIFF
--- a/tests/infrared/16/metrics-qdr-connectors.yaml.template
+++ b/tests/infrared/16/metrics-qdr-connectors.yaml.template
@@ -2,7 +2,7 @@
 tripleo_heat_templates:
     - /usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-write-qdr.yaml
     - /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml
-    - /usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml 
+    - /usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml
     - /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml
 
 custom_templates:

--- a/tests/infrared/16/metrics-qdr-connectors.yaml.template
+++ b/tests/infrared/16/metrics-qdr-connectors.yaml.template
@@ -2,6 +2,8 @@
 tripleo_heat_templates:
     - /usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-write-qdr.yaml
     - /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml
+    - /usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml 
+    - /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml
 
 custom_templates:
     parameter_defaults:


### PR DESCRIPTION
I am not sure this is what should be merged into the main branch since it uses the enable-legacy-telemetry.yaml, but wanted to add this here to track what I used.