### PR TITLE
Provide ability to not deploy stf-connectors.yaml

### DIFF
--- a/tests/infrared/16/infrared-openstack.sh
+++ b/tests/infrared/16/infrared-openstack.sh
@@ -24,6 +24,7 @@ ENVIRONMENT_TEMPLATE="${ENVIRONMENT_TEMPLATE:-stf-connectors.yaml.template}"
 
 TEMPEST_ONLY="${TEMPEST_ONLY:-false}"
 RUN_WORKLOAD="${RUN_WORKLOAD:-false}"
+ENABLE_STF_CONNECTORS="${ENABLE_STF_CONNECTORS:-true}"
 
 ir_run_cleanup() {
   infrared virsh \
@@ -116,11 +117,16 @@ else
   ir_run_cleanup
   ir_run_provision
   ir_create_undercloud
-  stf_create_config
+  if ${ENABLE_STF_CONNECTORS}; then
+    stf_create_config
+  else
+    touch outputs/stf-connectors.yaml
+  fi
   ir_create_overcloud
   ir_expose_ui
+  if ${RUN_WORKLOAD}; then
+    ir_run_workload
+  fi
 fi
 
-if ${RUN_WORKLOAD}; then
-  ir_run_workload
-fi
+

--- a/tests/infrared/16/infrared-openstack.sh
+++ b/tests/infrared/16/infrared-openstack.sh
@@ -121,6 +121,7 @@ else
     stf_create_config
   else
     touch outputs/stf-connectors.yaml
+    truncate --size 0 outputs/stf-connectors.yaml
   fi
   ir_create_overcloud
   ir_expose_ui


### PR DESCRIPTION
Provide ability to _not_ deploy stf-connectors.yaml from an existing template. It came up
today that Chris had good luck with our deployment scripts in repo, but that running
the configuration from the STF documentation didn't seem to work (in multicloud).

Addition of ENABLE_STF_CONNECTORS={true,false} flag allows standard OSP deployment
but without tainting the OSP environment with the STF deployment workflow.