### PR TITLE
Resolve issues with deploy_ci.sh script

### DIFF
--- a/build/metadata.sh
+++ b/build/metadata.sh
@@ -5,11 +5,12 @@
 
 # Configure these
 OPERATOR_NAME=${OPERATOR_NAME:-service-telemetry-operator}
-CSV_VERSION=${CSV_VERSION:-1.0.0}
+CSV_VERSION=${CSV_VERSION:-1.0.1}
 IMAGE_BUILDER=${IMAGE_BUILDER:-podman}
 IMAGE_BUILD_ARGS=${IMAGE_BUILD_ARGS:-''}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 REQUIRED_OPERATOR_SDK_VERSION=${REQUIRED_OPERATOR_SDK_VERSION:-v0.15.2}
+SERVICE_TELEMETRY_SUBSCRIPTION=${SERVICE_TELEMETRY_SUBSCRIPTION:-servicetelemetry-operator-stable-infrawatch-operators-openshift-marketplace}
 
 # Automatic
 CSV_FILE=${CSV_FILE:-"deploy/olm-catalog/${OPERATOR_NAME}/${CSV_VERSION}/${OPERATOR_NAME}.v${CSV_VERSION}.clusterserviceversion.yaml"}

--- a/deploy/deploy_local_build.sh
+++ b/deploy/deploy_local_build.sh
@@ -11,7 +11,7 @@ REL=$(dirname "$0"); source "${REL}/../build/metadata.sh"
 CSV_NAME="${OPERATOR_NAME}.v${CSV_VERSION}"
 
 # Do a partial SAO uninstall (non-DRY/generic name, matches quickstart manifest)
-oc delete sub servicetelemetry-operator-beta-infrawatch-operators-openshift-marketplace || true
+oc delete sub ${SERVICE_TELEMETRY_SUBSCRIPTION} || true
 while oc get csv "${CSV_NAME}"; do
     oc delete csv "${CSV_NAME}" || true
     echo "Waiting for csv "${CSV_NAME}" to disappear"


### PR DESCRIPTION
Changes to the name of the CSV name resulted in failure to delete the CSV during
deploy_ci.sh testing. Updating to the proper name is now resulting in deploy_ci.sh
completing to the end.

Unblocks #82 