### PR TITLE
Smart Gateway deployment improvements

### DIFF
--- a/roles/servicetelemetry/tasks/base_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/base_smartgateway.yml
@@ -1,0 +1,12 @@
+- name: Figure out manifest override parameter
+  set_fact:
+    smartgateway_manifest_override: "smartgateway_{{ agent.name|lower }}_{{ data_type }}_manifest"
+- name: "Create default Smart Gateway manifest for {{ agent_name }} {{ data_type }}"
+  set_fact:
+    "{{ smartgateway_manifest_override }}": "{{ lookup('template', manifest) }}"
+  when: "{{ smartgateway_manifest_override }} is not defined"
+  tags:
+    - skip_ansible_lint
+- name: "Deploy instance of Smart Gateway for {{ agent_name }} {{ data_type }}"
+  k8s:
+    definition: "{{ lookup('vars', smartgateway_manifest_override) }}"

--- a/roles/servicetelemetry/tasks/base_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/base_smartgateway.yml
@@ -1,12 +1,20 @@
 - name: Figure out manifest override parameter
   set_fact:
     smartgateway_manifest_override: "smartgateway_{{ agent.name|lower }}_{{ data_type }}_manifest"
-- name: "Create default Smart Gateway manifest for {{ agent_name }} {{ data_type }}"
+
+- name: What SmartGateway manifest are we working on?
+  debug:
+    msg: "Working on {{ smartgateway_manifest_override }}"
+
+- name: "Generate Smart Gateway manifest and store when override is not provided"
   set_fact:
     "{{ smartgateway_manifest_override }}": "{{ lookup('template', manifest) }}"
-  when: "{{ smartgateway_manifest_override }} is not defined"
-  tags:
-    - skip_ansible_lint
-- name: "Deploy instance of Smart Gateway for {{ agent_name }} {{ data_type }}"
+  when: "vars[smartgateway_manifest_override] is not defined"
+
+- name: "Show manifest we're going to load"
+  debug:
+    var: vars[smartgateway_manifest_override] | from_yaml
+
+- name: "Deploy instance of Smart Gateway"
   k8s:
-    definition: "{{ lookup('vars', smartgateway_manifest_override) }}"
+    definition: "{{ lookup('vars', smartgateway_manifest_override) | from_yaml }}"

--- a/roles/servicetelemetry/tasks/component_events_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/component_events_smartgateway.yml
@@ -11,64 +11,14 @@
     elastic_pass: "{{ elasticsearch_es_elastic_user | json_query('resources[].data.elastic') | b64decode }}"
   no_log: true
 
-- name: Create default Events Smart Gateway manifest for collectd
-  set_fact:
-    smartgateway_collectd_events_manifest: |
-      apiVersion: smartgateway.infra.watch/v2alpha1
-      kind: SmartGateway
-      metadata:
-        name: '{{ meta.name }}-collectd-notification'
-        namespace: '{{ meta.namespace }}'
-      spec:
-        size: 1
-        amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notify'
-        amqpDataSource: 'collectd'
-        serviceType: 'events'
-        debug: false
-        elasticUrl: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
-        useBasicAuth: true
-        elasticUser: '{{ elastic_user }}'
-        elasticPass: '{{ elastic_pass }}'
-        useTls: true
-        tlsClientCert: /config/certs/tls.crt
-        tlsClientKey: /config/certs/tls.key
-        tlsCaCert: /config/certs/ca.crt
-        tlsServerName: 'elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local'
-        resetIndex: false
-  when: smartgateway_collectd_events_manifest is not defined
-
-- name: Create default Events Smart Gateway manifest for ceilometer
-  set_fact:
-    smartgateway_ceilometer_events_manifest: |
-      apiVersion: smartgateway.infra.watch/v2alpha1
-      kind: SmartGateway
-      metadata:
-        name: '{{ meta.name }}-ceilometer-notification'
-        namespace: '{{ meta.namespace }}'
-      spec:
-        size: 1
-        amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/ceilometer/event.sample'
-        amqpDataSource: 'ceilometer'
-        serviceType: 'events'
-        debug: false
-        elasticUrl: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
-        useBasicAuth: true
-        elasticUser: '{{ elastic_user }}'
-        elasticPass: '{{ elastic_pass }}'
-        useTls: true
-        tlsClientCert: /config/certs/tls.crt
-        tlsClientKey: /config/certs/tls.key
-        tlsCaCert: /config/certs/ca.crt
-        tlsServerName: 'elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local'
-        resetIndex: false
-  when: smartgateway_ceilometer_events_manifest is not defined
-
-- name: Deploy instance of Smart Gateway for Collectd Events
-  k8s:
-    definition:
-      '{{ smartgateway_collectd_events_manifest }}'
-
-- name: Deploy instance of Smart Gateway for Ceilometer Events
-  k8s:
-    definition:
-      '{{ smartgateway_ceilometer_events_manifest }}'
+- name: Deploy Events Smart Gateway instance for each agent
+  vars:
+    data_type: 'events'
+    manifest: './manifest_smartgateway_events.j2'
+  include_tasks: base_smartgateway.yml
+  loop:
+    - { name: 'Collectd', channel: 'collectd/notify'}
+    - { name: 'Ceilometer', channel: 'anycast/ceilometer/event.sample'}
+  loop_control:
+    loop_var: agent
+    label: "{{ agent.name }}"

