### PR TITLE
Raise the linkCapacity of QDR->bridge

### DIFF
--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -34,6 +34,8 @@
             port: 5671
             saslMechanisms: ANONYMOUS
             sslProfile: openstack
+          - port: 5673
+            linkCapacity: 25000
         interRouterListeners:
           - authenticatePeer: true
             expose: true

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -4,7 +4,7 @@ metadata:
   name: '{{ meta.name }}-{{ agent.name|lower }}-telemetry'
   namespace: '{{ meta.namespace }}'
 spec:
-  amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/{{ agent.channel }}'
+  amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ agent.channel }}'
   debug: false
   serviceType: 'metrics'
   size: 1


### PR DESCRIPTION
* Adds a new edgeListener on 5673 with linkCapacity 25000
* Adjusts metrics SG bridge to connect to new listener
* Minimizes presettled metrics loss during throughput testing
  * Should also provide performance improvements in unsettled mode bursts
* Other SG modes can keep using 5672 until we converge the SG code