### PR TITLE
Enable libpodstats and sensubility amqp1 transport

### DIFF
--- a/tests/infrared/16/stf-connectors.yaml.template
+++ b/tests/infrared/16/stf-connectors.yaml.template
@@ -21,6 +21,8 @@ custom_templates:
         ManagePolling: true
         ManagePipeline: true
         NotificationDriver: 'messagingv2'
+        CollectdEnableLibpodstats: true
+        CollectdSensubilityTransport: amqp1
         CeilometerQdrEventsConfig:
             driver: amqp
             topic: event


### PR DESCRIPTION
Enable libpodstats plugin and configure sensubility to use amqp1 bus to store in ES