### PR TITLE
Update release data for 1.0.3

### DIFF
--- a/.osdk-scorecard.yaml
+++ b/.osdk-scorecard.yaml
@@ -1,7 +1,7 @@
 scorecard:
   version: v1alpha2
   output: text
-  bundle: deploy/olm-catalog/service-telemetry-operator/1.0.3/metadata
+  bundle: deploy/olm-catalog/service-telemetry-operator/bundle/metadata
   plugins:
     - basic:
         cr-manifest:

--- a/deploy/olm-catalog/service-telemetry-operator/bundle/Dockerfile
+++ b/deploy/olm-catalog/service-telemetry-operator/bundle/Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=service-telemetry-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+
+COPY /*.yaml /manifests/
+COPY /metadata/annotations.yaml /metadata/annotations.yaml

--- a/deploy/olm-catalog/service-telemetry-operator/bundle/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/bundle/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicetelemetrys.infra.watch
+spec:
+  group: infra.watch
+  names:
+    kind: ServiceTelemetry
+    listKind: ServiceTelemetryList
+    plural: servicetelemetrys
+    singular: servicetelemetry
+  scope: Namespaced
+  version: v1alpha1
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Metadata definition for the ServiceTelemetry object
+          type: object
+        spec:
+          description: Specification of the desired behavior of the Service Telemetry Operator.
+          properties:
+            metricsEnabled:
+              description: Whether the Service Telemetry Operator should enable components related to metrics collection and storage.
+              type: boolean
+            eventsEnabled:
+              description: Whether the Service Telemetry Operator should enable components related to events collection and storage.
+              type: boolean
+            highAvailabilityEnabled:
+              description: Whether to deploy the services in HA mode.
+              type: boolean
+            storageEphemeralEnabled:
+              description: Request ephemeral storage (non-persistent, development use only) in the storage backends such as Prometheus and ElasticSearch.
+              type: boolean
+            prometheusStorageClass:
+              description: Storage class name used for Prometheus PVC
+              type: string
+            prometheusStorageResources:
+              description: Storage resource definition for Prometheus
+              type: string
+            prometheusStorageSelector:
+              description: Storage selector definition for Prometheus
+              type: string
+            prometheusPvcStorageRequest:
+              description: PVC storage requested size for Prometheus
+              type: string
+            alertmanagerStorageClass:
+              description: Storage class name used for Alertmanager PVC
+              type: string
+            alertmanagerStorageResources:
+              description: Storage resource definition for Alertmanager
+              type: string
+            alertmanagerStorageSelector:
+              description: Storage selector definition for Alertmanager
+              type: string
+            alertmanagerPvcStorageRequest:
+              description: PVC storage requested size for Alertmanager
+              type: string
+        status:
+          description: Status results of an instance of Service Telemetry
+          properties:
+            conditions:
+              description: The resulting conditions when a Service Telemetry is instantiated
+              items:
+                properties:
+                  status:
+                    type: string
+                  type:
+                    type: string
+                  reason:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                type: object
+              type: array
+          type: object

--- a/deploy/olm-catalog/service-telemetry-operator/bundle/manifests/service-telemetry-operator.v1.0.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/bundle/manifests/service-telemetry-operator.v1.0.3.clusterserviceversion.yaml
@@ -1,0 +1,269 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "infra.watch/v1alpha1",
+          "kind": "ServiceTelemetry",
+          "metadata": {
+            "name": "stf-default"
+          },
+          "spec": {
+            "eventsEnabled": false,
+            "highAvailabilityEnabled": false,
+            "metricsEnabled": true,
+            "storageEphemeralEnabled": false
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Monitoring
+    certified: "false"
+    containerImage: quay.io/infrawatch/service-telemetry-operator:v1.0.3
+    createdAt: "2020-01-10T21:30:00Z"
+    description: Service Telemetry Framework. Umbrella Operator for instantiating
+      the required dependencies and configuration of various components to build a
+      Service Telemetry platform for telco grade monitoring.
+    repository: https://github.com/infrawatch/service-telemetry-operator
+    support: Red Hat, Inc.
+  name: service-telemetry-operator.v1.0.3
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents an instance of the Service Telemetry Framework
+      displayName: STF Cluster
+      kind: ServiceTelemetry
+      name: servicetelemetrys.infra.watch
+      resources:
+      - kind: Pods
+        name: ""
+        version: v1
+      - kind: ConfigMaps
+        name: ""
+        version: v1
+      - kind: ServiceTelemetrys
+        name: servicetelemetrys.infra.watch
+        version: v1alpha1
+      - kind: ReplicaSets
+        name: ""
+        version: v1
+      - kind: Deployments
+        name: ""
+        version: v1
+      - kind: Services
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: Whether to enable collection and storage components for metrics
+        displayName: Metrics Enabled
+        path: metricsEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether to enable collection and storage components for events
+        displayName: Events Enabled
+        path: eventsEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether to enable high availability for Service Telemetry components
+        displayName: High Availability Enabled
+        path: highAvailabilityEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Whether to enable ephemeral storage for development environments
+        displayName: Ephemeral Storage Enabled
+        path: storageEphemeralEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Size of PV request for Prometheus storage. Add your unit to the
+          end (i.e. M (Megabytes), G (Gigabytes), etc) such as "20G".
+        displayName: Prometheus Storage Size
+        path: prometheusPvcStorageRequest
+        x-descriptors:
+        - urn:alm:descriptor:tectonic.ui:text
+      statusDescriptors:
+      - description: Conditions provided by deployment
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    required:
+    - description: A declaration of a required Certificate
+      displayName: AMQ Certificate Manager
+      kind: Certificate
+      name: certificates.certmanager.k8s.io
+      version: v1alpha1
+    - description: Creation of AMQ Interconnect routers
+      displayName: AMQ Interconnect
+      kind: Interconnect
+      name: interconnects.interconnectedcloud.github.io
+      version: v1alpha1
+    - description: Creation of Prometheus instances
+      displayName: Prometheus
+      kind: Prometheus
+      name: prometheuses.monitoring.coreos.com
+      version: v1
+    - description: Creation of Smart Gateways
+      displayName: Smart Gateway
+      kind: SmartGateway
+      name: smartgateways.smartgateway.infra.watch
+      version: v2alpha1
+  description: Service Telemetry Operator for monitoring clouds
+  displayName: Service Telemetry Operator
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgaWQ9Ikljb25zIgogICB2aWV3Qm94PSIwIDAgMTI4IDEyOCIKICAgdmVyc2lvbj0iMS4xIgogICBzb2RpcG9kaTpkb2NuYW1lPSJJY29uLVJlZF9IYXQtRGlhZ3JhbXMtR3JhcGhfQXJyb3dfVXAtQi1CbGFjay1SR0Iuc3ZnIgogICB3aWR0aD0iMTI4IgogICBoZWlnaHQ9IjEyOCIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMS4wYmV0YTIgKHVua25vd24pIj4KICA8bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGE2NiI+CiAgICA8cmRmOlJERj4KICAgICAgPGNjOldvcmsKICAgICAgICAgcmRmOmFib3V0PSIiPgogICAgICAgIDxkYzpmb3JtYXQ+aW1hZ2Uvc3ZnK3htbDwvZGM6Zm9ybWF0PgogICAgICAgIDxkYzp0eXBlCiAgICAgICAgICAgcmRmOnJlc291cmNlPSJodHRwOi8vcHVybC5vcmcvZGMvZGNtaXR5cGUvU3RpbGxJbWFnZSIgLz4KICAgICAgICA8ZGM6dGl0bGU+SWNvbi1SZWRfSGF0LURpYWdyYW1zLUdyYXBoX0Fycm93X1VwXzEtQi1CbGFjay1SR0I8L2RjOnRpdGxlPgogICAgICA8L2NjOldvcms+CiAgICA8L3JkZjpSREY+CiAgPC9tZXRhZGF0YT4KICA8ZGVmcwogICAgIGlkPSJkZWZzNjQiIC8+CiAgPHNvZGlwb2RpOm5hbWVkdmlldwogICAgIHBhZ2Vjb2xvcj0iI2ZmZmZmZiIKICAgICBib3JkZXJjb2xvcj0iIzY2NjY2NiIKICAgICBpbmtzY2FwZTpkb2N1bWVudC1yb3RhdGlvbj0iMCIKICAgICBib3JkZXJvcGFjaXR5PSIxIgogICAgIG9iamVjdHRvbGVyYW5jZT0iMTAiCiAgICAgZ3JpZHRvbGVyYW5jZT0iMTAiCiAgICAgZ3VpZGV0b2xlcmFuY2U9IjEwIgogICAgIGlua3NjYXBlOnBhZ2VvcGFjaXR5PSIwIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIxOTIwIgogICAgIGlua3NjYXBlOndpbmRvdy1oZWlnaHQ9IjEwNjIiCiAgICAgaWQ9Im5hbWVkdmlldzYyIgogICAgIHNob3dncmlkPSJmYWxzZSIKICAgICBpbmtzY2FwZTp6b29tPSI0LjM4MDEzMzciCiAgICAgaW5rc2NhcGU6Y3g9IjkwLjc4Njg1IgogICAgIGlua3NjYXBlOmN5PSI1OS42NDgxNDMiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjM4NDAiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjE4IgogICAgIGlua3NjYXBlOndpbmRvdy1tYXhpbWl6ZWQ9IjAiCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0iSWNvbnMiIC8+CiAgPHRpdGxlCiAgICAgaWQ9InRpdGxlNTciPkljb24tUmVkX0hhdC1EaWFncmFtcy1HcmFwaF9BcnJvd19VcF8xLUItQmxhY2stUkdCPC90aXRsZT4KICA8cGF0aAogICAgIHN0eWxlPSJzdHJva2Utd2lkdGg6NC44MjU2NiIKICAgICBkPSJtIDEyNi44MTUzNiwyOS42MTY4NzUgYSAzLjYxOTI1ODgsMy42MTkyNTg4IDAgMCAwIC01LjExNTIyLDAgbCAtMy40NzQ0OCwzLjQ3NDQ4OSBWIDEwLjg0NDk4OCBBIDMuNjY3NTE1NiwzLjY2NzUxNTYgMCAwIDAgMTE0LjYwNjM5LDcuMzcwNDk5MyBIIDguNDQxNDc2OSBBIDMuNjE5MjU4OCwzLjYxOTI1ODggMCAwIDAgNC44MjIyMTgyLDEwLjg0NDk4OCBWIDkxLjYyNjg0IGwgLTMuNzY0MDI4NywzLjY2NzUxNiBhIDMuNjE5MjU4OCwzLjYxOTI1ODggMCAwIDAgMi41NTc2MDk1LDYuMTc2ODc0IDMuNTcxMDAxOSwzLjU3MTAwMTkgMCAwIDAgMS4yMDY0MTkyLC0wLjI0MTI4IHYgMTUuNzc5OTYgYSAzLjU3MTAwMTksMy41NzEwMDE5IDAgMCAwIDMuNjE5MjU4NywzLjYxOTI2IEggMTE0LjYwNjM5IGEgMy42MTkyNTg4LDMuNjE5MjU4OCAwIDAgMCAzLjYxOTI3LC0zLjYxOTI2IFYgNDMuMjI1Mjg4IGwgOC41ODk3LC04LjI1MTkwOSBhIDMuNjE5MjU4OCwzLjYxOTI1ODggMCAwIDAgMCwtNS4zNTY1MDQgeiBNIDU3LjkwNDY3NSw2My45Mjc0NDcgViAyNS4zMjIwMjIgYSAzLjYxOTI1OTksMy42MTkyNTk5IDAgMCAxIDcuMjM4NTE5LDAgdiAzOC42MDU0MjUgYSAzLjYxOTI1OTksMy42MTkyNTk5IDAgMCAxIC03LjIzODUxOSwwIHogTSA4Ni44NTg3NDYsNDQuNjI0NzM0IFYgMjUuMzIyMDIyIGEgMy42MTkyNTg4LDMuNjE5MjU4OCAwIDAgMSA3LjIzODUxNSwwIHYgMTkuMzAyNzEyIGEgMy42MTkyNTg4LDMuNjE5MjU4OCAwIDEgMSAtNy4yMzg1MTUsMCB6IE0gMzYuMTg5MTI4LDI1LjMyMjAyMiB2IDE5LjMwMjcxMiBhIDMuNjE5MjU5LDMuNjE5MjU5IDAgMSAxIC03LjIzODUxOCwwIFYgMjUuMzIyMDIyIGEgMy42MTkyNTksMy42MTkyNTkgMCAwIDEgNy4yMzg1MTgsMCB6IE0gMTEwLjk4NzE0LDExMy4zOTA2NSBIIDEyLjA2MDczNiBWIDk0LjYxODc2MSBsIDI0Ljk5NzAxMywtMjQuNTE0NDQzIDI0LjEyODM4OCwyNC4xMjgzOSBhIDMuMDg4NDM0MSwzLjA4ODQzNDEgMCAwIDAgMS4yMDY0MTcsMC43MjM4NTEgaCAwLjQzNDMxNCBhIDQuODI1Njc4Myw0LjgyNTY3ODMgMCAwIDAgMC45NjUxMzYsMC4yNDEyODEgMi4yNjgwNjg3LDIuMjY4MDY4NyAwIDAgMCAwLjc3MjEwOCwwIHYgMCBhIDMuMzc3OTc0OCwzLjM3Nzk3NDggMCAwIDAgMS41OTI0NzUsLTAuODIwMzY0IHYgMCBMIDExMC42NDkzMyw1MC4zNjcyOTUgWiIKICAgICBpZD0icGF0aDU5IgogICAgIGlua3NjYXBlOmNvbm5lY3Rvci1jdXJ2YXR1cmU9IjAiIC8+Cjwvc3ZnPgo=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      deployments:
+      - name: service-telemetry-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: service-telemetry-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: service-telemetry-operator
+            spec:
+              containers:
+              - command:
+                - /usr/local/bin/ao-logs
+                - /tmp/ansible-operator/runner
+                - stdout
+                image: quay.io/infrawatch/service-telemetry-operator:v1.0.3
+                imagePullPolicy: Always
+                name: ansible
+                resources: {}
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                  readOnly: true
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: service-telemetry-operator
+                - name: ANSIBLE_GATHERING
+                  value: explicit
+                image: quay.io/infrawatch/service-telemetry-operator:v1.0.3
+                imagePullPolicy: Always
+                name: operator
+                resources: {}
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+              serviceAccountName: service-telemetry-operator
+              volumes:
+              - emptyDir: {}
+                name: runner
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - interconnectedcloud.github.io
+          - smartgateway.infra.watch
+          - monitoring.coreos.com
+          - elasticsearch.k8s.elastic.co
+          - certmanager.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - service-telemetry-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+        - apiGroups:
+          - infra.watch
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: service-telemetry-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - servicetelemetry
+  - monitoring
+  - telemetry
+  - notifications
+  - telecommunications
+  links:
+  - name: Source Code
+    url: https://github.com/infrawatch/service-telemetry-operator
+  - name: Documentation
+    url: https://infrawatch.github.io/documentation
+  maintainers:
+  - email: support@redhat.com
+    name: Red Hat (CloudOps)
+  maturity: alpha
+  minKubeVersion: 1.14.0
+  provider:
+    name: Red Hat
+  replaces: service-telemetry-operator.v1.0.2
+  version: 1.0.3

--- a/deploy/olm-catalog/service-telemetry-operator/bundle/metadata/annotations.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/bundle/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: plain
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: service-telemetry-operator

--- a/deploy/olm-catalog/service-telemetry-operator/service-telemetry-operator.package.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/service-telemetry-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: service-telemetry-operator.v1.0.2
+- currentCSV: service-telemetry-operator.v1.0.3
   name: stable
 defaultChannel: stable
 packageName: servicetelemetry-operator


### PR DESCRIPTION
This isn't going to be the final solution since I'm running an older version of operator-sdk (0.15.2)
and bundles are slightly setup differently, but this will allow us to pass our current versions with
scorecard testing in operator-sdk.
