### PR TITLE
Support for Smart Gateway compile changes

### DIFF
--- a/build/stf-run-ci/tasks/create_builds.yml
+++ b/build/stf-run-ci/tasks/create_builds.yml
@@ -2,10 +2,13 @@
 - name: Create BuildConfig and ImageStream
   shell: oc new-build --name {{ artifact.name }} --dockerfile - < {{ artifact.working_build_dir }}/{{ artifact.dockerfile_path }}
 
+- name: Kill first build since it will always fail (triggered on BuildConfig creation)
+  shell: sleep 10 ; oc delete build {{ artifact.name }}-1
+
 - name: Kick off build
   block:
     - name: Start local image build
-      command: oc start-build {{ artifact.name }} --wait --from-dir "{{ artifact.working_build_dir }}"
+      command: oc start-build {{ artifact.name }} --wait --follow --from-dir "{{ artifact.working_build_dir }}"
       register: build_name
   always:
     - name: Describe local image build (results)

--- a/build/stf-run-ci/tasks/create_builds.yml
+++ b/build/stf-run-ci/tasks/create_builds.yml
@@ -8,7 +8,7 @@
 - name: Kick off build
   block:
     - name: Start local image build
-      command: oc start-build {{ artifact.name }} --wait --follow --from-dir "{{ artifact.working_build_dir }}"
+      command: oc start-build {{ artifact.name }} --wait --from-dir "{{ artifact.working_build_dir }}"
       register: build_name
   always:
     - name: Describe local image build (results)

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -4,12 +4,12 @@
 
 - name: Get latest CSV for Smart Gateway Operator
   shell: |
-    ls -1v --hide=*.yaml working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/ | tail -1
+    ls -1v --hide=bundle --hide=*.yaml working/smart-gateway-operator/deploy/olm-catalog/smart-gateway-operator/ | tail -1
   register: sgo_current_csv
 
 - name: Get latest CSV for Service Telemetry Operator
   shell: |
-    ls -1v --hide=*.yaml ../deploy/olm-catalog/service-telemetry-operator/ | tail -1
+    ls -1v --hide=bundle --hide=*.yaml ../deploy/olm-catalog/service-telemetry-operator/ | tail -1
   register: sto_current_csv
 
 # --- Smart Gateway Operator ---

--- a/deploy/containerlogs.sh
+++ b/deploy/containerlogs.sh
@@ -3,7 +3,7 @@
 PODS=$(oc get pods -o jsonpath="{.items[*].metadata.name}")
 podArr=($PODS)
 
-echo "Last 5 lines of POD:CONTAINER logs"
+echo "[INFO]******* Last 15 lines of POD:CONTAINER logs"
 for pod in "${podArr[@]}"
 do
         containers=$(oc get pod "$pod" -ojsonpath="{.spec.containers[*].name}")
@@ -14,8 +14,8 @@ do
                 echo
                 echo
                 echo
-                echo "====================== $pod:$container ======================"
-                oc logs "$pod" -c $container | tail -n5
+                echo "[Container Logs]********$pod:$container"
+                oc logs "$pod" -c $container | tail -n15
 
         done
 


### PR DESCRIPTION
Adds changes to the CI system to support the changes for Smart Gateway moving to
CentOS 8 and go mod. Was having some issues with building the Smart Gateway image
so this adds some additional logging output on the console. Also does some clean up
by removing the first build which is expected to fail. (Failure is expected because
on creation of the BuildConfig it will fire a Build, but it fails due to how the
Build is configured on auto-trigger. Subsequent builds pass.)