### PR TITLE
Set proper value when quickstart in ephemeral mode

### DIFF
--- a/build/stf-run-ci/tasks/deploy_stf.yml
+++ b/build/stf-run-ci/tasks/deploy_stf.yml
@@ -9,17 +9,20 @@
         name: default
         namespace: "{{ namespace }}"
       spec:
+        alerting:
+          alertmanager:
+            storage:
+              strategy: {{ "ephemeral" if __service_telemetry_storage_ephemeral_enabled else "persistent" }}
         backends:
           events:
             elasticsearch:
               enabled: {{ __service_telemetry_events_enabled }}
               storage:
-                strategy: {{ __service_telemetry_storage_ephemeral_enabled }}
           metrics:
             prometheus:
               enabled: {{ __service_telemetry_metrics_enabled }}
               storage:
-                strategy: {{ __service_telemetry_storage_ephemeral_enabled }}
+                strategy: {{ "ephemeral" if __service_telemetry_storage_ephemeral_enabled else "persistent" }}
         highAvailability:
           enabled: {{ __service_telemetry_high_availability_enabled }}
   when: service_telemetry_manifest is not defined


### PR DESCRIPTION
Pass the proper value to the storage.strategy parameter when the ephemeral
flag is set to true or false. A value of 'ephemeral' or 'persistent' must be
passed to the ServiceTelemetry object, not true/false.
