### PR TITLE
Provide support for local building prometheus-webhook-snmp

### DIFF
--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -22,6 +22,7 @@ choose to override:
 | ------------------------------                  | ------------ | --------- | ------------------------------------                                                                  |
 | `__deploy_stf`                                  | {true,false} | true      | Whether to deploy an instance of STF                                                                  |
 | `__local_build_enabled`                         | {true,false} | true      | Whether to deploySTF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch` |
+| `prometheus_webhook_snmp_branch`                | <git_branch> | master    | Which Prometheus Webhook SNMP git branch to checkout                                                  |
 | `sgo_branch`                                    | <git_branch> | master    | Which Smart Gateway Operator git branch to checkout                                                   |
 | `sg_branch`                                     | <git_branch> | master    | Which Smart Gateway git branch to checkout                                                            |
 | `sg_core_branch`                                | <git_branch> | master    | Which Smart Gateway Core git branch to checkout                                                       |

--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -58,3 +58,17 @@
         repo: https://github.com/infrawatch/sg-bridge
         dest: working/sg-bridge
         version: master
+
+- name: Get prometheus-webhook-snmp
+  block:
+    - name: Try cloning same-named branch or override branch
+      git:
+        repo: https://github.com/infrawatch/prometheus-webhook-snmp
+        dest: working/prometheus-webhook-snmp
+        version: "{{ prometheus_webhook_snmp_branch | default(branch, true) }}"
+  rescue:
+    - name: Get master branch because same-named doesn't exist
+      git:
+        repo: https://github.com/infrawatch/prometheus-webhook-snmp
+        dest: working/prometheus-webhook-snmp
+        version: master

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -12,6 +12,7 @@
     sto_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/service-telemetry-operator:latest
     sg_core_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/sg-core:latest
     sg_bridge_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/sg-bridge:latest
+    prometheus_webhook_snmp_image_path: image-registry.openshift-image-registry.svc:5000/{{ namespace }}/prometheus-webhook-snmp:latest
 
 - block:
   - name: Setup supporting repositories
@@ -32,6 +33,7 @@
       - { name: smart-gateway, dockerfile_path: Dockerfile, image_reference_name: sg_image_path, working_build_dir: ./working/smart-gateway }
       - { name: sg-core, dockerfile_path: build/Dockerfile, image_reference_name: sg_core_image_path, working_build_dir: ./working/sg-core }
       - { name: sg-bridge, dockerfile_path: build/Dockerfile, image_reference_name: sg_bridge_image_path, working_build_dir: ./working/sg-bridge }
+      - { name: prometheus-webhook-snmp, dockerfile_path: Dockerfile, image_reference_name: prometheus_webhook_snmp_image_path, working_build_dir: ./working/prometheus-webhook-snmp }
     loop_control:
       loop_var: artifact
     tags:

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -56,8 +56,14 @@
 - name: Replace SG image path in STO CSV
   replace:
     path: working/service-telemetry-operator.clusterserviceversion.yaml
-    regexp: '(\s+)image: image-registry\.openshift-image-registry\.svc\:5000/service-telemetry/service-telemetry-operator\:.+$'
+    regexp: '(\s+)image: quay\.io/infrawatch/service-telemetry-operator\:.+$'
     replace: '\1image: {{ sto_image_path }}'
+
+- name: Replace prometheus-webhook-snmp image path in STO CSV
+  replace:
+    path: working/service-telemetry-operator.clusterserviceversion.yaml
+    regexp: '(\s+)image: quay\.io/infrawatch/prometheus-webhook-snmp\:.+$'
+    replace: '\1image: {{ prometheus_webhook_snmp_image_path }}'
 
 - name: Replace namespace in STO CSV
   replace:


### PR DESCRIPTION
Provides ability to compile a local version of Prometheus Webhook SNMP. Also updates
the inline sed replacement for image path with the current path to the service-telemetry-operator
image.
