### PR TITLE
Resolve issue with ElasticSearch password retrieval

### DIFF
--- a/roles/servicetelemetry/tasks/component_clouds.yml
+++ b/roles/servicetelemetry/tasks/component_clouds.yml
@@ -31,7 +31,7 @@
 
   - name: Filter out ElasticSearch password for BasicAuth
     set_fact:
-      elastic_pass: "{{ elasticsearch_es_elastic_user | json_query('resources[].data.elastic') | b64decode }}"
+      elastic_pass: "{{ elasticsearch_es_elastic_user | json_query('resources[0].data.elastic') | b64decode }}"
     no_log: true
 
   - name: Deploy Events Smart Gateway instance for each collector


### PR DESCRIPTION
In later versions of Ansible and Python there is an issue with how data is passed to
the b64decode filter. Make sure we only ever pass a single resource from the list (as
we would only expect to ever have 1 resource).

Resolves: rhbz#1924195
