### PR TITLE
Tweaks to result in an OSP16 deployment

### DIFF
--- a/tests/infrared/16/metrics-qdr-connectors.yaml.template
+++ b/tests/infrared/16/metrics-qdr-connectors.yaml.template
@@ -1,8 +1,7 @@
 ---
 tripleo_heat_templates:
-    - /usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-write-qdr.yaml
-    - /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml
     - /usr/share/openstack-tripleo-heat-templates/environments/enable-legacy-telemetry.yaml
+    - /usr/share/openstack-tripleo-heat-templates/environments/enable-stf.yaml
     - /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml
 
 custom_templates:


### PR DESCRIPTION
Changes to the infrared-openstack.sh script to result in the successful deployment of OSP16.0
with Ceph and Tempest added for fun and profit. Parameterizes several options that were static
before to allow for a more flexible script while assuming primarily defaults will be utilized.

Re-adds the internal knowledge because it's been discussed that leaking this doesn't seem to
be a huge issue(?). Can pull it out in a subsequent commit as it'll be killed in a squash.