### PR TITLE
Adjust grafana datasource name to be more general

### DIFF
--- a/roles/servicetelemetry/tasks/component_grafana.yml
+++ b/roles/servicetelemetry/tasks/component_grafana.yml
@@ -35,7 +35,7 @@
     k8s:
       api_version: integreatly.org/v1alpha1
       name: '{{ meta.name }}-ds-datasource'
-      kind: GrafanaDatasource
+      kind: GrafanaDataSource
       namespace: '{{ meta.namespace }}'
       state: absent
 

--- a/roles/servicetelemetry/tasks/component_grafana.yml
+++ b/roles/servicetelemetry/tasks/component_grafana.yml
@@ -34,7 +34,7 @@
   - name: Remove legacy datasources
     k8s:
       api_version: integreatly.org/v1alpha1
-      name: '{{ meta.name }}-ds-datasource'
+      name: '{{ meta.name }}-ds-prometheus'
       kind: GrafanaDataSource
       namespace: '{{ meta.namespace }}'
       state: absent

--- a/roles/servicetelemetry/tasks/component_grafana.yml
+++ b/roles/servicetelemetry/tasks/component_grafana.yml
@@ -34,7 +34,7 @@
   - name: Remove legacy datasources
     k8s:
       api_version: integreatly.org/v1alpha1
-      name: '{{meta.name}}-ds-datasource'
+      name: '{{ meta.name }}-ds-datasource'
       kind: grafanadatasource
       namespace: '{{ meta.namespace }}'
       state: absent

--- a/roles/servicetelemetry/tasks/component_grafana.yml
+++ b/roles/servicetelemetry/tasks/component_grafana.yml
@@ -23,13 +23,21 @@
         api_version: v1
         kind: Secret
         name: elasticsearch-es-elastic-user
-        namespace: service-telemetry
+        namespace: '{{ meta.namespace }}'
       register: es_secret
 
     - name: Decode elasticsearch password
       set_fact:
         elasticsearch_pass: '{{ es_secret.resources[0].data.elastic | b64decode }}'
     when: servicetelemetry_vars.backends.events.elasticsearch.enabled
+
+  - name: Remove legacy datasources
+    k8s:
+      api_version: integreatly.org/v1alpha1
+      name: '{{meta.name}}-ds-datasource'
+      kind: grafanadatasource
+      namespace: '{{ meta.namespace }}'
+      state: absent
 
   - name: Set datasources
     set_fact:

--- a/roles/servicetelemetry/tasks/component_grafana.yml
+++ b/roles/servicetelemetry/tasks/component_grafana.yml
@@ -35,7 +35,7 @@
     k8s:
       api_version: integreatly.org/v1alpha1
       name: '{{ meta.name }}-ds-datasource'
-      kind: grafanadatasource
+      kind: GrafanaDatasource
       namespace: '{{ meta.namespace }}'
       state: absent
 

--- a/roles/servicetelemetry/templates/manifest_grafana_ds.j2
+++ b/roles/servicetelemetry/templates/manifest_grafana_ds.j2
@@ -1,7 +1,7 @@
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDataSource
 metadata:
-  name: {{ meta.name }}-ds-prometheus
+  name: {{ meta.name }}-datasources
   namespace: {{ meta.namespace }}
 spec:
   datasources:


### PR DESCRIPTION
Previous naming of the grafandatasource implied only a prometheus datasource was controlled by the object when in fact a couple of elasticsearch datasources were too. This made documentation misleading