### PR TITLE
Update infrared-openstack.sh 13 script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Install Ansible
+        run: python -m pip install ansible
+
       - name: Install operator_sdk.util dependency for Ansible role linting
         run: ansible-galaxy collection install operator_sdk.util
 

--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -48,8 +48,8 @@ ir_run_provision() {
       --host-key "${SSH_KEY}" \
       --image-url "${VM_IMAGE_LOCATION}" \
       --host-memory-overcommit True \
-      -e override.controller.cpu=8 \
-      -e override.controller.memory=32768 \
+      -e override.controller.cpu=4 \
+      -e override.controller.memory=16384 \
       --serial-files True
 }
 
@@ -98,8 +98,8 @@ ir_create_overcloud() {
       --deploy yes \
       --ntp-server "${NTP_SERVER}" \
       --registry-mirror "${OSP_REGISTRY_MIRROR}" \
-      --overcloud-domain "${OVERCLOUD_DOMAIN}" \
       --overcloud-templates outputs/stf-connectors.yaml \
+      --overcloud-domain "${OVERCLOUD_DOMAIN}" \
       --containers yes
 }
 

--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -6,7 +6,7 @@ set -e
 #  ./infrared-openstack.sh
 
 VIRTHOST=${VIRTHOST:-localhost}
-AMQP_HOST=${AMQP_HOST:-default-interconnect-5671-service-telemetry.apps.stf.cloudops.psi.redhat.com}
+AMQP_HOST=${AMQP_HOST:-default-interconnect-5671-service-telemetry.apps-crc.testing}
 AMQP_PORT=${AMQP_PORT:-443}
 SSH_KEY="${SSH_KEY:-${HOME}/.ssh/id_rsa}"
 NTP_SERVER="${NTP_SERVER:-clock.redhat.com,10.5.27.10,10.11.160.238}"

