### PR TITLE
Add prefix to virtual resources

### DIFF
--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -25,6 +25,8 @@ LIBVIRT_DISKPOOL="${LIBVIRT_DISKPOOL:-/var/lib/libvirt/images}"
 
 TEMPEST_ONLY="${TEMPEST_ONLY:-false}"
 
+PREFIX="{PREFIX:-osp}"
+
 ir_run_cleanup() {
   infrared virsh \
       -vv \
@@ -32,7 +34,8 @@ ir_run_cleanup() {
       --disk-pool "${LIBVIRT_DISKPOOL}" \
       --host-address "${VIRTHOST}" \
       --host-key "${SSH_KEY}" \
-      --cleanup yes
+      --cleanup yes \
+      --prefix "${PREFIX}"
 }
 
 ir_run_provision() {
@@ -47,7 +50,8 @@ ir_run_provision() {
       --host-memory-overcommit True \
       -e override.controller.cpu=8 \
       -e override.controller.memory=32768 \
-      --serial-files True
+      --serial-files True \
+      --prefix "${PREFIX}"
 }
 
 ir_create_undercloud() {

--- a/tests/infrared/16/infrared-openstack.sh
+++ b/tests/infrared/16/infrared-openstack.sh
@@ -24,6 +24,8 @@ LIBVIRT_DISKPOOL="${LIBVIRT_DISKPOOL:-/var/lib/libvirt/images}"
 
 TEMPEST_ONLY="${TEMPEST_ONLY:-false}"
 
+PREFIX="{PREFIX:-osp}"
+
 ir_run_cleanup() {
   infrared virsh \
       -vv \
@@ -31,7 +33,8 @@ ir_run_cleanup() {
       --disk-pool "${LIBVIRT_DISKPOOL}" \
       --host-address "${VIRTHOST}" \
       --host-key "${SSH_KEY}" \
-      --cleanup yes
+      --cleanup yes \
+      --prefix "${PREFIX}"
 }
 
 ir_run_provision() {
@@ -46,7 +49,8 @@ ir_run_provision() {
       --host-memory-overcommit True \
       -e override.controller.cpu=8 \
       -e override.controller.memory=32768 \
-      --serial-files True
+      --serial-files True \
+      --prefix "${PREFIX}"
 }
 
 ir_create_undercloud() {


### PR DESCRIPTION
Adding the prefix options separates out virtual resources used on a machine such that `infrared virsh --cleanup` will not interfere with other VMs on the same host.