### PR TITLE
HA for SmartGateway, AlertManager, and Prometheus

### DIFF
--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -7,11 +7,13 @@ storage_ephemeral_enabled: false
 graphing_enabled: false
 
 # default values
+prometheus_deployment_size: 1
 prometheus_storage_class: ""
 prometheus_storage_resources: {}
 prometheus_storage_selector: {}
 prometheus_pvc_storage_request: 20G
 
+alertmanager_deployment_size: 1
 alertmanager_storage_class: ""
 alertmanager_storage_resources: {}
 alertmanager_storage_selector: {}
@@ -23,6 +25,7 @@ elastic_user: elastic
 
 qdr_deployment_size: 1
 
+smartgateway_deployment_size: 1
 smartgateway_servicemonitor_spec_endpoints_interval: 10s
 
 graphing_spec_ingress_enabled: false

--- a/roles/servicetelemetry/tasks/main.yml
+++ b/roles/servicetelemetry/tasks/main.yml
@@ -31,9 +31,12 @@
 - name: Adjust defaults for HA
   when: high_availability_enabled
   set_fact:
+    alertmanager_deployment_size: 2
     elasticsearch_node_count: 3
     elasticsearch_redundancy_policy: FullRedundancy
+    prometheus_deployment_size: 2
     qdr_deployment_size: 2
+    smartgateway_deployment_size: 2
 
 - name: Create QDR instance
   include_tasks: component_qdr.yml

--- a/roles/servicetelemetry/templates/manifest_alertmanager.j2
+++ b/roles/servicetelemetry/templates/manifest_alertmanager.j2
@@ -6,7 +6,7 @@ metadata:
   name: '{{ meta.name }}'
   namespace: '{{ meta.namespace }}'
 spec:
-  replicas: 1
+  replicas: {{ alertmanager_deployment_size }}
   serviceAccountName: prometheus-k8s
   serviceMonitorSelector:
     matchLabels:

--- a/roles/servicetelemetry/templates/manifest_prometheus.j2
+++ b/roles/servicetelemetry/templates/manifest_prometheus.j2
@@ -6,7 +6,7 @@ metadata:
   name: '{{ meta.name }}'
   namespace: '{{ meta.namespace }}'
 spec:
-  replicas: 1
+  replicas: {{ prometheus_deployment_size }}
   ruleSelector: {}
   securityContext: {}
   serviceAccountName: prometheus-k8s

--- a/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
@@ -4,7 +4,7 @@ metadata:
   name: '{{ meta.name }}-{{ agent.name|lower }}-notification'
   namespace: '{{ meta.namespace }}'
 spec:
-  size: {{smartgateway_deployment_size}}
+  size: {{ smartgateway_deployment_size }}
   amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/{{ agent.channel }}'
   amqpDataSource: '{{ agent.name|lower }}'
   serviceType: 'events'

--- a/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
@@ -4,7 +4,7 @@ metadata:
   name: '{{ meta.name }}-{{ agent.name|lower }}-notification'
   namespace: '{{ meta.namespace }}'
 spec:
-  size: 1
+  size: {{smartgateway_deployment_size}}
   amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/{{ agent.channel }}'
   amqpDataSource: '{{ agent.name|lower }}'
   serviceType: 'events'

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -8,6 +8,6 @@ spec:
   amqpDataSource: '{{ agent.name|lower }}'
   debug: false
   serviceType: 'metrics'
-  size: 1
+  size: {% if agent.name == 'collectd' %} {{smartgateway_deployment_size}} {% else %} 1 {% endif %}
   prefetch: 15000
   useTimestamp: true

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -8,6 +8,6 @@ spec:
   amqpDataSource: '{{ agent.name|lower }}'
   debug: false
   serviceType: 'metrics'
-  size: {% if agent.name == 'collectd' %} {{smartgateway_deployment_size}} {% else %} 1 {% endif %}
+  size: {% if agent.name == 'collectd' %} {{ smartgateway_deployment_size }} {% else %} 1 {% endif %}
   prefetch: 15000
   useTimestamp: true

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -8,6 +8,10 @@ spec:
   amqpDataSource: '{{ agent.name|lower }}'
   debug: false
   serviceType: 'metrics'
-  size: {% if agent.name == 'collectd' %} {{ smartgateway_deployment_size }} {% else %} 1 {% endif %}
+{% if agent.name == "collectd" %}
+  size: {{ smartgateway_deployment_size }}
+{% else %}
+  size: 1
+{% endif %}
   prefetch: 15000
   useTimestamp: true


### PR DESCRIPTION
* Deploys two each of SmartGateway, Prometheus, and AlertManager when high_availability_enabled
* Existing code only supported ES and QDR in HA mode
* These components were held up until we could correct some behaviors in the smart gateway, namely:
  * Presenting each metrics only once caused disjoint datasets in prometheus (fixed for collectd via sg-core, but not ceilometer yet)
  * Writing duplicate events into ES (Fixed in https://github.com/infrawatch/smart-gateway/pull/88)