--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -67,7 +67,7 @@ ir_create_undercloud() {
       --tls-ca https://password.corp.redhat.com/RH-IT-Root-CA.crt \
       --overcloud-domain "${OVERCLOUD_DOMAIN}" \
       --config-options DEFAULT.undercloud_timezone=UTC \
-      --config-options DEFAULT.container_insecure_registries=registry-proxy.engineering.redhat.com
+      --config-options DEFAULT.container_insecure_registries="${OSP_REGISTRY_MIRROR}"
 }
 
 ir_image_sync_undercloud() {
@@ -75,6 +75,7 @@ ir_image_sync_undercloud() {
       -o outputs/undercloud-image-sync.yml \
       --images-task rpm \
       --build "${OSP_BUILD}" \
+      --mirror "${OSP_REGISTRY_MIRROR}" \
       --images-update no
 }
 
@@ -98,7 +99,6 @@ ir_create_overcloud() {
       --tagging yes \
       --deploy yes \
       --ntp-server "${NTP_SERVER}" \
-      --registry-mirror "${OSP_REGISTRY_MIRROR}" \
       --overcloud-templates outputs/stf-connectors.yaml \
       --overcloud-domain "${OVERCLOUD_DOMAIN}" \
       --containers yes

--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -6,10 +6,11 @@ set -e
 #  ./infrared-openstack.sh
 
 VIRTHOST=${VIRTHOST:-localhost}
-AMQP_HOST=${AMQP_HOST:-stf-default-interconnect-5671-service-telemetry.apps-crc.testing}
+AMQP_HOST=${AMQP_HOST:-default-interconnect-5671-service-telemetry.apps.stf.cloudops.psi.redhat.com}
 AMQP_PORT=${AMQP_PORT:-443}
 SSH_KEY="${SSH_KEY:-${HOME}/.ssh/id_rsa}"
 NTP_SERVER="${NTP_SERVER:-clock.redhat.com,10.5.27.10,10.11.160.238}"
+CLOUD_NAME="${CLOUD_NAME:-sample}"
 
 VM_IMAGE_URL_PATH="${VM_IMAGE_URL_PATH:-http://download.devel.redhat.com/rhel-7/rel-eng/RHEL-7/latest-RHEL-7.9/compose/Server/x86_64/images}"
 # Recommend these default to tested immutable dentifiers where possible, pass "latest" style ids via environment if you want them
@@ -78,7 +79,7 @@ ir_image_sync_undercloud() {
 }
 
 stf_create_config() {
-  sed -e "s/<<AMQP_HOST>>/${AMQP_HOST}/;s/<<AMQP_PORT>>/${AMQP_PORT}/" ${ENVIRONMENT_TEMPLATE} > outputs/stf-connectors.yaml
+  sed -e "s/<<AMQP_HOST>>/${AMQP_HOST}/;s/<<AMQP_PORT>>/${AMQP_PORT}/;s/<<CLOUD_NAME>>/${CLOUD_NAME}/" ${ENVIRONMENT_TEMPLATE} > outputs/stf-connectors.yaml
 }
 
 ir_create_overcloud() {

--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -99,7 +99,7 @@ ir_create_overcloud() {
       --tagging yes \
       --deploy yes \
       --ntp-server "${NTP_SERVER}" \
-      --overcloud-templates outputs/stf-connectors.yaml \
+      --overcloud-templates ceilometer-write-qdr-edge-only,collectd-write-qdr-edge-only,outputs/stf-connectors.yaml \
       --overcloud-domain "${OVERCLOUD_DOMAIN}" \
       --containers yes
 }

--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -121,6 +121,13 @@ if ${TEMPEST_ONLY}; then
   ir_run_tempest
 else
   echo "-- full cloud deployment"
+  echo ">> Cloud name: ${CLOUD_NAME}"
+  echo ">> Overcloud domain: ${OVERCLOUD_DOMAIN}"
+  echo ">> STF enabled: ${ENABLE_STF_CONNECTORS}"
+  echo ">> OSP version: ${OSP_VERSION}"
+  echo ">> OSP build: ${OSP_BUILD}"
+  echo ">> OSP topology: ${OSP_TOPOLOGY}"
+
   ir_run_cleanup
   ir_run_provision
   ir_create_undercloud
@@ -132,4 +139,12 @@ else
     truncate --size 0 outputs/stf-connectors.yaml
   fi
   ir_create_overcloud
+
+  echo "-- deployment completed"
+  echo ">> Cloud name: ${CLOUD_NAME}"
+  echo ">> Overcloud domain: ${OVERCLOUD_DOMAIN}"
+  echo ">> STF enabled: ${ENABLE_STF_CONNECTORS}"
+  echo ">> OSP version: ${OSP_VERSION}"
+  echo ">> OSP build: ${OSP_BUILD}"
+  echo ">> OSP topology: ${OSP_TOPOLOGY}"
 fi

--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -23,8 +23,10 @@ OSP_MIRROR="${OSP_MIRROR:-rdu2}"
 OSP_REGISTRY_MIRROR="${OSP_REGISTRY_MIRROR:-registry-proxy.engineering.redhat.com}"
 LIBVIRT_DISKPOOL="${LIBVIRT_DISKPOOL:-/var/lib/libvirt/images}"
 ENVIRONMENT_TEMPLATE="${ENVIRONMENT_TEMPLATE:-stf-connectors.yaml.template}"
+OVERCLOUD_DOMAIN="${OVERCLOUD_DOMAIN:-`hostname -s`}"
 
 TEMPEST_ONLY="${TEMPEST_ONLY:-false}"
+ENABLE_STF_CONNECTORS="${ENABLE_STF_CONNECTORS:-true}"
 
 ir_run_cleanup() {
   infrared virsh \
@@ -62,6 +64,7 @@ ir_create_undercloud() {
       --images-update no \
       --registry-mirror "${OSP_REGISTRY_MIRROR}" \
       --tls-ca https://password.corp.redhat.com/RH-IT-Root-CA.crt \
+      --overcloud-domain "${OVERCLOUD_DOMAIN}" \
       --config-options DEFAULT.undercloud_timezone=UTC \
       --config-options DEFAULT.container_insecure_registries=registry-proxy.engineering.redhat.com
 }
@@ -95,6 +98,7 @@ ir_create_overcloud() {
       --deploy yes \
       --ntp-server "${NTP_SERVER}" \
       --registry-mirror "${OSP_REGISTRY_MIRROR}" \
+      --overcloud-domain "${OVERCLOUD_DOMAIN}" \
       --overcloud-templates outputs/stf-connectors.yaml \
       --containers yes
 }

--- a/tests/infrared/13/stf-connectors.yaml.template
+++ b/tests/infrared/13/stf-connectors.yaml.template
@@ -1,37 +1,69 @@
 ---
-tripleo_heat_templates:
-    - /usr/share/openstack-tripleo-heat-templates/environments/metrics/qdr-edge-only.yaml
-    - /usr/share/openstack-tripleo-heat-templates/environments/metrics/collectd-write-qdr.yaml
-    - /usr/share/openstack-tripleo-heat-templates/environments/metrics/ceilometer-write-qdr.yaml
-
 custom_templates:
+    resource_registry:
+        OS::TripleO::Services::Collectd: /usr/share/openstack-tripleo-heat-templates/docker/services/metrics/collectd.yaml
+        OS::TripleO::Services::MetricsQdr: /usr/share/openstack-tripleo-heat-templates/docker/services/metrics/qdr.yaml
+        OS::TripleO::Services::CeilometerAgentCentral: /usr/share/openstack-tripleo-heat-templates/docker/services/ceilometer-agent-central.yaml
+        OS::TripleO::Services::CeilometerAgentNotification: /usr/share/openstack-tripleo-heat-templates/docker/services/ceilometer-agent-notification.yaml
+        OS::TripleO::Services::CeilometerAgentIpmi: /usr/share/openstack-tripleo-heat-templates/docker/services/ceilometer-agent-ipmi.yaml
+        OS::TripleO::Services::ComputeCeilometerAgent: /usr/share/openstack-tripleo-heat-templates/docker/services/ceilometer-agent-compute.yaml
+        OS::TripleO::Services::Redis: /usr/share/openstack-tripleo-heat-templates/docker/services/pacemaker/database/redis.yaml
+
     parameter_defaults:
+        EventPipelinePublishers: []
+        CeilometerEnablePanko: false
         CeilometerQdrPublishEvents: true
-
+        CeilometerQdrEventsConfig:
+            driver: amqp
+            topic: <<CLOUD_NAME>>-event
         CollectdAmqpInstances:
-            notify:
+            <<CLOUD_NAME>>-notify:
+                format: JSON
                 notify: true
+                presettle: false
+            <<CLOUD_NAME>>-telemetry:
                 format: JSON
                 presettle: false
-            telemetry:
-                format: JSON
-                presettle: false
-
+        CollectdAmqpInterval: 5
+        CollectdConnectionType: amqp1
         CollectdDefaultPlugins:
-            - cpu
-            - df
-            - load
-            - connectivity
-            - intel_rdt
-            - ipmi
-            - procevent
-
-        MetricsQdrSSLProfiles:
-            - name: sslProfile
-
+        - cpu
+        - df
+        - disk
+        - hugepages
+        - interface
+        - load
+        - memory
+        - processes
+        - unixsock
+        - uptime
+        - connectivity
+        - intel_rdt
+        - ipmi
+        - procevent
+        CollectdDefaultPollingInterval: 5
+        MetricsQdrAddresses:
+        -   distribution: multicast
+            prefix: collectd
+        -   distribution: multicast
+            prefix: anycast/ceilometer
         MetricsQdrConnectors:
-            - host: <<AMQP_HOST>>
-              port: <<AMQP_PORT>>
-              role: edge
-              verifyHostname: false
-              sslProfile: sslProfile
+        -   host: <<AMQP_HOST>>
+            port: <<AMQP_PORT>>
+            role: edge
+            sslProfile: sslProfile
+            verifyHostname: false
+        MetricsQdrSSLProfiles:
+        -   name: sslProfile
+        ExtraConfig:
+            collectd::plugin::cpu::reportbycpu: true
+            collectd::plugin::cpu::reportbystate: true
+            collectd::plugin::cpu::reportnumcpu: false
+            collectd::plugin::cpu::valuespercentage: true
+            collectd::plugin::df::ignoreselected: true
+            collectd::plugin::df::reportbydevice: true
+            collectd::plugin::df::fstypes: ['xfs']
+            collectd::plugin::load::reportrelative: true
+            collectd::plugin::virt::connection: "qemu:///system"
+            collectd::plugin::virt::extra_stats: "cpu_util disk disk_err pcpu job_stats_background perf vcpupin"
+            collectd::plugin::virt::hostname_format: "hostname"

--- a/tests/infrared/13/stf-connectors.yaml.template
+++ b/tests/infrared/13/stf-connectors.yaml.template
@@ -11,11 +11,18 @@ custom_templates:
 
     parameter_defaults:
         EventPipelinePublishers: []
+        PipelinePublishers: []
+        ManagePipeline: true
+        ManagePolling: true
         CeilometerEnablePanko: false
         CeilometerQdrPublishEvents: true
+        CeilometerQdrPublishMetrics: true
         CeilometerQdrEventsConfig:
             driver: amqp
             topic: <<CLOUD_NAME>>-event
+        CeilometerQdrMetricsConfig:
+            driver: amqp
+            topic: <<CLOUD_NAME>>-metering
         CollectdAmqpInstances:
             <<CLOUD_NAME>>-notify:
                 format: JSON
@@ -25,6 +32,7 @@ custom_templates:
                 format: JSON
                 presettle: false
         CollectdAmqpInterval: 5
+        CollectdDefaultPollingInterval: 5
         CollectdConnectionType: amqp1
         CollectdDefaultPlugins:
         - cpu
@@ -41,7 +49,6 @@ custom_templates:
         - intel_rdt
         - ipmi
         - procevent
-        CollectdDefaultPollingInterval: 5
         MetricsQdrAddresses:
         -   distribution: multicast
             prefix: collectd
@@ -56,6 +63,7 @@ custom_templates:
         MetricsQdrSSLProfiles:
         -   name: sslProfile
         ExtraConfig:
+            ceilometer::agent::polling::polling_interval: 5
             collectd::plugin::cpu::reportbycpu: true
             collectd::plugin::cpu::reportbystate: true
             collectd::plugin::cpu::reportnumcpu: false


### PR DESCRIPTION
Remove the PREFIX option that I don't think we ever got working correctly. Import
the ENVIRONMENT_TEMPLATE variable that we use in the 16 script for future considerations.

Bump the base OS image and puddle target to match current phase 2 tests for OSP13.

Reduce CPU and memory footprint to match recent changes in 16 script.