### PR TITLE
Adjust smoketests and deployment for SNMPtraps

### DIFF
--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -30,6 +30,7 @@ choose to override:
 | `__service_telemetry_high_availability_enabled` | {true,false} | false     | Whether to enable high availability support in ServiceTelemetry                                       |
 | `__service_telemetry_metrics_enabled`           | {true,false} | true      | Whether to enable metrics support in ServiceTelemetry                                                 |
 | `__service_telemetry_storage_ephemeral_enabled` | {true,false} | false     | Whether to enable ephemeral storage support in ServiceTelemetry                                       |
+| `__service_telemetry_snmptraps_enabled`         | {true,false} | false     | Whether to enable snmptraps delivery via Alertmanager receiver (prometheus-webhook-snmp)              |
 
 
 Example Playbook

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -12,3 +12,4 @@ __service_telemetry_events_enabled: true
 __service_telemetry_high_availability_enabled: false
 __service_telemetry_metrics_enabled: true
 __service_telemetry_storage_ephemeral_enabled: false
+__service_telemetry_snmptraps_enabled: false

--- a/build/stf-run-ci/tasks/deploy_stf.yml
+++ b/build/stf-run-ci/tasks/deploy_stf.yml
@@ -13,6 +13,9 @@
           alertmanager:
             storage:
               strategy: {{ "ephemeral" if __service_telemetry_storage_ephemeral_enabled else "persistent" }}
+            receivers:
+              snmpTraps:
+                enabled: {{ __service_telemetry_snmptraps_enabled }}
         backends:
           events:
             elasticsearch:
@@ -27,6 +30,10 @@
         highAvailability:
           enabled: {{ __service_telemetry_high_availability_enabled }}
   when: service_telemetry_manifest is not defined
+
+- name: Show ServiceTelemetry manifest
+  debug:
+    var: service_telemetry_manifest | from_yaml
 
 - name: Create ServiceTelemetry instance
   k8s:

--- a/ci.yml
+++ b/ci.yml
@@ -5,7 +5,7 @@ global:
     THIS_BRANCH: __branch__
 script:
   - oc new-project "${OCP_PROJECT}"
-  - ansible-playbook --extra-vars working_namespace="${OCP_PROJECT}" --extra-vars working_branch="${THIS_BRANCH}" build/run-ci.yaml
+  - ansible-playbook --extra-vars working_namespace="${OCP_PROJECT}" --extra-vars working_branch="${THIS_BRANCH}" --extra-vars __service_telemetry_snmptraps_enabled="true" build/run-ci.yaml
   - ./tests/smoketest/smoketest.sh
 after_script:
   - echo Final State; echo

--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -5,4 +5,5 @@ oc new-project "${OCP_PROJECT}"
 ansible-playbook \
     --extra-vars namespace="${OCP_PROJECT}" \
     --extra-vars __local_build_enabled=false \
+    --extra-vars __service_telemetry_snmptraps_enabled=true \
     ${REL}/../build/run-ci.yaml

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -53,7 +53,7 @@ for NAME in "${CLOUDNAMES[@]}"; do
 done
 
 # check alert status for in snmp webhook
-trapoutput=`oc logs $(oc get pod -l "app=stf-default-snmp-webhook" -o jsonpath='{.items[0].metadata.name}') | grep 'Sending SNMP trap'`
+trapoutput=$(oc logs --selector 'app=default-snmp-webhook' | grep 'Sending SNMP trap')
 RET=$((RET || $?)) # Accumulate exit codes
 
 echo "*** [INFO] Showing oc get all..."
@@ -96,7 +96,7 @@ oc logs "$(oc get pod -l common.k8s.elastic.co/type=elasticsearch -o jsonpath='{
 echo
 
 echo "*** [INFO] Logs from snmp webhook..."
-oc logs "$(oc get pod -l app=stf-default-snmp-webhook -o jsonpath='{.items[0].metadata.name}')"
+oc logs "$(oc get pod -l app=default-snmp-webhook -o jsonpath='{.items[0].metadata.name}')"
 echo
 
 if [ $RET -eq 0 ]; then


### PR DESCRIPTION
Initial implementation to get quickstart.sh and smoketests.sh updated to account for
snmptraps testing against STF 1.1. Smoketests didn't pass for me but now it completes
without error.
