### PR TITLE
[backport stable-1.3] Add port 5672 back to listeners for Interconnect

### DIFF
--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -43,6 +43,7 @@
             saslMechanisms: EXTERNAL
             sslProfile: inter-router
         listeners:
+          - port: 5672
           - expose: {{ servicetelemetry_vars.transports.qdr.web.enabled }}
             http: true
             port: 8672


### PR DESCRIPTION
Without port 5672 in the listeners it is not possible to use qdstat for debug
and verification of Interconnect deployments.

Cherry picked from commit 15c63f97ca40b54df0d181190d2c47c5e9aaf1d1

Resolves: rhbz#1976981
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
