### PR TITLE
Fix typo in parameter name

### DIFF
--- a/tests/infrared/16/stf-gnocchi-connectors.yaml.template
+++ b/tests/infrared/16/stf-gnocchi-connectors.yaml.template
@@ -26,8 +26,8 @@ custom_templates:
         GnocchiBackend: 'rbd'
         GnocchiRbdPoolName: 'metrics'
 
-        EventPipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=low']
-        MetricPipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=low']
+        EventPipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=high']
+        PipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=high']
         CeilometerQdrPublishEvents: true
         CeilometerQdrPublishMetrics: true
         CeilometerEnablePanko: false


### PR DESCRIPTION
MetricPipelinePublishers is a typo, it should be PipelinePublishers as in 
https://github.com/openstack/tripleo-heat-templates/blob/master/environments/enable-legacy-telemetry.yaml#L27-L28
Otherwise 'gnocchi://?filter_project=service&archive_policy=high' doesn't land in /etc/ceilometer/pipeline.yaml
under publishers, only notifier (for sending data via amqp1).