### PR TITLE
Remove components that are marked disabled

### DIFF
--- a/roles/servicetelemetry/tasks/component_alertmanager.yml
+++ b/roles/servicetelemetry/tasks/component_alertmanager.yml
@@ -32,11 +32,13 @@
 
 - name: Create an Alertmanager configuration secret
   k8s:
+    state: '{{ "present" if servicetelemetry_vars.alerting.enabled else "absent" }}'
     definition:
       '{{ alertmanager_config_manifest }}'
 
 - name: Create an instance of Alertmanager
   k8s:
+    state: '{{ "present" if servicetelemetry_vars.alerting.enabled else "absent" }}'
     definition:
       '{{ alertmanager_manifest }}'
 # TODO: Create route to access Alertmanager (conditional, default off)

--- a/roles/servicetelemetry/tasks/component_elasticsearch.yml
+++ b/roles/servicetelemetry/tasks/component_elasticsearch.yml
@@ -9,5 +9,6 @@
 
 - name: Create an instance of ElasticSearch
   k8s:
+    state: '{{ "present" if servicetelemetry_vars.backends.elasticsearch.enabled else "absent" }}'
     definition:
       '{{ elasticsearch_manifest }}'

--- a/roles/servicetelemetry/tasks/component_elasticsearch.yml
+++ b/roles/servicetelemetry/tasks/component_elasticsearch.yml
@@ -9,6 +9,6 @@
 
 - name: Create an instance of ElasticSearch
   k8s:
-    state: '{{ "present" if servicetelemetry_vars.backends.elasticsearch.enabled else "absent" }}'
+    state: '{{ "present" if servicetelemetry_vars.backends.events.elasticsearch.enabled else "absent" }}'
     definition:
       '{{ elasticsearch_manifest }}'

--- a/roles/servicetelemetry/tasks/component_grafana.yml
+++ b/roles/servicetelemetry/tasks/component_grafana.yml
@@ -9,6 +9,7 @@
 
 - name: Create an instance of Grafana
   k8s:
+    state: '{{ "present" if servicetelemetry_vars.graphing.enabled else "absent" }}'
     definition:
       '{{ grafana_manifest }}'
 
@@ -21,6 +22,7 @@
 
   - name: Create the Prometheus datasource
     k8s:
+      state: '{{ "present" if servicetelemetry_vars.graphing.enabled else "absent" }}'
       definition:
         '{{ grafana_ds_prometheus_manifest }}'
   when: servicetelemetry_vars.backends.metrics.prometheus.enabled

--- a/roles/servicetelemetry/tasks/component_prometheus.yml
+++ b/roles/servicetelemetry/tasks/component_prometheus.yml
@@ -9,6 +9,7 @@
 
 - name: Create an instance of Prometheus
   k8s:
+    state: '{{ "present" if servicetelemetry_vars.backends.metrics.prometheus.enabled else "absent" }}'
     definition:
       '{{ prometheus_manifest }}'
 

--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -63,5 +63,6 @@
 
 - name: Create QDR instance
   k8s:
+    state: '{{ "present" if servicetelemetry_vars.transports.qdr.enabled else "absent" }}'
     definition:
       '{{ interconnect_manifest }}'

--- a/roles/servicetelemetry/tasks/component_servicemonitor.yml
+++ b/roles/servicetelemetry/tasks/component_servicemonitor.yml
@@ -32,5 +32,6 @@
 
 - name: Create ServiceMonitor to scrape Smart Gateway
   k8s:
+    state: '{{ "present" if servicetelemetry_vars.backends.metrics.prometheus.enabled else "absent" }}'
     definition:
       '{{ servicemonitor_manifest }}'

--- a/roles/servicetelemetry/tasks/main.yml
+++ b/roles/servicetelemetry/tasks/main.yml
@@ -30,7 +30,6 @@
 # --> backends.metrics
 - name: Create Prometheus instance
   include_tasks: component_prometheus.yml
-  when: servicetelemetry_vars.backends.metrics.prometheus.enabled
 
 # create Service Monitor instance
 - name: Create Service Monitor instance
@@ -47,19 +46,16 @@
 
   - name: Setup ElasticSearch
     include_tasks: component_elasticsearch.yml
-  when: servicetelemetry_vars.backends.events.elasticsearch.enabled
 
 # --> alerting
 - name: Create Alertmanager instance
   include_tasks: component_alertmanager.yml
-  when: servicetelemetry_vars.alerting.enabled
 
 # --> graphing
 - name: Deploy graphing
   block:
   - name: Create Grafana instance
     include_tasks: component_grafana.yml
-  when: servicetelemetry_vars.graphing.enabled
 
 # --> clouds
 - name: Get data about clouds


### PR DESCRIPTION
Remove the k8s object when the component is marked 'enabled: false' so that components can be
brought up and down from the ServiceTelemetry CR.
