### PR TITLE
Bump Operator-SDK base image to v0.16.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.14.1
+FROM quay.io/operator-framework/ansible-operator:v0.16.0
 
 COPY watches.yaml ${HOME}/watches.yaml
 COPY roles/ ${HOME}/roles/


### PR DESCRIPTION
This bumps the base image for Operator SDK to match the downstream image under v4.5.0.

Related: https://github.com/infrawatch/smart-gateway-operator/pull/63