### PR TITLE
Bump OCP installable version to include v4.7 (#219)

### DIFF
--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -36,7 +36,7 @@
         namespace: openshift-marketplace
       spec:
         displayName: Red Hat STF Operators
-        image: quay.io/redhat-operators-stf/stf-catalog:v4.6
+        image: quay.io/redhat-operators-stf/stf-catalog:stable
         publisher: Red Hat
         sourceType: grpc
         updateStrategy:

--- a/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
+++ b/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.5-v4.6"
+LABEL com.redhat.openshift.versions="v4.6-v4.7"
 LABEL com.redhat.delivery.backport=true
 
 LABEL com.redhat.component="service-telemetry-operator-bundle-container" \

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -530,7 +530,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat
   maturity: beta
-  minKubeVersion: 1.18.0
+  minKubeVersion: 1.19.0
   provider:
     name: Red Hat
   version: 1.99.0


### PR DESCRIPTION
* Bump OCP installable version to include v4.7

Bump bundle so that OCP 4.6 and 4.7 are available for STF installation.

Resolves: rhbz#1975792

* Use new amq-interconnect stable tag

Cherry picked from commit 53201c2163c22fc05239b7e62ef72d63435048f4
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
