### PR TITLE
Drop publisher label for ceilometer

### DIFF
--- a/roles/servicetelemetry/tasks/component_servicemonitor.yml
+++ b/roles/servicetelemetry/tasks/component_servicemonitor.yml
@@ -24,6 +24,9 @@
               - action: labeldrop
                 regex: job
                 sourcelabels: []
+              - action: labeldrop
+                regex: publisher
+                sourcelabels: []
             port: prom-http
         selector:
           matchLabels:


### PR DESCRIPTION
Ceilometer agents run on all controllers, thus they all receive metrics
from RabbitMQ internally and send them to STF via QDR. This results in
what looks like broken metrics since the data rotates around the various
agents, effectively sending the same data 3 times, but with one
different label identifying the controller agent the data was being sent
from.

This change drops the publisher label which is only used by ceilometer.
Removing the publisher label resolves what looks like different data
from 3 different publishers. The result is that you get a single metric
which shows up linearly.

Resolves: rhbz#1952188
