### PR TITLE
    Set label so tuned executes for elasticsearch mmap

### DIFF
--- a/roles/servicetelemetry/templates/manifest_elasticsearch.j2
+++ b/roles/servicetelemetry/templates/manifest_elasticsearch.j2
@@ -14,10 +14,13 @@ spec:
         node.data: true
         node.ingest: true
         node.master: true
-        node.store.allow_mmap: false
+        node.store.allow_mmap: true
       count: {{ elasticsearch_node_count }}
       name: default
       podTemplate:
+        metadata:
+          labels:
+            tuned.openshift.io/elasticsearch: elasticsearch
         spec:
           containers:
             - name: elasticsearch


### PR DESCRIPTION
    Set a label on the ElasticSearch pod(s) so that OpenShift's default Tuned profile will
    result in the proper setting of vm.max_map_count on the node where ElasticSearch is
    scheduled.
    
    Closes #81
