### PR TITLE
Add Smart Gateway Debug Enablement

### DIFF
--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -39,8 +39,17 @@ spec:
             metricsEnabled:
               description: Whether the Service Telemetry Operator should enable components related to metrics collection and storage.
               type: boolean
+            metricsSmartGatewayCollectdDebugEnabled:
+              description: Enable Collectd Smart Gateway debugging for collectd telemetry
+              type: boolean
             eventsEnabled:
               description: Whether the Service Telemetry Operator should enable components related to events collection and storage.
+              type: boolean
+            eventsSmartGatewayCollectdDebugEnabled:
+              description: Enable Collectd Smart Gateway debugging for collectd notification
+              type: boolean
+            eventsSmartGatewayCeilometerDebugEnabled:
+              description: Enable Collectd Smart Gateway debugging for ceilometer notification
               type: boolean
             highAvailabilityEnabled:
               description: Whether to deploy the services in HA mode.

--- a/deploy/crds/infra.watch_v1alpha1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1alpha1_servicetelemetry_cr.yaml
@@ -5,5 +5,6 @@ metadata:
 spec:
   metricsEnabled: true
   eventsEnabled: false
+  debug: true
   highAvailabilityEnabled: false
 # vim: set ft=yaml shiftwidth=2 tabstop=2 expandtab:

--- a/deploy/crds/infra.watch_v1alpha1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1alpha1_servicetelemetry_cr.yaml
@@ -4,7 +4,9 @@ metadata:
   name: stf-default
 spec:
   metricsEnabled: true
+  metricsSmartGatewayCollectdDebugEnabled: false
   eventsEnabled: false
-  debug: true
+  eventsSmartGatewayCollectdDebugEnabled: false
+  eventsSmartGatewayCeilometerDebugEnabled: false
   highAvailabilityEnabled: false
 # vim: set ft=yaml shiftwidth=2 tabstop=2 expandtab:

--- a/deploy/olm-catalog/service-telemetry-operator/0.1.1/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/0.1.1/infra.watch_servicetelemetrys_crd.yaml
@@ -39,8 +39,17 @@ spec:
             metricsEnabled:
               description: Whether the Service Telemetry Operator should enable components related to metrics collection and storage.
               type: boolean
+            metricsSmartGatewayCollectdDebugEnabled:
+              description: Enable Collectd Smart Gateway debugging for collectd telemetry
+              type: boolean
             eventsEnabled:
               description: Whether the Service Telemetry Operator should enable components related to events collection and storage.
+              type: boolean
+            eventsSmartGatewayCollectdDebugEnabled:
+              description: Enable Collectd Smart Gateway debugging for collectd notification
+              type: boolean
+            eventsSmartGatewayCeilometerDebugEnabled:
+              description: Enable Collectd Smart Gateway debugging for ceilometer notification
               type: boolean
             highAvailabilityEnabled:
               description: Whether to deploy the services in HA mode.

--- a/deploy/olm-catalog/service-telemetry-operator/0.1.1/service-telemetry-operator.v0.1.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/0.1.1/service-telemetry-operator.v0.1.1.clusterserviceversion.yaml
@@ -62,9 +62,24 @@ spec:
         path: metricsEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enable Smart Gateway debugging for collectd telemetry
+        displayName: Smart Gateway Collectd Telemetry Debugging
+        path: metricsSmartGatewayCollectdDebugEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Whether to enable collection and storage components for events
         displayName: Events Enabled
         path: eventsEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enable Smart Gateway debugging for collectd notifications
+        displayName: Smart Gateway Collectd Telemetry Debugging
+        path: eventsSmartGatewayCollectdDebugEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enable Smart Gateway debugging for ceilometer notifications
+        displayName: Smart Gateway Ceilometer Notification Debugging
+        path: eventsSmartGatewayCeilometerDebugEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Whether to enable high availability for Service Telemetry components

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -1,7 +1,10 @@
 ---
 # set default enablement
 metrics_enabled: true
+metrics_smart_gateway_collectd_debug_enabled: false
 events_enabled: false
+events_smart_gateway_collectd_debug_enabled: false
+events_smart_gateway_ceilometer_debug_enabled: false
 high_availability_enabled: false
 
 # default values

--- a/roles/servicetelemetry/tasks/component_events_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/component_events_smartgateway.yml
@@ -24,7 +24,7 @@
         amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notify'
         amqpDataSource: 'collectd'
         serviceType: 'events'
-        debug: false
+        debug: {{ events_smart_gateway_collectd_debug_enabled }}
         elasticUrl: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
         useBasicAuth: true
         elasticUser: '{{ elastic_user }}'
@@ -51,7 +51,7 @@
         amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/ceilometer/event.sample'
         amqpDataSource: 'ceilometer'
         serviceType: 'events'
-        debug: false
+        debug: {{ events_smart_gateway_ceilometer_debug_enabled }}
         elasticUrl: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
         useBasicAuth: true
         elasticUser: '{{ elastic_user }}'

--- a/roles/servicetelemetry/tasks/component_metrics_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/component_metrics_smartgateway.yml
@@ -9,7 +9,7 @@
       spec:
         amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/telemetry'
         containerImagePath: 'quay.io/infrawatch/smart-gateway:latest'
-        debug: false
+        debug: {{ metrics_smart_gateway_collectd_debug_enabled }}
         serviceType: 'metrics'
         size: 1
         prefetch: 15000


### PR DESCRIPTION
Provide ability to enable debugging with a simple flag on the ServiceTelemetry CR
for the various Smart Gateways we have.