### PR TITLE
Use valid parameter for PVC in ES

### DIFF
--- a/roles/servicetelemetry/templates/manifest_elasticsearch.j2
+++ b/roles/servicetelemetry/templates/manifest_elasticsearch.j2
@@ -36,7 +36,7 @@ spec:
             - emptyDir: {}
               name: elasticsearch-data
 {% else %}
-      volumeClaimTemplate:
+      volumeClaimTemplates:
         - metadata:
             name: elasticsearch-data
           spec:


### PR DESCRIPTION
Use the proper (plural) form for volumeClaimTemplates in the ElasticSearch manifest since the
elasticsearches.elasticsearch.k8s.elastic.co CRD uses a list (plural) vs a singular dictionary
(prometheuses.monitoring.coreos.com etc).

This change allows specifying a requested PersistentVolume size via a PersistentVolumeClaim.
Prior to this change the request would only be 1Gi not the value requested.

Closes #117
