### PR TITLE
Added a more complete prometheus alert rules file

### DIFF
--- a/deploy/alerts/README.md
+++ b/deploy/alerts/README.md
@@ -6,16 +6,16 @@ amount of standard deviation). They provide a default and may
 require adjustment for specific deployments.
 
 ## alerts_extended.yaml
-Besides `alerts.yaml` alarms from openstack.rules, it includes:
- - ceph.rules: 
+Besides `alerts.yaml` alarms from **openstack.rules**, it includes:
+ - **ceph.rules**: 
      * ceph osd down
      * ceph full (warning and critical)
- - virtual.rules:
+ - **virtual.rules**:
      * high cpu virtual (warning and critical)
      * memory low virtual (warning and critical)
      * error packets rx/tx virtual
      * dropped packers rx/tx virtual
- - availability.rules:
+ - **availability.rules**:
      * metric listener down
      * host down
 

--- a/deploy/alerts/README.md
+++ b/deploy/alerts/README.md
@@ -9,10 +9,10 @@ require adjustment for specific deployments.
 Besides `alerts.yaml` alarms from openstack.rules, it includes:
  - ceph.rules: 
      * ceph osd down
-     * ceph full (warning and critical) alarms
+     * ceph full (warning and critical)
  - virtual.rules:
-     * high cpu virtual (warning and critical
-     * memory low virtual (warning and critical
+     * high cpu virtual (warning and critical)
+     * memory low virtual (warning and critical)
      * error packets rx/tx virtual
      * dropped packers rx/tx virtual
  - availability.rules:

--- a/deploy/alerts/README.md
+++ b/deploy/alerts/README.md
@@ -5,6 +5,20 @@ These alarms are triggered by a substantial change (over a certain
 amount of standard deviation). They provide a default and may
 require adjustment for specific deployments.
 
+## alerts_extended.yaml
+Besides `alerts.yaml` alarms from openstack.rules, it includes:
+ - ceph.rules: 
+     * ceph osd down
+     * ceph full (warning and critical) alarms
+ - virtual.rules:
+     * high cpu virtual (warning and critical
+     * memory low virtual (warning and critical
+     * error packets rx/tx virtual
+     * dropped packers rx/tx virtual
+ - availability.rules:
+     * metric listener down
+     * host down
+
 ## Installation
 
 Log into OpenShift and
@@ -12,3 +26,10 @@ Log into OpenShift and
 ```
 oc apply -f alerts.yaml
 ```
+
+or:
+
+```
+oc apply -f alerts_extended.yaml
+```
+

--- a/deploy/alerts/alerts_extended.yml
+++ b/deploy/alerts/alerts_extended.yml
@@ -1,0 +1,382 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    prometheus: stf-default
+    role: alert-rules
+  name: prometheus-alarm-rules
+  namespace: service-telemetry
+spec:
+  groups:
+    - name: ./openstack.rules
+      rules:
+        - expr: 'rate(collectd_disk_disk_io_time_io_time_total[5m])'
+          record: 'job:iotime:rate_5m'
+        - expr: 'stddev_over_time(job:iotime:rate_5m[1h])'
+          record: 'job:iotime:rate_5m:stddev_over_time_1h'
+        - expr: 'avg_over_time(job:iotime:rate_5m[1h])'
+          record: 'job:iotime:rate_5m:avg_over_time_1h'
+        - alert: iotime warn
+          expr: >-
+            (abs(job:iotime:rate_5m - job:iotime:rate_5m:avg_over_time_1h) / job:iotime:rate_5m:stddev_over_time_1h) > 3
+          for: 10m
+          labels:
+            severity: warn
+          annotations:
+            summary: IO time spent (warning)
+
+        - expr: 'rate(collectd_disk_disk_io_time_weightedio_time_total[5m])'
+          record: 'job:weightiotime:rate_5m'
+        - expr: 'stddev_over_time(job:weightiotime:rate_5m[1h])'
+          record: 'job:weightiotime:rate_5m:stddev_over_time_1h'
+        - expr: 'avg_over_time(job:weightiotime:rate_5m[1h])'
+          record: 'job:weightiotime:rate_5m:avg_over_time_1h'
+        - alert: weightiotime warn
+          expr: >-
+            (abs(job:weightiotime:rate_5m - job:weightiotime:rate_5m:avg_over_time_1h) / job:weightiotime:rate_5m:stddev_over_time_1h) > 3
+          for: 10m
+          labels:
+            severity: warn
+          annotations:
+            summary: Weighted IO time spent (warning)
+
+        - expr: 'rate(collectd_disk_disk_time_read_total[5m])'
+          record: 'job:disk:time:read:rate_5m'
+        - expr: 'stddev_over_time(job:disk:time:read:rate_5m[1h])'
+          record: 'job:disk:time:read:rate_5m:stddev_over_time_1h'
+        - expr: 'avg_over_time(job:disk:time:read:rate_5m[1h])'
+          record: 'job:disk:time:read:rate_5m:avg_over_time_1h'
+        - alert: disk:time:read warn
+          expr: >-
+            (abs(job:disk:time:read:rate_5m - job:disk:time:read:rate_5m:avg_over_time_1h) / job:disk:time:read:rate_5m:stddev_over_time_1h) >3
+          for: 10m
+          labels:
+            severity: warn
+          annotations:
+            summary: IO read (warning)
+
+        - alert: disk:time:read critical
+          expr: >-
+            (abs(job:disk:time:read:rate_5m - job:disk:time:read:rate_5m:avg_over_time_1h) / job:disk:time:read:rate_5m:stddev_over_time_1h) >6
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: IO read (critical)
+        - expr: 'rate(collectd_disk_disk_time_write_total[5m])'
+          record: 'job:disk:time:write:rate_5m'
+        - expr: 'stddev_over_time(job:disk:time:write:rate_5m[1h])'
+          record: 'job:disk:time:write:rate_5m:stddev_over_time_1h'
+        - expr: 'avg_over_time(job:disk:time:write:rate_5m[1h])'
+          record: 'job:disk:time:write:rate_5m:avg_over_time_1h'
+        - alert: disk:time:write warn
+          expr: >-
+            (abs(job:disk:time:write:rate_5m - job:disk:time:write:rate_5m:avg_over_time_1h) / job:disk:time:write:rate_5m:stddev_over_time_1h) >3
+          for: 10m
+          labels:
+            severity: warn
+          annotations:
+            summary: IO write (warning)
+
+        - alert: disk:time:write critical
+          expr: >-
+            (abs(job:disk:time:write:rate_5m - job:disk:time:write:rate_5m:avg_over_time_1h) / job:disk:time:write:rate_5m:stddev_over_time_1h) >6
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: IO write (critical)
+        - expr: 'rate(collectd_disk_disk_ops_read_total[5m])'
+          record: 'job:disk:time:read:rate_5m'
+        - expr: 'stddev_over_time(job:disk:time:read:rate_5m[1h])'
+          record: 'job:disk:time:read:rate_5m:stddev_over_time_1h'
+        - expr: 'avg_over_time(job:disk:time:read:rate_5m[1h])'
+          record: 'job:disk:time:read:rate_5m:avg_over_time_1h'
+        - alert: disk:time:read warn
+          expr: >-
+            (abs(job:disk:time:read:rate_5m - job:disk:time:read:rate_5m:avg_over_time_1h) / job:disk:time:read:rate_5m:stddev_over_time_1h) >3
+          for: 10m
+          labels:
+            severity: warn
+          annotations:
+            summary: disk ops read (warning)
+
+        - alert: disk:time:read critical
+          expr: >-
+            (abs(job:disk:time:read:rate_5m - job:disk:time:read:rate_5m:avg_over_time_1h) / job:disk:time:read:rate_5m:stddev_over_time_1h) >6
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: disk ops read (critical)
+        - expr: 'rate(collectd_disk_disk_ops_write_total[5m])'
+          record: 'job:disk:time:write:rate_5m'
+        - expr: 'stddev_over_time(job:disk:time:write:rate_5m[1h])'
+          record: 'job:disk:time:write:rate_5m:stddev_over_time_1h'
+        - expr: 'avg_over_time(job:disk:time:write:rate_5m[1h])'
+          record: 'job:disk:time:write:rate_5m:avg_over_time_1h'
+        - alert: disk:time:write warn
+          expr: >-
+            (abs(job:disk:time:write:rate_5m - job:disk:time:write:rate_5m:avg_over_time_1h) / job:disk:time:write:rate_5m:stddev_over_time_1h) >3
+          for: 10m
+          labels:
+            severity: warn
+          annotations:
+            summary: disk ops write (warning)
+
+        - alert: disk:time:write critical
+          expr: >-
+            (abs(job:disk:time:write:rate_5m - job:disk:time:write:rate_5m:avg_over_time_1h) / job:disk:time:write:rate_5m:stddev_over_time_1h) >6
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: disk ops write (critical)
+
+        - alert: error packets rx 
+          labels:
+            severity: warning
+          annotations:
+            summary: error packets RX (warning)
+          expr: >-
+            rate(collectd_interface_if_errors_rx_total[5m]) > 1.0
+          for: 5m
+        - alert: error packets tx
+          labels:
+            severity: warning
+          annotations:
+            summary: error packets TX (warning)
+          expr: >-
+            rate(collectd_interface_if_errors_tx_total[5m]) > 1.0
+          for: 5m
+        - alert: dropped packets rx 
+          labels:
+            severity: warning
+          annotations:
+            summary: dropped packets RX (warning)
+          expr: >-
+            rate(collectd_interface_if_dropped_rx_total[5m]) > 50.0
+          for: 5m
+        - alert: dropped packets tx
+          labels:
+            severity: warning
+          annotations:
+            summary: dropped packets TX (warning)
+          expr: >-
+            rate(collectd_interface_if_dropped_tx_total[5m]) > 50.0
+          for: 5m
+
+        - alert: high cpu
+          labels:
+            severity: warn
+          annotations:
+            summary: CPU usage high (warning)
+          expr: >-
+            sum without(plugin_instance,type_instance) (collectd_cpu_percent{type_instance=~"user|system"}) / sum without(plugin_instance,type_instance) (collectd_cpu_percent{type_instance="idle"}) > 0.5
+          for: 10m
+        - alert: high cpu
+          labels:
+            severity: critical
+          annotations:
+            summary: CPU usage high (critical)
+          expr: >-
+            sum without(plugin_instance,type_instance) (collectd_cpu_percent{type_instance=~"user|system"}) / sum without(plugin_instance,type_instance) (collectd_cpu_percent{type_instance="idle"}) > 0.7
+          for: 10m
+        - alert: inode usage
+          labels:
+            severity: warning
+          annotations:
+            summary: Inodes usage (warning)
+          expr: >-
+            sum without (endpoint,service,type_instance) (collectd_df_df_inodes{plugin_instance="root",type_instance="used"})/ (sum without (endpoint,service,type_instance) (collectd_df_df_inodes{plugin_instance="root",type_instance=~"free|used"})) > 0.6
+          for: 10m
+        - alert: inode usage
+          labels:
+            severity: critical
+          annotations:
+            summary: Inodes usage (critical)
+          expr: >-
+            sum without (endpoint,service,type_instance) (collectd_df_df_inodes{plugin_instance="root",type_instance="used"})/ (sum without (endpoint,service,type_instance) (collectd_df_df_inodes{plugin_instance="root",type_instance=~"free|used"})) > 0.8
+          for: 10m
+        - alert: load longterm
+          labels:
+            severity: warning
+          annotations:
+            summary: load longterm (warning)
+          expr: >-
+            (collectd_load_longterm / collectd_cpu_count) > 0.7 and (collectd_load_longterm / collectd_cpu_count) < 0.9
+          for: 10m
+        - alert: load longterm
+          labels:
+            severity: critical
+          annotations:
+            summary: load longterm (critical)
+          expr: >-
+            (collectd_load_longterm / collectd_cpu_count) >= 0.9
+          for: 10m
+        - alert: load midterm
+          labels:
+            severity: warning
+          annotations:
+            summary: load midterm (warning)
+          expr: >-
+            (collectd_load_midterm / collectd_cpu_count) > 0.7 and (collectd_load_midterm / collectd_cpu_count) < 0.9
+          for: 10m
+        - alert: load midterm
+          labels:
+            severity: critical
+          annotations:
+            summary: load midterm (critical)
+          expr: >-
+            (collectd_load_midterm / collectd_cpu_count) >= 0.9
+          for: 10m
+        - alert: load shortterm
+          labels:
+            severity: warning
+          annotations:
+            summary: load shortterm (warning)
+          expr: >-
+            (collectd_load_shortterm / collectd_cpu_count) > 0.7 and (collectd_load_shortterm / collectd_cpu_count) < 0.9
+          for: 10m
+        - alert: load shortterm
+          labels:
+            severity: critical
+          annotations:
+            summary: load shortterm (critical)
+          expr: >-
+            (collectd_load_shortterm / collectd_cpu_count) >= 0.9
+          for: 10m
+        - alert: memory low
+          labels:
+            severity: warning
+          annotations:
+            summary: memory low (warning)
+          expr: >-
+            sum without(type_instance) (collectd_memory{type_instance="used"})/sum without(type_instance) (collectd_memory) > 0.8 and sum without(type_instance) (collectd_memory{type_instance="used"})/sum without(type_instance) (collectd_memory) < 0.9
+          for: 10m
+        - alert: memory low
+          labels:
+            severity: critical
+          annotations:
+            summary: memory low (critical)
+          expr: >-
+            sum without(type_instance) (collectd_memory{type_instance="used"})/sum without(type_instance) (collectd_memory) >= 0.9
+          for: 10m
+
+    - name: ./availability.rules
+      rules:
+        - alert: Metric Listener down
+          labels:
+            severity: critical
+          expr: collectd_qpid_router_status < 1
+          annotations:
+            summary: server down (critical)
+
+        - alert: host down (1d)
+          labels:
+            severity: critical
+          annotations:
+            summary: Host down 1 day (critical)
+          expr: >-
+            count (collectd_load_shortterm offset 1h > 0) by (host) unless count(collectd_load_shortterm) by (host)
+          for: 5m
+
+
+    - name: ./virtual.rules
+      rules:
+        - alert: high cpu virtual
+          labels:
+            severity: warn
+          annotations:
+            summary: Virtual CPU usage high (warning)
+          expr: >-
+            avg without(resource,project,publisher) (ceilometer_cpu_util)  > 80.0
+          for: 5m
+        - alert: high cpu virtual
+          labels:
+            severity: critical
+          annotations:
+            summary: Virtual CPU usage high (critical)
+          expr: >-
+            avg without(resource,project,publisher) (ceilometer_cpu_util)  > 90.0
+          for: 5m
+
+        - alert: memory low virtual
+          labels:
+            severity: warn
+          annotations:
+            summary: virtual memory low (warning)
+          expr: >-
+            (avg by (resource,project)  (max_over_time(ceilometer_memory_usage[30m]))) / (avg by (resource,project)  (max_over_time(ceilometer_memory[1d]))) > 0.8
+          for: 5m
+        - alert: memory high virtual
+          labels:
+            severity: warn
+          annotations:
+            summary: virtual memory low (high)
+          expr: >-
+            (avg by (resource,project)  (max_over_time(ceilometer_memory_usage[30m]))) / (avg by (resource,project)  (max_over_time(ceilometer_memory[1d]))) > 0.9
+          for: 5m
+
+        - alert: error packets rx virtual
+          labels:
+            severity: warning
+          annotations:
+            summary: Virtual error packets RX (warning)
+          expr: >-
+            rate(collectd_virt_if_errors_rx_total[5m]) > 1.0
+          for: 5m
+        - alert: error packets tx virtual
+          labels:
+            severity: warning
+          annotations:
+            summary: Virtual error packets TX (warning)
+          expr: >-
+            rate(collectd_virt_if_errors_tx_total[5m]) > 1.0
+          for: 5m
+
+        - alert: dropped packets rx virtual
+          labels:
+            severity: warning
+          annotations:
+            summary: Virtual dropped packets RX (warning)
+          expr: >-
+            rate(collectd_virt_if_dropped_rx_total[5m]) > 50.0
+          for: 5m
+        - alert: dropped packets tx virtual
+          labels:
+            severity: warning
+          annotations:
+            summary: Virtual dropped packets TX (warning)
+          expr: >-
+            rate(collectd_virt_if_dropped_tx_total[5m]) > 50.0
+          for: 5m
+
+
+    - name: ./ceph.rules
+      rules:
+        - alert: Ceph OSDs down
+          labels:
+            severity: critical
+          annotations:
+            summary: ceph OSDs down (critical)
+          expr: >-
+            avg(collectd_ceph_ceph_bytes{type_instance="Cluster.numOsd"}) != avg(collectd_ceph_ceph_bytes{type_instance="Cluster.numOsdUp"})
+          for: 5m
+        - alert: Ceph full
+          labels:
+            severity: warning
+          annotations:
+            summary: ceph full (warning)
+          expr: >-
+            avg by (service) (collectd_ceph_ceph_bytes{type_instance="Cluster.osdBytesUsed"})/avg by (service)(collectd_ceph_ceph_bytes{type_instance="Cluster.osdBytes"})>0.75
+          for: 5m
+        - alert: Ceph full
+          labels:
+            severity: critical
+          annotations:
+            summary: ceph full (critical)
+          expr: >-
+            avg by (service) (collectd_ceph_ceph_bytes{type_instance="Cluster.osdBytesUsed"})/avg by (service)(collectd_ceph_ceph_bytes{type_instance="Cluster.osdBytes"})>0.8
+          for: 5m


### PR DESCRIPTION
In addition to the existing  prometheus alert rules (`alerts.yaml`) we suggest adding a new one (`alerts_extended.yaml`) with prometheus rules for:
 - ceph
 - virtual layer
 - availability