### PR TITLE
Bump ElasticSearch version to 7.10.2

### DIFF
--- a/roles/servicetelemetry/templates/manifest_elasticsearch.j2
+++ b/roles/servicetelemetry/templates/manifest_elasticsearch.j2
@@ -4,7 +4,7 @@ metadata:
   name: elasticsearch
   namespace: '{{ meta.namespace }}'
 spec:
-  version: 7.5.1
+  version: 7.10.2
   http:
     tls:
       certificate:


### PR DESCRIPTION
Bump the ElasticSearch version in the template to 7.10.2, the last free version distributed
under the Apache v2 license (later versions are SSPL). The latest ECK version of 1.4 no longer
supports installing ElasticSearch 7.5.1 and results in a failed ElasticSearch object due to
7.5.1 being unsupported.

In the future this version value should be exposed in the ServiceTelemetry object so administrators
can set the desired version for their environment.
