### PR TITLE
Prometheus is pulled from community-operators

### DIFF
--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -115,5 +115,5 @@
         channel: beta
         installPlanApproval: Automatic
         name: prometheus
-        source: operatorhubio-operators
+        source: community-operators
         sourceNamespace: openshift-marketplace


### PR DESCRIPTION
without this change, prometheus won't install anymore during quickstart or run-ci.