### PR TITLE
Use new unstable channel for quickstart

### DIFF
--- a/build/stf-run-ci/tasks/setup_stf.yml
+++ b/build/stf-run-ci/tasks/setup_stf.yml
@@ -9,7 +9,7 @@
         namespace: openshift-marketplace
       spec:
         displayName: InfraWatch Operators
-        image: quay.io/infrawatch-operators/infrawatch-catalog:latest
+        image: quay.io/infrawatch-operators/infrawatch-catalog:unstable
         publisher: InfraWatch
         sourceType: grpc
         updateStrategy:
@@ -26,7 +26,7 @@
         name: smart-gateway-operator
         namespace: "{{ namespace }}"
       spec:
-        channel: latest
+        channel: unstable
         installPlanApproval: Automatic
         name: smart-gateway-operator
         source: infrawatch-operators
@@ -42,7 +42,7 @@
         name: service-telemetry-operator
         namespace: "{{ namespace }}"
       spec:
-        channel: latest
+        channel: unstable
         installPlanApproval: Automatic
         name: service-telemetry-operator
         source: infrawatch-operators

--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 REL=$(dirname "$0"); source "${REL}/../build/metadata.sh"
+EPHEMERAL_STORAGE="${EPHEMERAL_STORAGE:-false}"
 
 oc new-project "${OCP_PROJECT}"
 ansible-playbook \
     --extra-vars namespace="${OCP_PROJECT}" \
     --extra-vars __local_build_enabled=false \
     --extra-vars __service_telemetry_snmptraps_enabled=true \
+    --extra-vars __service_telemetry_storage_ephemeral_enabled=${EPHEMERAL_STORAGE} \
     ${REL}/../build/run-ci.yaml

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -74,8 +74,8 @@ oc logs "$(oc get pod -l application=default-interconnect -o jsonpath='{.items[0
 echo
 
 echo "*** [INFO] Logs from smart gateways..."
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-meter" -c bridge -o jsonpath='{.items[0].metadata.name}')"
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-meter" -c smart-gateway -o jsonpath='{.items[0].metadata.name}')"
+oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-meter" -o jsonpath='{.items[0].metadata.name}')" -c bridge
+oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-meter" -o jsonpath='{.items[0].metadata.name}')" -c smart-gateway
 oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-event" -o jsonpath='{.items[0].metadata.name}')"
 oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-meter" -o jsonpath='{.items[0].metadata.name}')"
 oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-event" -o jsonpath='{.items[0].metadata.name}')"


### PR DESCRIPTION
Use the new unstable channel for the quickstart.sh script. Also sneaks in a small
feature that makes using quickstart.sh against systems without persistent storage
easier (adds EPHERMAL_STORAGE environment variable).

Closes #164
