### PR TITLE
Enhance CI automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ The quickest way to start up Service Telemetry Framework for development is to
 run the `quickstart.sh` script located in the `deploy/` directory after starting
 up a [CodeReady Containers](https://github.com/code-ready/crc) environment.
 
-To deploy a local build of the Service Telemetry Operator itself, start by
-running `build/build_ci.sh`. Once that's done, you can test new builds of the
 core operator code like this:
 
 ```shell

--- a/build/metadata.sh
+++ b/build/metadata.sh
@@ -25,4 +25,3 @@ OCP_REGISTRY=${OCP_REGISTRY:-$(oc registry info)}
 OCP_REGISTRY_INTERNAL=${OCP_REGISTRY_INTERNAL:-$(oc registry info --internal=true)}
 OCP_TAG=${OCP_TAG:-latest}
 OCP_USER=${OCP_USER:-openshift}
-QUICKSTART_CONFIG=${QUICKSTART_CONFIG:-configs/default.bash}

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -12,6 +12,62 @@ Requirements
 - Ansible
 - `oc` command line tool
 
+Variables
+---------
+
+Not all variables are listed here, but these are the most common ones you might
+choose to override:
+
+| Parameter name                                  | Values       | Default   | Description                                                                                           |
+| ------------------------------                  | ------------ | --------- | ------------------------------------                                                                  |
+| `__deploy_stf`                                  | {true,false} | true      | Whether to deploy an instance of STF                                                                  |
+| `__local_build_enabled`                         | {true,false} | true      | Whether to deploySTF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch` |
+| `sg_branch`                                     | <git_branch> | master    | Which Smart Gateway git branch to checkout                                                            |
+| `sgo_branch`                                    | <git_branch> | master    | Which Smart Gateway git branch to checkout                                                            |
+| `__service_telemetry_events_enabled`            | {true,false} | true      | Whether to enable events support in ServiceTelemetry                                                  |
+| `__service_telemetry_high_availability_enabled` | {true,false} | false     | Whether to enable high availability support in ServiceTelemetry                                       |
+| `__service_telemetry_metrics_enabled`           | {true,false} | true      | Whether to enable metrics support in ServiceTelemetry                                                 |
+| `__service_telemetry_storage_ephemeral_enabled` | {true,false} | false     | Whether to enable ephemeral storage support in ServiceTelemetry                                       |
+
+
+Example Playbook
+----------------
+
+```yaml
+---
+# run STF CI setup in CRC (already provisioned)
+- hosts: localhost
+  connection: local
+  tasks:
+  - name: Run the STF CI system
+    import_role:
+        name: stf-run-ci
+```
+
+Usage
+-----
+
+You can deploy Service Telemetry Framework using this role in a few
+configuration methods:
+
+* local build artifacts from Git repository cloned locally
+* standard deployment using Subscription and OLM
+* supporting components but no instance of Service Telemetry Operator
+
+You can deploy using the sample `run-ci.yaml` from the _Example Playbook_
+section:
+
+```
+ansible-playbook run-ci.yaml
+```
+
+If you want to do a standard deployment (existing remote artifacts) you can use
+the following command:
+
+```
+ansible-playbook --extra-vars __local_build_enabled=false run-ci.yaml
+```
+
 License
 -------
 

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -23,7 +23,7 @@ choose to override:
 | `__deploy_stf`                                  | {true,false} | true      | Whether to deploy an instance of STF                                                                  |
 | `__local_build_enabled`                         | {true,false} | true      | Whether to deploySTF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch` |
 | `sg_branch`                                     | <git_branch> | master    | Which Smart Gateway git branch to checkout                                                            |
-| `sgo_branch`                                    | <git_branch> | master    | Which Smart Gateway git branch to checkout                                                            |
+| `sgo_branch`                                    | <git_branch> | master    | Which Smart Gateway Operator git branch to checkout                                                   |
 | `__service_telemetry_events_enabled`            | {true,false} | true      | Whether to enable events support in ServiceTelemetry                                                  |
 | `__service_telemetry_high_availability_enabled` | {true,false} | false     | Whether to enable high availability support in ServiceTelemetry                                       |
 | `__service_telemetry_metrics_enabled`           | {true,false} | true      | Whether to enable metrics support in ServiceTelemetry                                                 |

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -5,6 +5,9 @@ list_of_stf_objects:
   - smart-gateway-operator
   - smart-gateway
 
+__local_build_enabled: true
+__deploy_stf: true
+
 __service_telemetry_events_enabled: true
 __service_telemetry_high_availability_enabled: false
 __service_telemetry_metrics_enabled: true

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -4,3 +4,8 @@ list_of_stf_objects:
   - service-telemetry-operator
   - smart-gateway-operator
   - smart-gateway
+
+__service_telemetry_events_enabled: true
+__service_telemetry_high_availability_enabled: false
+__service_telemetry_metrics_enabled: true
+__service_telemetry_storage_ephemeral_enabled: false

--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -7,14 +7,12 @@
         repo: https://github.com/infrawatch/smart-gateway-operator
         dest: working/smart-gateway-operator
         version: "{{ sgo_branch | default(branch, true) }}"
-        force: yes
   rescue:
     - name: Get master branch because same-named doesn't exist
       git:
         repo: https://github.com/infrawatch/smart-gateway-operator
         dest: working/smart-gateway-operator
         version: master
-        force: yes
 
 - name: Get Smart Gateway
   block:
@@ -23,12 +21,10 @@
         repo: https://github.com/infrawatch/smart-gateway
         dest: working/smart-gateway
         version: "{{ sg_branch | default(branch, true) }}"
-        force: yes
   rescue:
     - name: Get master branch because same-named doesn't exist
       git:
         repo: https://github.com/infrawatch/smart-gateway
         dest: working/smart-gateway
         version: master
-        force: yes
 

--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -2,11 +2,11 @@
 # clone our other repositories into this repo
 - name: Get Smart Gateway Operator
   block:
-    - name: Try cloning same-named branch
+    - name: Try cloning same-named branch or override branch
       git:
         repo: https://github.com/infrawatch/smart-gateway-operator
         dest: working/smart-gateway-operator
-        version: "{{ branch }}"
+        version: "{{ sgo_branch | default(branch, true) }}"
   rescue:
     - name: Get master branch because same-named doesn't exist
       git:
@@ -16,11 +16,11 @@
 
 - name: Get Smart Gateway
   block:
-    - name: Try cloning same-named branch
+    - name: Try cloning same-named branch or override branch
       git:
         repo: https://github.com/infrawatch/smart-gateway
         dest: working/smart-gateway
-        version: "{{ branch }}"
+        version: "{{ sg_branch | default(branch, true) }}"
   rescue:
     - name: Get master branch because same-named doesn't exist
       git:

--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -7,12 +7,14 @@
         repo: https://github.com/infrawatch/smart-gateway-operator
         dest: working/smart-gateway-operator
         version: "{{ sgo_branch | default(branch, true) }}"
+        force: yes
   rescue:
     - name: Get master branch because same-named doesn't exist
       git:
         repo: https://github.com/infrawatch/smart-gateway-operator
         dest: working/smart-gateway-operator
         version: master
+        force: yes
 
 - name: Get Smart Gateway
   block:
@@ -21,10 +23,12 @@
         repo: https://github.com/infrawatch/smart-gateway
         dest: working/smart-gateway
         version: "{{ sg_branch | default(branch, true) }}"
+        force: yes
   rescue:
     - name: Get master branch because same-named doesn't exist
       git:
         repo: https://github.com/infrawatch/smart-gateway
         dest: working/smart-gateway
         version: master
+        force: yes
 

--- a/build/stf-run-ci/tasks/deploy_stf.yml
+++ b/build/stf-run-ci/tasks/deploy_stf.yml
@@ -1,47 +1,3 @@
----
-# TODO: not super pretty but it seems to work for now. Would be a bit cleaner
-# perhaps if we imported a semver function of some sort.
-- name: Get latest CSV for Smart Gateway Operator
-  shell: |
-    ls -1v --hide=*.yaml working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/ | tail -1
-  register: sgo_current_csv
-
-- name: Get latest CSV for Service Telemetry Operator
-  shell: |
-    ls -1v --hide=*.yaml ../deploy/olm-catalog/service-telemetry-operator/ | tail -1
-  register: sto_current_csv
-
-- name: Load Smart Gateway Operator RBAC
-  command: oc apply -f working/smart-gateway-operator/deploy/{{ item }}
-  loop:
-    - service_account.yaml
-    - role.yaml
-    - role_binding.yaml
-    - olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smartgateway.infra.watch_smartgateways_crd.yaml
-
-# TODO: I'm sorry this is pretty messy. There is probably an Ansible module
-# that would make this a bit cleaner to read. Likely start with lineinfile or a
-# filter that could parse the contents inline via lookup to the k8s module
-- name: Load Smart Gateway Operator CSV
-  shell: |
-    sed -e "s#quay.io/infrawatch/smart-gateway:latest#{{ sg_image_path }}#g;s#quay.io/infrawatch/smart-gateway-operator:latest#{{ sgo_image_path }}#g;s#placeholder#{{ namespace }}#g" working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
-
-- name: Load Service Telemetry Operator RBAC
-  command: oc apply -f ../deploy/{{ item }}
-  loop:
-    - service_account.yaml
-    - role.yaml
-    - role_binding.yaml
-    - olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/infra.watch_servicetelemetrys_crd.yaml
-
-- name: Load Service Telemetry Operator CSV
-  shell: |
-    sed -e "s#quay.io/infrawatch/service-telemetry-operator:v{{ sto_current_csv.stdout }}#{{ sto_image_path }}#g;s#placeholder#{{ namespace }}#g" ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
-
-- name: Wait for Service Telemetry Operator to be Succeeded
-  shell: |
-    while ! oc get csv | grep service-telemetry-operator | grep Succeeded; do echo "waiting for Service Telemetry Operator..."; sleep 3; done
-
 # NOTE: be aware that if the API version changes for the ServiceTelemetry
 # object that it'll need to be updated here
 - name: Create default ServiceTelemetry manifest
@@ -56,7 +12,10 @@
         eventsEnabled: {{ __service_telemetry_events_enabled }}
         highAvailabilityEnabled: {{ __service_telemetry_high_availability_enabled }}
         metricsEnabled: {{ __service_telemetry_metrics_enabled }}
-        storageEphemeralEnabled: {{ __service_telemetry_storage_ephemeral_enabled }}- name: Create ServiceTelemetry instance
+        storageEphemeralEnabled: {{ __service_telemetry_storage_ephemeral_enabled }}
+  when: service_telemetry_manifest is not defined
+
+- name: Create ServiceTelemetry instance
   k8s:
     definition:
       '{{ service_telemetry_manifest }}'

--- a/build/stf-run-ci/tasks/deploy_stf.yml
+++ b/build/stf-run-ci/tasks/deploy_stf.yml
@@ -44,15 +44,19 @@
 
 # NOTE: be aware that if the API version changes for the ServiceTelemetry
 # object that it'll need to be updated here
-- name: Create ServiceTelemetry instance
-  k8s:
-    definition:
+- name: Create default ServiceTelemetry manifest
+  set_fact:
+    service_telemetry_manifest: |
       apiVersion: infra.watch/v1alpha1
       kind: ServiceTelemetry
       metadata:
         name: stf-default
         namespace: "{{ namespace }}"
       spec:
-        eventsEnabled: true
-        highAvailabilityEnabled: false
-        metricsEnabled: true
+        eventsEnabled: {{ __service_telemetry_events_enabled }}
+        highAvailabilityEnabled: {{ __service_telemetry_high_availability_enabled }}
+        metricsEnabled: {{ __service_telemetry_metrics_enabled }}
+        storageEphemeralEnabled: {{ __service_telemetry_storage_ephemeral_enabled }}- name: Create ServiceTelemetry instance
+  k8s:
+    definition:
+      '{{ service_telemetry_manifest }}'

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -41,6 +41,7 @@
 - block:
   - name: Deploy an instance of STF
     include_tasks: deploy_stf.yml
+
   - name: Validate system is operational
     shell: ./validate_deployment.sh
     args:
@@ -48,6 +49,6 @@
     register: validate_deployment
 
   - debug:
-    var: validate_deployment.stdout_lines
+      var: validate_deployment.stdout_lines
 
   when: __deploy_stf | bool

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -4,6 +4,8 @@
   set_fact:
     branch: "{{ working_branch | default('master') }}"
     namespace: "{{ working_namespace | default('service-telemetry') }}"
+
+- name: Set default image paths when skipping local builds
     sg_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway:latest
     sgo_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway-operator:latest
     sto_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/service-telemetry-operator:latest

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -4,13 +4,20 @@
   set_fact:
     branch: "{{ working_branch | default('master') }}"
     namespace: "{{ working_namespace | default('service-telemetry') }}"
+    sg_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway:latest
+    sgo_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway-operator:latest
+    sto_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/service-telemetry-operator:latest
 
 - block:
   - name: Setup supporting repositories
     include_tasks: clone_repos.yml
+    tags:
+      - clone
 
   - name: Setup supporting Operator subscriptions
     include_tasks: setup_base.yml
+    tags:
+      - deploy
 
   - name: Create builds and artifacts
     include_tasks: create_builds.yml
@@ -20,9 +27,13 @@
       - { name: smart-gateway, dockerfile_path: Dockerfile, image_reference_name: sg_image_path, working_build_dir: ./working/smart-gateway }
     loop_control:
       loop_var: artifact
+    tags:
+      - build
 
   - name: Setup STF using local artifacts
     include_tasks: setup_stf_local_build.yml
+    tags:
+      - deploy
 
   when: __local_build_enabled | bool
 

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -6,9 +6,10 @@
     namespace: "{{ working_namespace | default('service-telemetry') }}"
 
 - name: Set default image paths when skipping local builds
-    sg_image_path: "image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway:latest"
-    sgo_image_path: "image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway-operator:latest"
-    sto_image_path: "image-registry.openshift-image-registry.svc:5000/{{ namespace }}/service-telemetry-operator:latest"
+  set_fact:
+    sg_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway:latest
+    sgo_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway-operator:latest
+    sto_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/service-telemetry-operator:latest
 
 - block:
   - name: Setup supporting repositories

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -5,29 +5,49 @@
     branch: "{{ working_branch | default('master') }}"
     namespace: "{{ working_namespace | default('service-telemetry') }}"
 
-- name: Setup supporting repositories
-  include_tasks: clone_repos.yml
+- block:
+  - name: Setup supporting repositories
+    include_tasks: clone_repos.yml
 
-- name: Setup supporting Operator subscriptions
-  include_tasks: setup_base.yml
+  - name: Setup supporting Operator subscriptions
+    include_tasks: setup_base.yml
 
-- name: Create builds and artifacts
-  include_tasks: create_builds.yml
-  loop:
-    - { name: service-telemetry-operator, dockerfile_path: build/Dockerfile, image_reference_name: sto_image_path, working_build_dir: ../ }
-    - { name: smart-gateway-operator, dockerfile_path: build/Dockerfile, image_reference_name: sgo_image_path, working_build_dir: ./working/smart-gateway-operator }
-    - { name: smart-gateway, dockerfile_path: Dockerfile, image_reference_name: sg_image_path, working_build_dir: ./working/smart-gateway }
-  loop_control:
-    loop_var: artifact
+  - name: Create builds and artifacts
+    include_tasks: create_builds.yml
+    loop:
+      - { name: service-telemetry-operator, dockerfile_path: build/Dockerfile, image_reference_name: sto_image_path, working_build_dir: ../ }
+      - { name: smart-gateway-operator, dockerfile_path: build/Dockerfile, image_reference_name: sgo_image_path, working_build_dir: ./working/smart-gateway-operator }
+      - { name: smart-gateway, dockerfile_path: Dockerfile, image_reference_name: sg_image_path, working_build_dir: ./working/smart-gateway }
+    loop_control:
+      loop_var: artifact
 
-- name: Deploy STF using local artifacts
-  include_tasks: deploy_stf.yml
+  - name: Setup STF using local artifacts
+    include_tasks: setup_stf_local_build.yml
 
-- name: Validate system is operational
-  shell: ./validate_deployment.sh
-  args:
-    executable: /bin/bash
-  register: validate_deployment
+  when: __local_build_enabled | bool
 
-- debug:
+- block:
+  - name: Setup supporting Operator subscriptions
+    include_tasks: setup_base.yml
+
+  - name: Setup Service Telemetry Framework from application registry
+    include_tasks: setup_stf.yml
+
+  when: not __local_build_enabled | bool
+
+- name: Pre-flight checks
+  include_tasks: preflight_checks.yml
+
+- block:
+  - name: Deploy an instance of STF
+    include_tasks: deploy_stf.yml
+  - name: Validate system is operational
+    shell: ./validate_deployment.sh
+    args:
+      executable: /bin/bash
+    register: validate_deployment
+
+  - debug:
     var: validate_deployment.stdout_lines
+
+  when: __deploy_stf | bool

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -6,9 +6,9 @@
     namespace: "{{ working_namespace | default('service-telemetry') }}"
 
 - name: Set default image paths when skipping local builds
-    sg_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway:latest
-    sgo_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway-operator:latest
-    sto_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/service-telemetry-operator:latest
+    sg_image_path: "image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway:latest"
+    sgo_image_path: "image-registry.openshift-image-registry.svc:5000/{{ namespace }}/smart-gateway-operator:latest"
+    sto_image_path: "image-registry.openshift-image-registry.svc:5000/{{ namespace }}/service-telemetry-operator:latest"
 
 - block:
   - name: Setup supporting repositories

--- a/build/stf-run-ci/tasks/preflight_checks.yml
+++ b/build/stf-run-ci/tasks/preflight_checks.yml
@@ -1,0 +1,4 @@
+---
+- name: Wait for Service Telemetry Operator to be Succeeded
+  shell: |
+    while ! oc get csv | grep service-telemetry-operator | grep Succeeded; do echo "waiting for Service Telemetry Operator..."; sleep 3; done

--- a/build/stf-run-ci/tasks/setup_stf.yml
+++ b/build/stf-run-ci/tasks/setup_stf.yml
@@ -1,0 +1,42 @@
+---
+- name: Set default InfraWatch OperatorSource manifest
+  set_fact:
+    infrawatch_operator_source_manifest: |
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorSource
+      metadata:
+        name: infrawatch-operators
+        namespace: openshift-marketplace
+      spec:
+        type: appregistry
+        endpoint: https://quay.io/cnr
+        registryNamespace: infrawatch
+        displayName: InfraWatch Operators
+        publisher: Red Hat (CloudOps)
+  when: infrawatch_operator_source_manifest is not defined
+
+- name: Set default Service Telemetry Operator Subscription manifest
+  set_fact:
+    service_telemetry_operator_subscription_manifest: |
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: servicetelemetry-operator-stable-infrawatch-operators-openshift-marketplace
+        namespace: "{{ namespace }}"
+      spec:
+        channel: stable
+        installPlanApproval: Automatic
+        name: servicetelemetry-operator
+        source: infrawatch-operators
+        sourceNamespace: openshift-marketplace
+  when: service_telemetry_operator_subscription_manifest is not defined
+
+- name: Subscribe to Service Telemetry Operator
+  k8s:
+    definition:
+      '{{ service_telemetry_operator_subscription_manifest }}'
+
+- name: Enable InfraWatch application registry
+  k8s:
+    definition:
+      '{{ infrawatch_operator_source_manifest }}'

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -22,9 +22,42 @@
 # TODO: I'm sorry this is pretty messy. There is probably an Ansible module
 # that would make this a bit cleaner to read. Likely start with lineinfile or a
 # filter that could parse the contents inline via lookup to the k8s module
+- name: Replace SG image path in SGO CSV
+  replace:
+    path: working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
+    regexp: '(\s+)image: quay\.io/infrawatch/smart-gateway\:.+$'
+    replace: '\1image: {{ sg_image_path }}'
+
+- name: Replace SGO image path in SGO CSV
+  replace:
+    path: working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
+    regexp: '(\s+)image: quay\.io/infrawatch/smart-gateway-operator\:.+$'
+    replace: '\1image: {{ sgo_image_path }}'
+
+- name: Replace namespace in SGO CSV
+  replace:
+    path: working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
+    regexp: 'placeholder'
+    replace: '{{ namespace }}'
+
 - name: Load Smart Gateway Operator CSV
-  shell: |
-    sed -e "s#quay.io/infrawatch/smart-gateway:latest#{{ sg_image_path }}#g;s#quay.io/infrawatch/smart-gateway-operator:latest#{{ sgo_image_path }}#g;s#placeholder#{{ namespace }}#g" working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
+  shell: oc apply -f working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
+
+#  shell: |
+#    sed -e "s#quay.io/infrawatch/smart-gateway:latest#{{ sg_image_path }}#g;s#quay.io/infrawatch/smart-gateway-operator:latest#{{ sgo_image_path }}#g;s#placeholder#{{ namespace }}#g" working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
+
+- name: Replace SG image path in STO CSV
+  replace:
+    path: ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml
+    regexp: '(\s+)image: quay\.io/infrawatch/service-telemetry-operator\:.+$'
+    replace: '\1image: {{ sto_image_path }}'
+
+- name: Replace namespace in STO CSV
+  replace:
+    path: ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml
+    regexp: 'placeholder'
+    replace: '{{ namespace }}'
+
 
 - name: Load Service Telemetry Operator RBAC
   command: oc apply -f ../deploy/{{ item }}
@@ -35,6 +68,8 @@
     - olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/infra.watch_servicetelemetrys_crd.yaml
 
 - name: Load Service Telemetry Operator CSV
-  shell: |
-    sed -e "s#quay.io/infrawatch/service-telemetry-operator:v{{ sto_current_csv.stdout }}#{{ sto_image_path }}#g;s#placeholder#{{ namespace }}#g" ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
+  shell: oc apply -f ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml
 
+#  shell: |
+#    sed -e "s#quay.io/infrawatch/service-telemetry-operator:v{{ sto_current_csv.stdout }}#{{ sto_image_path }}#g;s#placeholder#{{ namespace }}#g" ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
+#

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -1,6 +1,7 @@
 ---
 # TODO: not super pretty but it seems to work for now. Would be a bit cleaner
 # perhaps if we imported a semver function of some sort.
+
 - name: Get latest CSV for Smart Gateway Operator
   shell: |
     ls -1v --hide=*.yaml working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/ | tail -1
@@ -10,6 +11,8 @@
   shell: |
     ls -1v --hide=*.yaml ../deploy/olm-catalog/service-telemetry-operator/ | tail -1
   register: sto_current_csv
+
+# --- Smart Gateway Operator ---
 
 - name: Load Smart Gateway Operator RBAC
   command: oc apply -f working/smart-gateway-operator/deploy/{{ item }}
@@ -22,42 +25,47 @@
 # TODO: I'm sorry this is pretty messy. There is probably an Ansible module
 # that would make this a bit cleaner to read. Likely start with lineinfile or a
 # filter that could parse the contents inline via lookup to the k8s module
+
+- name: Copy SGO CSV to working directory
+  command: cp working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml working/
+
 - name: Replace SG image path in SGO CSV
   replace:
-    path: working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
-    regexp: '(\s+)image: quay\.io/infrawatch/smart-gateway\:.+$'
-    replace: '\1image: {{ sg_image_path }}'
+    path: working/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
+    regexp: '(\s+)value: quay\.io/infrawatch/smart-gateway\:.+$'
+    replace: '\1value: {{ sg_image_path }}'
 
 - name: Replace SGO image path in SGO CSV
   replace:
-    path: working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
+    path: working/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
     regexp: '(\s+)image: quay\.io/infrawatch/smart-gateway-operator\:.+$'
     replace: '\1image: {{ sgo_image_path }}'
 
 - name: Replace namespace in SGO CSV
   replace:
-    path: working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
+    path: working/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
     regexp: 'placeholder'
     replace: '{{ namespace }}'
 
 - name: Load Smart Gateway Operator CSV
-  shell: oc apply -f working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
+  shell: oc apply -f working/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml
 
-#  shell: |
-#    sed -e "s#quay.io/infrawatch/smart-gateway:latest#{{ sg_image_path }}#g;s#quay.io/infrawatch/smart-gateway-operator:latest#{{ sgo_image_path }}#g;s#placeholder#{{ namespace }}#g" working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
+# --- Service Telemetry Operator ---
+
+- name: Copy STO CSV to working directory
+  command: cp ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml working/
 
 - name: Replace SG image path in STO CSV
   replace:
-    path: ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml
+    path: working/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml
     regexp: '(\s+)image: quay\.io/infrawatch/service-telemetry-operator\:.+$'
     replace: '\1image: {{ sto_image_path }}'
 
 - name: Replace namespace in STO CSV
   replace:
-    path: ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml
+    path: working/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml
     regexp: 'placeholder'
     replace: '{{ namespace }}'
-
 
 - name: Load Service Telemetry Operator RBAC
   command: oc apply -f ../deploy/{{ item }}
@@ -68,8 +76,4 @@
     - olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/infra.watch_servicetelemetrys_crd.yaml
 
 - name: Load Service Telemetry Operator CSV
-  shell: oc apply -f ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml
-
-#  shell: |
-#    sed -e "s#quay.io/infrawatch/service-telemetry-operator:v{{ sto_current_csv.stdout }}#{{ sto_image_path }}#g;s#placeholder#{{ namespace }}#g" ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
-#
+  shell: oc apply -f working/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -1,0 +1,40 @@
+---
+# TODO: not super pretty but it seems to work for now. Would be a bit cleaner
+# perhaps if we imported a semver function of some sort.
+- name: Get latest CSV for Smart Gateway Operator
+  shell: |
+    ls -1v --hide=*.yaml working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/ | tail -1
+  register: sgo_current_csv
+
+- name: Get latest CSV for Service Telemetry Operator
+  shell: |
+    ls -1v --hide=*.yaml ../deploy/olm-catalog/service-telemetry-operator/ | tail -1
+  register: sto_current_csv
+
+- name: Load Smart Gateway Operator RBAC
+  command: oc apply -f working/smart-gateway-operator/deploy/{{ item }}
+  loop:
+    - service_account.yaml
+    - role.yaml
+    - role_binding.yaml
+    - olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smartgateway.infra.watch_smartgateways_crd.yaml
+
+# TODO: I'm sorry this is pretty messy. There is probably an Ansible module
+# that would make this a bit cleaner to read. Likely start with lineinfile or a
+# filter that could parse the contents inline via lookup to the k8s module
+- name: Load Smart Gateway Operator CSV
+  shell: |
+    sed -e "s#quay.io/infrawatch/smart-gateway:latest#{{ sg_image_path }}#g;s#quay.io/infrawatch/smart-gateway-operator:latest#{{ sgo_image_path }}#g;s#placeholder#{{ namespace }}#g" working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/{{ sgo_current_csv.stdout }}/smart-gateway-operator.v{{ sgo_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
+
+- name: Load Service Telemetry Operator RBAC
+  command: oc apply -f ../deploy/{{ item }}
+  loop:
+    - service_account.yaml
+    - role.yaml
+    - role_binding.yaml
+    - olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/infra.watch_servicetelemetrys_crd.yaml
+
+- name: Load Service Telemetry Operator CSV
+  shell: |
+    sed -e "s#quay.io/infrawatch/service-telemetry-operator:v{{ sto_current_csv.stdout }}#{{ sto_image_path }}#g;s#placeholder#{{ namespace }}#g" ../deploy/olm-catalog/service-telemetry-operator/{{ sto_current_csv.stdout }}/service-telemetry-operator.v{{ sto_current_csv.stdout }}.clusterserviceversion.yaml | oc apply -f -
+

--- a/ci.yml
+++ b/ci.yml
@@ -4,7 +4,9 @@ global:
     OCP_PROJECT: __commit__
     THIS_BRANCH: __branch__
 script:
+  - echo "Working with project ${OCP_PROJECT}"
   - oc new-project "${OCP_PROJECT}"
+  - echo ansible-playbook --extra-vars working_namespace="${OCP_PROJECT}" --extra-vars working_branch="${THIS_BRANCH}" build/run-ci.yaml
   - ansible-playbook --extra-vars working_namespace="${OCP_PROJECT}" --extra-vars working_branch="${THIS_BRANCH}" build/run-ci.yaml
   - ./tests/smoketest/smoketest.sh
 after_script:

--- a/ci.yml
+++ b/ci.yml
@@ -11,5 +11,7 @@ after_script:
   - echo Final State; echo
   - oc get pods
   - echo
+  - cd working/smart-gateway ; git reset --hard HEAD
+  - cd working/smart-gateway-operator ; git reset --hard HEAD
   - ./deploy/containerlogs.sh
   - ./deploy/remove_stf.sh

--- a/ci.yml
+++ b/ci.yml
@@ -11,7 +11,5 @@ after_script:
   - echo Final State; echo
   - oc get pods
   - echo
-  - cd working/smart-gateway ; git reset --hard HEAD
-  - cd working/smart-gateway-operator ; git reset --hard HEAD
   - ./deploy/containerlogs.sh
   - ./deploy/remove_stf.sh

--- a/ci.yml
+++ b/ci.yml
@@ -4,9 +4,7 @@ global:
     OCP_PROJECT: __commit__
     THIS_BRANCH: __branch__
 script:
-  - echo "Working with project ${OCP_PROJECT}"
   - oc new-project "${OCP_PROJECT}"
-  - echo ansible-playbook --extra-vars working_namespace="${OCP_PROJECT}" --extra-vars working_branch="${THIS_BRANCH}" build/run-ci.yaml
   - ansible-playbook --extra-vars working_namespace="${OCP_PROJECT}" --extra-vars working_branch="${THIS_BRANCH}" build/run-ci.yaml
   - ./tests/smoketest/smoketest.sh
 after_script:

--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+REL=$(dirname "$0"); source "${REL}/../build/metadata.sh"
+
+oc new-project "${OCP_PROJECT}"
+ansible-playbook \
+    --extra-vars namespace="${OCP_PROJECT}" \
+    --extra-vars __local_build_enabled=false \
+    ${REL}/../build/run-ci.yaml


### PR DESCRIPTION
Implements a few features that I stripped when migrating to an Ansible based deployment method for CI setup, which was also being used for local testing.

* add `quickstart.sh` script which wraps a call to `ansible-playbook` with appropriate overrides
* adds standard `ServiceTelemetry` manifest overrides (metrics, events, high availability, ephemeral storage)
* adds the appropriate logic to allow for various overrides and deployment methods
* full `ServiceTelemetry` manifest override

Also adds some new features that were requested:

* ability to do a standard deployment without local builds (`-e __local_builds_enabled=false`)
* ability to override Smart Gateway (Operator) repository branches (`-e sg_branch=<branch_name>`, `-e sgo_branch=<branch_name>`)

Should beget the need for #105 (hopefully)