### PR TITLE
Add control on Grafana's anonymous authentication

### DIFF
--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -59,6 +59,7 @@ servicetelemetry_defaults:
       admin_password: secret
       admin_user: root
       disable_signout_menu: false
+      auth_anonymous: true
 
   # 'clouds' object is not partially updatable like other objects. If 'clouds'
   # object is defined then the default is overwritten.

--- a/roles/servicetelemetry/templates/manifest_grafana.j2
+++ b/roles/servicetelemetry/templates/manifest_grafana.j2
@@ -10,7 +10,7 @@ spec:
     auth:
       disable_signout_menu: {{ servicetelemetry_vars.graphing.grafana.disable_signout_menu }}
     auth.anonymous:
-      enabled: true
+      enabled: {{ servicetelemetry_vars.graphing.grafana.auth_anonymous }}
     log:
       level: warn
       mode: console


### PR DESCRIPTION
This allows the user to disable anonymous authentication on Grafana.