### PR TITLE
Deploy a sensubility smartgateway

### DIFF
--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -73,7 +73,7 @@ servicetelemetry_defaults:
             subscription_address: anycast/ceilometer/metering.sample
             debug_enabled: false
           - collector_type: sensubility
-            subscription_address: sensubility/metrics
+            subscription_address: sensubility/telemetry
             debug_enabled: false
       events:
         collectors:

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -72,6 +72,9 @@ servicetelemetry_defaults:
           - collector_type: ceilometer
             subscription_address: anycast/ceilometer/metering.sample
             debug_enabled: false
+          - collector_type: sensubility
+            subscription_address: sensubility/metrics
+            debug_enabled: false
       events:
         collectors:
           - collector_type: collectd


### PR DESCRIPTION
A sensubility smartgateway is configured to listen to container health events from sensubility at a separate QDR  address from all other smartgateways and store the results as metrics into Prometheus. Resolves: rhbz#1956912

Depends-on: https://github.com/infrawatch/sg-core/pull/60