### PR TITLE
Enable metrics and events from ceilometer

### DIFF
--- a/tests/infrared/16/metrics-qdr-connectors.yaml.template
+++ b/tests/infrared/16/metrics-qdr-connectors.yaml.template
@@ -6,9 +6,10 @@ tripleo_heat_templates:
     - /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml
 
 custom_templates:
-    CeilometerQdrPublishEvents: true
-    CeilometerQdrPublishMetrics: true
     parameter_defaults:
+        CeilometerQdrPublishEvents: true
+        CeilometerQdrPublishMetrics: true
+
         MetricsQdrConnectors:
             - host: <<AMQP_HOST>>
               port: <<AMQP_PORT>>

--- a/tests/infrared/16/metrics-qdr-connectors.yaml.template
+++ b/tests/infrared/16/metrics-qdr-connectors.yaml.template
@@ -6,6 +6,8 @@ tripleo_heat_templates:
     - /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml
 
 custom_templates:
+    CeilometerQdrPublishEvents: true
+    CeilometerQdrPublishMetrics: true
     parameter_defaults:
         MetricsQdrConnectors:
             - host: <<AMQP_HOST>>


### PR DESCRIPTION
Pre-emptive addition of configurations necessary to enable ceilometer events and metrics once Martin's Tripleo patches get merged