--- a/roles/servicetelemetry/tasks/component_metrics_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/component_metrics_smartgateway.yml
@@ -1,21 +1,11 @@
-- name: Create default Metrics Smart Gateway manifest
-  set_fact:
-    smartgateway_collectd_metrics_manifest: |
-      apiVersion: smartgateway.infra.watch/v2alpha1
-      kind: SmartGateway
-      metadata:
-        name: '{{ meta.name }}-collectd-telemetry'
-        namespace: '{{ meta.namespace }}'
-      spec:
-        amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/telemetry'
-        debug: false
-        serviceType: 'metrics'
-        size: 1
-        prefetch: 15000
-        useTimestamp: true
-  when: smartgateway_collectd_metrics_manifest is not defined
-
-- name: Deploy instance of Smart Gateway for Collectd Metrics
-  k8s:
-    definition:
-      '{{ smartgateway_collectd_metrics_manifest }}'
+- name: Deploy Metrics Smart Gateway instance for each agent
+  vars:
+    data_type: 'metrics'
+    manifest: './manifest_smartgateway_metrics.j2'
+  include_tasks: base_smartgateway.yml
+  loop:
+    - { name: 'Collectd', channel: 'collectd/telemetry'}
+    #- { name: 'Ceilometer', channel: 'anycast/ceilometer/metric.sample'}
+  loop_control:
+    loop_var: agent
+    label: "{{ agent.name }}"

--- a/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
@@ -1,0 +1,21 @@
+apiVersion: smartgateway.infra.watch/v2alpha1
+kind: SmartGateway
+metadata:
+  name: '{{ meta.name }}-{{ agent.name|lower }}-notification'
+  namespace: '{{ meta.namespace }}'
+spec:
+  size: 1
+  amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/{{ agent.channel }}'
+  amqpDataSource: '{{ agent.name|lower }}'
+  serviceType: 'events'
+  debug: false
+  elasticUrl: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
+  useBasicAuth: true
+  elasticUser: '{{ elastic_user }}'
+  elasticPass: '{{ elastic_pass }}'
+  useTls: true
+  tlsClientCert: /config/certs/tls.crt
+  tlsClientKey: /config/certs/tls.key
+  tlsCaCert: /config/certs/ca.crt
+  tlsServerName: 'elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local'
+  resetIndex: false

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -1,0 +1,12 @@
+apiVersion: smartgateway.infra.watch/v2alpha1
+kind: SmartGateway
+metadata:
+  name: '{{ meta.name }}-{{ agent.name|lower }}-telemetry'
+  namespace: '{{ meta.namespace }}'
+spec:
+  amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/{{ agent.channel }}'
+  debug: false
+  serviceType: 'metrics'
+  size: 1
+  prefetch: 15000
+  useTimestamp: true


### PR DESCRIPTION
This patch:
  - exports manifest templates to template files (so that it can be pointed in documentation
    and possibly user can generate manifest using [1])
  - applies DRY principle on SG deployment for various data types and agents

[1] https://github.com/mattrobenolt/jinja2-cli