### PR TITLE
Allow gnocchi to use predefined policies

### DIFF
--- a/tests/infrared/16/gnocchi-connectors.yaml.template
+++ b/tests/infrared/16/gnocchi-connectors.yaml.template
@@ -11,14 +11,14 @@ custom_templates:
         OS::TripleO::Services::AodhEvaluator: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-evaluator-container-puppet.yaml
         OS::TripleO::Services::AodhNotifier: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-notifier-container-puppet.yaml
         OS::TripleO::Services::AodhListener: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-listener-container-puppet.yaml
-        OS::TripleO::Services::PankoApi: /usr/share/openstack-tripleo-heat-templates/deployment/deprecated/panko/panko-api-container-puppet.yaml
 
     parameter_defaults:
         CeilometerEnableGnocchi: true
+        CeilometerEnablePanko: false
         GnocchiArchivePolicy: 'high'
         GnocchiBackend: 'rbd'
         GnocchiRbdPoolName: 'metrics'
 
-        EventPipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=high']
-        PipelinePublishers: ['gnocchi://?filter_project=service&archive_policy=high']
+        EventPipelinePublishers: ['gnocchi://?filter_project=service']
+        PipelinePublishers: ['gnocchi://?filter_project=service']
 


### PR DESCRIPTION
By locking the archive policy via publisher, there's only one archive policy possible for use in gnocchi.

Ceilometer comes with predefined archive-policies
https://github.com/openstack/ceilometer/blob/master/ceilometer/publisher/data/gnocchi_resources.yaml

Panko is not required, it is also deprecated and removed
from upstream.