### PR TITLE
Expose SmartGateway debug option

### DIFF
--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -217,6 +217,9 @@ spec:
                           subscriptionAddress:
                             description: Address to subscribe on the data transport to receive telemetry.
                             type: string
+                          debugEnabled:
+                            description: Enable console debugging. Default is 'false'.
+                            type: boolean
                         type: object
                       type: array
                   type: object
@@ -236,6 +239,9 @@ spec:
                           subscriptionAddress:
                             description: Address to subscribe on the data transport to receive notifications.
                             type: string
+                          debugEnabled:
+                            description: Enable console debugging. Default is 'false'.
+                            type: boolean
                         type: object
                       type: array
                   type: object

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -68,18 +68,18 @@ servicetelemetry_defaults:
         collectors:
           - collector_type: collectd
             subscription_address: collectd/telemetry
-            debugEnabled: false
+            debug_enabled: false
           - collector_type: ceilometer
             subscription_address: anycast/ceilometer/metering.sample
-            debugEnabled: false
+            debug_enabled: false
       events:
         collectors:
           - collector_type: collectd
             subscription_address: collectd/notify
-            debugEnabled: false
+            debug_enabled: false
           - collector_type: ceilometer
             subscription_address: anycast/ceilometer/event.sample
-            debugEnabled: false
+            debug_enabled: false
 
 
 # These variables are outside of the defaults. Their values will be

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -68,14 +68,18 @@ servicetelemetry_defaults:
         collectors:
           - collector_type: collectd
             subscription_address: collectd/telemetry
+            debugEnabled: false
           - collector_type: ceilometer
             subscription_address: anycast/ceilometer/metering.sample
+            debugEnabled: false
       events:
         collectors:
           - collector_type: collectd
             subscription_address: collectd/notify
+            debugEnabled: false
           - collector_type: ceilometer
             subscription_address: anycast/ceilometer/event.sample
+            debugEnabled: false
 
 
 # These variables are outside of the defaults. Their values will be

--- a/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
@@ -8,7 +8,7 @@ spec:
   amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/{{ this_collector.subscription_address }}'
   amqpDataSource: '{{ this_collector.collector_type }}'
   serviceType: 'events'
-  debug: {{ this_collector.debug_enabled }}
+  debug: {{ this_collector.debug_enabled | default(false) }}
   elasticUrl: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
   useBasicAuth: true
   elasticUser: '{{ elastic_user | default('elastic') }}'

--- a/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
@@ -8,7 +8,7 @@ spec:
   amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/{{ this_collector.subscription_address }}'
   amqpDataSource: '{{ this_collector.collector_type }}'
   serviceType: 'events'
-  debug: false
+  debug: {{ this_collector.debug_enabled }}
   elasticUrl: 'https://elasticsearch-es-http.{{ meta.namespace }}.svc.cluster.local:9200'
   useBasicAuth: true
   elasticUser: '{{ elastic_user | default('elastic') }}'

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -6,7 +6,7 @@ metadata:
 spec:
   amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ this_collector.subscription_address }}'
   amqpDataSource: '{{ this_collector.collector_type }}'
-  debug: false
+  debug: {{ this_collector.debug_enabled }}
   serviceType: 'metrics'
 {% if this_collector.collector_type == "collectd" %}
   size: {{ smartgateway_deployment_size }}

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -6,7 +6,7 @@ metadata:
 spec:
   amqpUrl: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ this_collector.subscription_address }}'
   amqpDataSource: '{{ this_collector.collector_type }}'
-  debug: {{ this_collector.debug_enabled }}
+  debug: {{ this_collector.debug_enabled | default(false) }}
   serviceType: 'metrics'
 {% if this_collector.collector_type == "collectd" %}
   size: {{ smartgateway_deployment_size }}


### PR DESCRIPTION
Expose the SmartGateway object 'debug' parameter as a 'cloud' configuration parameter within
the ServiceTelemetry object. This allows an administrator to enable debugging on a per SmartGateway
instance. Default remains false.
