### PR TITLE
Promxy POC in test directory

### DIFF
--- a/tests/promxy/README.md
+++ b/tests/promxy/README.md
@@ -1,0 +1,5 @@
+# Promxy POC
+
+This is a test deployment of promxy to help validate HA work.
+
+You can use http://promxy:8082 as a prometheus datasource (for example in grafana) that abstracts over the real Prometheuses and fills gaps in data.

--- a/tests/promxy/promxy-launcher.sh
+++ b/tests/promxy/promxy-launcher.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+oc delete \
+   deployment/promxy \
+   configmap/promxy-config
+
+oc create -f promxy-manifests.yaml
+
+oc rollout status deployment/promxy

--- a/tests/promxy/promxy-manifests.yaml
+++ b/tests/promxy/promxy-manifests.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promxy-config
+data:
+  config.yaml: |
+    ##
+    ## Regular prometheus configuration
+    ##
+    global:
+      evaluation_interval: 5s
+      external_labels:
+        source: promxy
+
+    # remote_write configuration is used by promxy as its local Appender, meaning all
+    # metrics promxy would "write" (not export) would be sent to this. Examples
+    # of this include: recording rules, metrics on alerting rules, etc.
+    # remote_write:
+    #   - url: http://localhost:8083/receive
+
+    ##
+    ### Promxy configuration
+    ##
+    promxy:
+      server_groups:
+      - static_configs:
+        - targets:
+          - prometheus-stf-default-0.prometheus-operated:9090
+          - prometheus-stf-default-1.prometheus-operated:9090
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: promxy
+  name: promxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: promxy
+  template:
+    metadata:
+      labels:
+        app: promxy
+    spec:
+      serviceAccountName: prometheus-k8s
+      containers:
+      - args:
+        - "--config=/etc/promxy/config.yaml"
+        - "--web.enable-lifecycle"
+        - "--log-level=trace"
+        env:
+          - name: ROLE
+            value: "1"
+        command:
+        - "/bin/promxy"
+        image: quay.io/jacksontj/promxy:latest
+        imagePullPolicy: Always
+        name: promxy
+        ports:
+        - containerPort: 8082
+          name: web
+        volumeMounts:
+        - mountPath: "/etc/promxy/"
+          name: promxy-config
+          readOnly: true
+      # container to reload configs on configmap change
+      - args:
+        - "--volume-dir=/etc/promxy"
+        - "--webhook-url=http://localhost:8082/-/reload"
+        image: jimmidyson/configmap-reload:v0.1
+        name: promxy-server-configmap-reload
+        volumeMounts:
+        - mountPath: "/etc/promxy/"
+          name: promxy-config
+          readOnly: true
+      volumes:
+      - configMap:
+          name: promxy-config
+        name: promxy-config
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: promxy
+spec:
+  ports:
+  - name: web
+    port: 8082
+    protocol: TCP
+    targetPort: web
+  selector:
+    app: promxy
+  type: ClusterIP


### PR DESCRIPTION
Not much to say about this other than it works to fill in gaps when doing HA Prometheus. We're unlikely to support this downstream, preferring Loki/Observatorium as our target, but this may still be useful for upstream usage, or for various testing scenarios.