### PR TITLE
more debugging output after ci script runs

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -8,5 +8,8 @@ script:
   - ./deploy/deploy_ci.sh
   - ./tests/smoketest/smoketest.sh
 after_script:
+  - echo Final State; echo
   - oc get pods
+  - echo
+  - ./deploy/containerlogs.sh
   - ./deploy/remove_stf.sh

--- a/deploy/containerlogs.sh
+++ b/deploy/containerlogs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+PODS=$(oc get pods -o jsonpath="{.items[*].metadata.name}")
+podArr=($PODS)
+
+echo "Last 5 lines of POD:CONTAINER logs"
+for pod in "${podArr[@]}"
+do
+        containers=$(oc get pod "$pod" -ojsonpath="{.spec.containers[*].name}")
+        containerArr=($containers)
+
+        for container in "${containerArr[@]}"
+        do
+                echo
+                echo
+                echo
+                echo "====================== $pod:$container ======================"
+                oc logs "$pod" -c $container | tail -n5
+
+        done
+
+        echo 
+        echo
+done
+exit 0
+~      


### PR DESCRIPTION
Added in a script to show the logs of every container in STF before cleaning up everything. This way, if STF fails to deploy or a container hangs, we can see why before they are all deleted