### PR TITLE
Adjust defaults and enhance UI view

### DIFF
--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -7,20 +7,36 @@ spec:
     enabled: true
     alertmanager:
       storage:
-        strategy: ephemeral
+        strategy: persistent
+        persistent:
+          storageResources: {}
+          storageSelector: {}
+          pvcStorageRequest: 20G
   backends:
     metrics:
       prometheus:
         enabled: true
+        scrapeInterval: 10s
         storage:
-          strategy: ephemeral
+          strategy: persistent
+          persistent:
+            storageResources: {}
+            storageSelector: {}
+            pvcStorageRequest: 20G
     events:
       elasticsearch:
         enabled: false
         storage:
-          strategy: ephemeral
+          strategy: persistent
+          persistent:
+            pvcStorageRequest: 20G
   graphing:
-    enabled: true
+    enabled: false
+    grafana:
+      ingressEnabled: false
+      adminPassword: secret
+      adminUser: root
+      disableSignoutMenu: false
   transports:
     qdr:
       enabled: true

--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -29,7 +29,7 @@ spec:
         storage:
           strategy: persistent
           persistent:
-            pvcStorageRequest: 20G
+            pvcStorageRequest: 20Gi
   graphing:
     enabled: false
     grafana:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -26,7 +26,12 @@ metadata:
             "alerting": {
               "alertmanager": {
                 "storage": {
-                  "strategy": "ephemeral"
+                  "persistent": {
+                    "pvcStorageRequest": "20G",
+                    "storageResources": {},
+                    "storageSelector": {}
+                  },
+                  "strategy": "persistent"
                 }
               },
               "enabled": true
@@ -36,21 +41,36 @@ metadata:
                 "elasticsearch": {
                   "enabled": false,
                   "storage": {
-                    "strategy": "ephemeral"
+                    "persistent": {
+                      "pvcStorageRequest": "20G"
+                    },
+                    "strategy": "persistent"
                   }
                 }
               },
               "metrics": {
                 "prometheus": {
                   "enabled": true,
+                  "scrapeInterval": "10s",
                   "storage": {
-                    "strategy": "ephemeral"
+                    "persistent": {
+                      "pvcStorageRequest": "20G",
+                      "storageResources": {},
+                      "storageSelector": {}
+                    },
+                    "strategy": "persistent"
                   }
                 }
               }
             },
             "graphing": {
-              "enabled": true
+              "enabled": false,
+              "grafana": {
+                "adminPassword": "secret",
+                "adminUser": "root",
+                "disableSignoutMenu": false,
+                "ingressEnabled": false
+              }
             },
             "highAvailability": {
               "enabled": false
@@ -139,6 +159,52 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Prometheus scrape interval. Custom values can be specified via
+          YAML configuration.
+        displayName: Prometheus scrape interval
+        path: backends.metrics.prometheus.scrapeInterval
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:select:10s
+        - urn:alm:descriptor:com.tectonic.ui:select:30s
+        - urn:alm:descriptor:com.tectonic.ui:select:60s
+        - urn:alm:descriptor:com.tectonic.ui:select:120s
+      - description: Prometheus storage strategy. Choose ephemeral or persistent.
+          Persistent storage requires a supporting backend.
+        displayName: Prometheus storage strategy
+        path: backends.metrics.prometheus.storage.strategy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
+        - urn:alm:descriptor:com.tectonic.ui:select:persistent
+      - description: Storage class configuration for Prometheus persistent storage
+        displayName: Prometheus storage class
+        path: backends.metrics.prometheus.storage.persistent.storageClass
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backends.metrics.prometheus.storage.strategy:persistent
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+      - description: Storage resources configuration for Prometheus persistent storage
+        displayName: Prometheus storage resources
+        path: backends.metrics.prometheus.storage.persistent.storageResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backends.metrics.prometheus.storage.strategy:persistent
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Storage selector configuration for Prometheus persistent storage
+        displayName: Prometheus storage selector
+        path: backends.metrics.prometheus.storage.persistent.storageSelector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backends.metrics.prometheus.storage.strategy:persistent
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: PVC requested size for Prometheus persistent storage
+        displayName: Prometheus PVC requested size
+        path: backends.metrics.prometheus.storage.persistent.pvcStorageRequest
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backends.metrics.prometheus.storage.strategy:persistent
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enable ElasticSearch for events backend. Requires subscribing
           to Elastic Cloud on Kubernetes (ECK) Operator.
         displayName: ElasticSearch enabled
@@ -146,36 +212,21 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Alertmanager storage strategy. Choose ephemeral or persistent.
-          Persistent storage requires a supporting backend.
-        displayName: Alertmanager storage strategy
-        path: alerting.alertmanager.storage.strategy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Storage
-        - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
-        - urn:alm:descriptor:com.tectonic.ui:select:persistent
-      - description: Prometheus storage strategy. Choose ephemeral or persistent.
-          Persistent storage requires a supporting backend.
-        displayName: Prometheus storage strategy
-        path: backends.metrics.prometheus.storage.strategy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Storage
-        - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
-        - urn:alm:descriptor:com.tectonic.ui:select:persistent
       - description: ElasticSearch storage strategy. Choose ephemeral or persistent.
           Persistent storage requires a supporting backend.
         displayName: ElasticSearch storage strategy
         path: backends.events.elasticsearch.storage.strategy
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Storage
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
         - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
         - urn:alm:descriptor:com.tectonic.ui:select:persistent
-      - description: Whether to enable high availability for Service Telemetry components
-        displayName: High Availability Enabled
-        path: highAvailability.enabled
+      - description: PVC requested size for ElasticSearch persistent storage
+        displayName: ElasticSearch PVC requested size
+        path: backends.events.elasticsearch.storage.persistent.pvcStorageRequest
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:High Availability
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backends.events.elasticsearch.storage.strategy:persistent
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enable graphing components and dashboard creation
         displayName: Enable Graphing
         path: graphing.enabled
@@ -187,24 +238,28 @@ spec:
         path: graphing.grafana.disableSignoutMenu
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Graphing
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:graphing.enabled:true
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enable ingress access to Grafana
         displayName: Enable Grafana Ingress Route
         path: graphing.grafana.ingressEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Graphing
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:graphing.enabled:true
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set Grafana admin username
         displayName: Grafana Admin Username
         path: graphing.grafana.adminUser
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Graphing
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:graphing.enabled:true
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Set Grafana admin password
         displayName: Grafana Admin Password
         path: graphing.grafana.adminPassword
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Graphing
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:graphing.enabled:true
         - urn:alm:descriptor:com.tectonic.ui:password
       - description: Enable Alerting via Alertmanager
         displayName: Enable Alerting
@@ -212,6 +267,42 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Alerting
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Alertmanager storage strategy. Choose ephemeral or persistent.
+          Persistent storage requires a supporting backend.
+        displayName: Alertmanager storage strategy
+        path: alerting.alertmanager.storage.strategy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Alerting
+        - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
+        - urn:alm:descriptor:com.tectonic.ui:select:persistent
+      - description: Storage class configuration for Alertmanager persistent storage
+        displayName: Alertmanager storage class
+        path: alerting.alertmanager.storage.persistent.storageClass
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Alerting
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:alerting.alertmanager.storage.strategy:persistent
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+      - description: Storage resources configuration for Alertmanager persistent storage
+        displayName: Alertmanager storage resources
+        path: alerting.alertmanager.storage.persistent.storageResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Alerting
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:alerting.alertmanager.storage.strategy:persistent
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Storage selector configuration for Alertmanager persistent storage
+        displayName: Alertmanager storage selector
+        path: alerting.alertmanager.storage.persistent.storageSelector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Alerting
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:alerting.alertmanager.storage.strategy:persistent
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: PVC requested size for Alertmanager persistent storage
+        displayName: Alertmanager PVC requested size
+        path: alerting.alertmanager.storage.persistent.pvcStorageRequest
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Alerting
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:alerting.alertmanager.storage.strategy:persistent
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enable QDR Transport via AMQ Interconnect
         displayName: Enable QDR Transport
         path: transports.qdr.enabled
@@ -223,8 +314,18 @@ spec:
         displayName: Remove Undefined Clouds
         path: cloudsRemoveOnMissing
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Clouds
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Whether to enable high availability for Service Telemetry components.
+          Enabling high availability will increase the number of running components
+          and can significantly increase the resources utilized by STF.
+        displayName: High Availability Enabled
+        path: highAvailability.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       statusDescriptors:
       - description: Conditions provided by deployment
         displayName: Conditions

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # remove SmartGateway object when cloud no longer in current `clouds` object list.
-clouds_remove_on_missing: true
+clouds_remove_on_missing: false
 
 servicetelemetry_defaults:
   high_availability:
@@ -11,7 +11,7 @@ servicetelemetry_defaults:
     alertmanager:
       deployment_size: 1
       storage:
-        strategy: ephemeral
+        strategy: persistent
         persistent:
           storage_class: ""
           storage_resources: {}
@@ -25,7 +25,7 @@ servicetelemetry_defaults:
         deployment_size: 1
         scrape_interval: 10s
         storage:
-          strategy: ephemeral
+          strategy: persistent
           persistent:
             storage_class: ""
             storage_resources: {}
@@ -36,7 +36,7 @@ servicetelemetry_defaults:
         enabled: false
         node_count: 1
         storage:
-          strategy: ephemeral
+          strategy: persistent
           persistent:
             pvc_storage_request: 20Gi
 


### PR DESCRIPTION
Adjust the defaults per feedback to keep persistent storage as the default. Set the
default value of cloudsRemoveOnMissing to 'false' to avoid accidentally deleting previous
multi-cloud configurations on upgrade.

Enhance the user interface by fully filling the example CustomResource so that all
fields defined in the specDescriptor object of the CSV have default values. Add
several x-descriptors to make control of an STF instance easier from the OpenShift
console. Fix some groupings and add show/hide controls based on entered values.
