### PR TITLE
Only need 15 OSDs in test configuration

### DIFF
--- a/tests/infrared/16/stf-connectors.yaml.template
+++ b/tests/infrared/16/stf-connectors.yaml.template
@@ -105,7 +105,6 @@ custom_templates:
                - ceph-osd.12
                - ceph-osd.13
                - ceph-osd.14
-               - ceph-osd.15
 
         MetricsQdrConnectors:
             - host: <<AMQP_HOST>>

--- a/tests/infrared/16/stf-gnocchi-connectors.yaml.template
+++ b/tests/infrared/16/stf-gnocchi-connectors.yaml.template
@@ -92,7 +92,6 @@ custom_templates:
                - ceph-osd.12
                - ceph-osd.13
                - ceph-osd.14
-               - ceph-osd.15
 
         CollectdExtraPlugins:
         - vmem


### PR DESCRIPTION
For our default test environment of 3 ceph nodes, there are only 15 OSDs configured. We have
16 configured as we start counting at 0. Dropping the ceph-osd.15 list item.
