### PR TITLE
Add port 5672 back to listeners for Interconnect

### DIFF
--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -43,6 +43,7 @@
             saslMechanisms: EXTERNAL
             sslProfile: inter-router
         listeners:
+          - port: 5672
           - expose: {{ servicetelemetry_vars.transports.qdr.web.enabled }}
             http: true
             port: 8672


### PR DESCRIPTION
Without port 5672 in the listeners it is not possible to use qdstat for debug
and verification of Interconnect deployments.

Resolves: rhbz#1976981
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
