### PR TITLE
Break out common configuration to enable-stf.yaml (#211)

### DIFF
--- a/tests/infrared/13/enable-stf.yaml.template
+++ b/tests/infrared/13/enable-stf.yaml.template
@@ -1,0 +1,71 @@
+# enable data collection that is compatible with the STF data model
+# enablement of the collectors and transport are done with separate enviroment files
+# recommended:
+# - environments/metrics/ceilometer-qdr-write.yaml
+# - environments/metrics/collectd-qdr-write.yaml
+# - environments/metrics/qdr-edge-only.yaml
+
+---
+tripleo_heat_templates:
+    []
+
+custom_templates:
+    # matches the documentation for enable-stf.yaml in stable-1.3 documentation
+    parameter_defaults:
+        # only send to STF, not other publishers
+        EventPipelinePublishers: []
+        PipelinePublishers: []
+
+        # manage the polling and pipeline configuration files for Ceilometer agents
+        ManagePolling: true
+        ManagePipeline: true
+
+        # enable Ceilometer metrics and events
+        CeilometerQdrPublishMetrics: true
+        CeilometerQdrPublishEvents: true
+
+        # set collectd overrides for higher telemetry resolution and extra plugins
+        # to load
+        CollectdConnectionType: amqp1
+        CollectdAmqpInterval: 5
+        CollectdDefaultPollingInterval: 5
+        CollectdDefaultPlugins:
+        - cpu
+        - df
+        - disk
+        - hugepages
+        - interface
+        - load
+        - memory
+        - processes
+        - unixsock
+        - uptime
+        CollectdExtraPlugins:
+        - vmem
+
+        ExtraConfig:
+            ceilometer::agent::polling::polling_interval: 30
+            ceilometer::agent::polling::polling_meters:
+            - cpu
+            - disk.*
+            - ip.*
+            - image.*
+            - memory
+            - memory.*
+            - network.*
+            - perf.*
+            - port
+            - port.*
+            - switch
+            - switch.*
+            - storage.*
+            - volume.*
+
+            # to avoid filling the memory buffers if disconnected from the message bus
+            collectd::plugin::amqp1::send_queue_limit: 50
+
+            # receive extra information about virtual memory
+            collectd::plugin::vmem::verbose: true
+
+            # provide the human-friendly name of the virtual instance
+            collectd::plugin::virt::plugin_instance_format: metadata

--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -24,8 +24,9 @@ OSP_MIRROR="${OSP_MIRROR:-rdu2}"
 OSP_REGISTRY_MIRROR="${OSP_REGISTRY_MIRROR:-registry-proxy.engineering.redhat.com}"
 LIBVIRT_DISKPOOL="${LIBVIRT_DISKPOOL:-/var/lib/libvirt/images}"
 ENVIRONMENT_TEMPLATE="${ENVIRONMENT_TEMPLATE:-stf-connectors.yaml.template}"
+ENABLE_STF_ENVIRONMENT_TEMPLATE="${ENABLE_STF_ENVIRONMENT_TEMPLATE:-enable-stf.yaml.template}"
 OVERCLOUD_DOMAIN="${OVERCLOUD_DOMAIN:-`hostname -s`}"
-
+CA_CERT_FILE_CONTENT="${CA_CERT_FILE_CONTENT:-}"
 TEMPEST_ONLY="${TEMPEST_ONLY:-false}"
 ENABLE_STF_CONNECTORS="${ENABLE_STF_CONNECTORS:-true}"
 
@@ -80,7 +81,11 @@ ir_image_sync_undercloud() {
 }
 
 stf_create_config() {
-  sed -e "s/<<AMQP_HOST>>/${AMQP_HOST}/;s/<<AMQP_PORT>>/${AMQP_PORT}/;s/<<CLOUD_NAME>>/${CLOUD_NAME}/" ${ENVIRONMENT_TEMPLATE} > outputs/stf-connectors.yaml
+  sed -r "s/<<AMQP_HOST>>/${AMQP_HOST}/;s/<<AMQP_PORT>>/${AMQP_PORT}/;s/<<CLOUD_NAME>>/${CLOUD_NAME}/;s%<<CA_CERT_FILE_CONTENT>>%${CA_CERT_FILE_CONTENT//$'\n'/<@@@>}%;s/<@@@>/\n                /g" ${ENVIRONMENT_TEMPLATE} > outputs/stf-connectors.yaml
+}
+
+enable_stf_create_config() {
+  cat ${ENABLE_STF_ENVIRONMENT_TEMPLATE} > outputs/enable-stf.yaml
 }
 
 ir_create_overcloud() {
@@ -99,7 +104,7 @@ ir_create_overcloud() {
       --tagging yes \
       --deploy yes \
       --ntp-server "${NTP_SERVER}" \
-      --overcloud-templates ceilometer-write-qdr-edge-only,collectd-write-qdr-edge-only,outputs/stf-connectors.yaml \
+      --overcloud-templates ceilometer-write-qdr-edge-only,collectd-write-qdr-edge-only,outputs/enable-stf.yaml,outputs/stf-connectors.yaml \
       --overcloud-domain "${OVERCLOUD_DOMAIN}" \
       --containers yes
 }
@@ -115,6 +120,11 @@ ir_run_tempest() {
       --revision=HEAD \
       --image http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
 }
+
+if [ -z "${CA_CERT_FILE_CONTENT}" ]; then
+    echo "CA_CERT_FILE_CONTENT must be set and passed to the deployment, or QDR will fail to connect."
+    exit 1
+fi
 
 if ${TEMPEST_ONLY}; then
   echo "-- Running tempest tests"
@@ -134,9 +144,12 @@ else
   ir_image_sync_undercloud
   if ${ENABLE_STF_CONNECTORS}; then
     stf_create_config
+    enable_stf_create_config
   else
     touch outputs/stf-connectors.yaml
     truncate --size 0 outputs/stf-connectors.yaml
+    touch outputs/enable-stf.yaml
+    truncate --size 0 outputs/enable-stf.yaml
   fi
   ir_create_overcloud
 
@@ -148,3 +161,4 @@ else
   echo ">> OSP build: ${OSP_BUILD}"
   echo ">> OSP topology: ${OSP_TOPOLOGY}"
 fi
+# vim: set shiftwidth=4 tabstop=4 expandtab:

--- a/tests/infrared/13/stf-connectors.yaml.template
+++ b/tests/infrared/13/stf-connectors.yaml.template
@@ -1,22 +1,10 @@
 ---
-custom_templates:
-    resource_registry:
-        OS::TripleO::Services::Collectd: /usr/share/openstack-tripleo-heat-templates/docker/services/metrics/collectd.yaml
-        OS::TripleO::Services::MetricsQdr: /usr/share/openstack-tripleo-heat-templates/docker/services/metrics/qdr.yaml
-        OS::TripleO::Services::CeilometerAgentCentral: /usr/share/openstack-tripleo-heat-templates/docker/services/ceilometer-agent-central.yaml
-        OS::TripleO::Services::CeilometerAgentNotification: /usr/share/openstack-tripleo-heat-templates/docker/services/ceilometer-agent-notification.yaml
-        OS::TripleO::Services::CeilometerAgentIpmi: /usr/share/openstack-tripleo-heat-templates/docker/services/ceilometer-agent-ipmi.yaml
-        OS::TripleO::Services::ComputeCeilometerAgent: /usr/share/openstack-tripleo-heat-templates/docker/services/ceilometer-agent-compute.yaml
-        OS::TripleO::Services::Redis: /usr/share/openstack-tripleo-heat-templates/docker/services/pacemaker/database/redis.yaml
+tripleo_heat_templates:
+    []
 
+custom_templates:
+    # set parameter defaults to match stable-1.3 documentation
     parameter_defaults:
-        EventPipelinePublishers: []
-        PipelinePublishers: []
-        ManagePipeline: true
-        ManagePolling: true
-        CeilometerEnablePanko: false
-        CeilometerQdrPublishEvents: true
-        CeilometerQdrPublishMetrics: true
         CeilometerQdrEventsConfig:
             driver: amqp
             topic: <<CLOUD_NAME>>-event
@@ -31,29 +19,6 @@ custom_templates:
             <<CLOUD_NAME>>-telemetry:
                 format: JSON
                 presettle: false
-        CollectdAmqpInterval: 5
-        CollectdDefaultPollingInterval: 5
-        CollectdConnectionType: amqp1
-        CollectdDefaultPlugins:
-        - cpu
-        - df
-        - disk
-        - hugepages
-        - interface
-        - load
-        - memory
-        - processes
-        - unixsock
-        - uptime
-        - connectivity
-        - intel_rdt
-        - ipmi
-        - procevent
-        MetricsQdrAddresses:
-        -   distribution: multicast
-            prefix: collectd
-        -   distribution: multicast
-            prefix: anycast/ceilometer
         MetricsQdrConnectors:
         -   host: <<AMQP_HOST>>
             port: <<AMQP_PORT>>
@@ -62,16 +27,6 @@ custom_templates:
             verifyHostname: false
         MetricsQdrSSLProfiles:
         -   name: sslProfile
-        ExtraConfig:
-            ceilometer::agent::polling::polling_interval: 5
-            collectd::plugin::cpu::reportbycpu: true
-            collectd::plugin::cpu::reportbystate: true
-            collectd::plugin::cpu::reportnumcpu: false
-            collectd::plugin::cpu::valuespercentage: true
-            collectd::plugin::df::ignoreselected: true
-            collectd::plugin::df::reportbydevice: true
-            collectd::plugin::df::fstypes: ['xfs']
-            collectd::plugin::load::reportrelative: true
-            collectd::plugin::virt::connection: "qemu:///system"
-            collectd::plugin::virt::extra_stats: "cpu_util disk disk_err pcpu job_stats_background perf vcpupin"
-            collectd::plugin::virt::hostname_format: "hostname"
+            caCertFileContent: |
+                <<CA_CERT_FILE_CONTENT>>
+

--- a/tests/infrared/16/enable-stf.yaml.template
+++ b/tests/infrared/16/enable-stf.yaml.template
@@ -1,0 +1,78 @@
+# enable data collection that is compatible with the STF data model
+# enablement of the collectors and transport are done with separate enviroment files
+# recommended:
+# - environments/metrics/ceilometer-qdr-write.yaml
+# - environments/metrics/collectd-qdr-write.yaml
+# - environments/metrics/qdr-edge-only.yaml
+
+---
+tripleo_heat_templates:
+    []
+
+custom_templates:
+    # matches the documentation for enable-stf.yaml in stable-1.3 documentation
+    parameter_defaults:
+        # only send to STF, not other publishers
+        EventPipelinePublishers: []
+        PipelinePublishers: []
+
+        # manage the polling and pipeline configuration files for Ceilometer agents
+        ManagePolling: true
+        ManagePipeline: true
+
+        # required to set valid parameter due to typo in ceilometer-write-qdr.yaml
+        # and will be resolved in a future release
+        CeilometerQdrPublishMetrics: true
+
+        # enable collection of API status
+        CollectdEnableSensubility: true
+        CollectdSensubilityTransport: amqp1
+
+        # enable collection of containerized service metrics
+        CollectdEnableLibpodstats: true
+
+        # set collectd overrides for higher telemetry resolution and extra plugins
+        # to load
+        CollectdConnectionType: amqp1
+        CollectdAmqpInterval: 5
+        CollectdDefaultPollingInterval: 5
+        CollectdExtraPlugins:
+        - vmem
+
+        ExtraConfig:
+            ceilometer::agent::polling::polling_interval: 30
+            ceilometer::agent::polling::polling_meters:
+            - cpu
+            - disk.*
+            - ip.*
+            - image.*
+            - memory
+            - memory.*
+            - network.*
+            - perf.*
+            - port
+            - port.*
+            - switch
+            - switch.*
+            - storage.*
+            - volume.*
+
+            # to avoid filling the memory buffers if disconnected from the message bus
+            collectd::plugin::amqp1::send_queue_limit: 50
+
+            # receive extra information about virtual memory
+            collectd::plugin::vmem::verbose: true
+
+            # provide name and uuid in addition to hostname for better correlation
+            # to ceilometer data
+            collectd::plugin::virt::hostname_format: "name uuid hostname"
+
+            # provide the human-friendly name of the virtual instance
+            collectd::plugin::virt::plugin_instance_format: metadata
+
+            # set memcached collectd plugin to report its metrics by hostname
+            # rather than host IP, ensuring metrics in the dashboard remain uniform
+            collectd::plugin::memcached::instances:
+              local:
+                host: "%{hiera(fqdn_canonical)}"
+                port: 11211

--- a/tests/infrared/16/stf-connectors.yaml.template
+++ b/tests/infrared/16/stf-connectors.yaml.template
@@ -3,38 +3,26 @@ tripleo_heat_templates:
     []
 
 custom_templates:
-    resource_registry:
-        OS::TripleO::Services::CeilometerAgentCentral: /usr/share/openstack-tripleo-heat-templates/deployment/ceilometer/ceilometer-agent-central-container-puppet.yaml
-        OS::TripleO::Services::CeilometerAgentIpmi: /usr/share/openstack-tripleo-heat-templates/deployment/ceilometer/ceilometer-agent-ipmi-container-puppet.yaml
-        OS::TripleO::Services::CeilometerAgentNotification: /usr/share/openstack-tripleo-heat-templates/deployment/ceilometer/ceilometer-agent-notification-container-puppet.yaml
-        OS::TripleO::Services::Collectd: /usr/share/openstack-tripleo-heat-templates/deployment/metrics/collectd-container-puppet.yaml
-        OS::TripleO::Services::ComputeCeilometerAgent: /usr/share/openstack-tripleo-heat-templates/deployment/ceilometer/ceilometer-agent-compute-container-puppet.yaml
-        OS::TripleO::Services::MetricsQdr: /usr/share/openstack-tripleo-heat-templates/deployment/metrics/qdr-container-puppet.yaml
-        OS::TripleO::Services::Redis: /usr/share/openstack-tripleo-heat-templates/deployment/database/redis-pacemaker-puppet.yaml
-
+    # set parameter defaults to match stable-1.3 documentation
     parameter_defaults:
-        EnableSTF: true
+        MetricsQdrConnectors:
+            - host: <<AMQP_HOST>>
+              port: <<AMQP_PORT>>
+              role: edge
+              verifyHostname: false
+              sslProfile: sslProfile
 
-        EventPipelinePublishers: []
-        PipelinePublishers: []
-        ManagePolling: true
-        ManagePipeline: true
-        NotificationDriver: 'messagingv2'
-        CeilometerQdrPublishEvents: true
-        CeilometerQdrPublishMetrics: true
-        CeilometerEnablePanko: false
+        MetricsQdrSSLProfiles:
+            - name: sslProfile
+
         CeilometerQdrEventsConfig:
             driver: amqp
             topic: <<CLOUD_NAME>>-event
+
         CeilometerQdrMetricsConfig:
             driver: amqp
             topic: <<CLOUD_NAME>>-metering
 
-        CollectdEnableSensubility: true
-        CollectdEnableLibpodstats: true
-        CollectdSensubilityTransport: amqp1
-        CollectdSensubilityResultsChannel: collectd/<<CLOUD_NAME>>-notify
-        CollectdSensubilityLogLevel: DEBUG
         CollectdAmqpInstances:
             <<CLOUD_NAME>>-notify:
                 format: JSON
@@ -43,57 +31,16 @@ custom_templates:
             <<CLOUD_NAME>>-telemetry:
                 format: JSON
                 presettle: false
-        CollectdConnectionType: amqp1
-        CollectdAmqpInterval: 5
-        CollectdDefaultPollingInterval: 5
 
-        CollectdExtraPlugins:
-        - vmem
+        CollectdSensubilityResultsChannel: collectd/<<CLOUD_NAME>>-notify
 
-        MetricsQdrAddresses:
-        -   distribution: multicast
-            prefix: collectd
-        -   distribution: multicast
-            prefix: anycast/ceilometer
-
-        MetricsQdrSSLProfiles:
-        -   name: sslProfile
-
+        # --- below here, extended configuration for environment beyond what is documented in stable-1.3
+        CollectdSensubilityLogLevel: DEBUG
         CephStorageExtraConfig:
             tripleo::profile::base::metrics::collectd::amqp_host: "%{hiera('storage')}"
             tripleo::profile::base::metrics::qdr::listener_addr: "%{hiera('storage')}"
 
         ExtraConfig:
-            ceilometer::agent::polling::polling_interval: 5
-            ceilometer::agent::polling::polling_meters:
-            - cpu
-            - disk.*
-            - ip.*
-            - image.*
-            - memory
-            - memory.*
-            - network.*
-            - perf.*
-            - port
-            - port.*
-            - switch
-            - switch.*
-            - storage.*
-            - volume.*
-
-            collectd::plugin::memcached::instances:
-              local:
-                host: "%{hiera('fqdn_canonical')}"
-                port: 11211
-
-            collectd::plugin::cpu::reportbycpu: true
-            collectd::plugin::cpu::reportbystate: true
-            collectd::plugin::cpu::valuespercentage: true
-            collectd::plugin::vmem::verbose: true
-            collectd::plugin::amqp1::send_queue_limit: 50
-            collectd::plugin::virt::hostname_format: "name uuid hostname"
-            collectd::plugin::virt::plugin_instance_format: metadata
-            collectd::plugin::virt::extra_stats: "cpu_util disk vcpu memory domain_state perf"
             collectd::plugin::ceph::daemons:
                - ceph-osd.0
                - ceph-osd.1
@@ -110,10 +57,3 @@ custom_templates:
                - ceph-osd.12
                - ceph-osd.13
                - ceph-osd.14
-
-        MetricsQdrConnectors:
-            - host: <<AMQP_HOST>>
-              port: <<AMQP_PORT>>
-              role: edge
-              verifyHostname: false
-              sslProfile: sslProfile


### PR DESCRIPTION
* Break out common configuration to enable-stf.yaml

* Make controller and compute resources configurable
* Align to documentation

* Create enable-stf template

* Actually create the enable-stf.yaml for deployment

* Allow deployment of caCertFileConfig for OSP13

* Sync default collectd plugins across OSP versions

* Indent fix

Cherry picked from commit cc54e3fe847ee7335db040df16fd07b0ab620d1c
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
