### PR TITLE
Adjust bundle Dockerfile to build for a bundle

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
+++ b/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
@@ -12,9 +12,9 @@ LABEL operators.operatorframework.io.bundle.channel.default.v1=<<BUNDLE_DEFAULT_
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
-LABEL com.redhat.delivery.operator.bundle=false
+LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.openshift.versions="v4.6-v4.7"
-LABEL com.redhat.delivery.backport=true
+LABEL com.redhat.delivery.backport=false
 
 LABEL com.redhat.component="service-telemetry-operator-bundle-container" \
       name="stf/service-telemetry-operator-bundle" \


### PR DESCRIPTION
Previously a change was mistakenly made to the wrong LABEL line which set the bundle
LABEL to false when the backport LABEL should have been set to false. Fixing the
Dockerfile.in for the bundle creation to disable the backport, but setting the build
to know this is a bundle image.

Invalid change was merged in 08a2ab5fb22a517ec7d07fac15206ee3cff92236
and this fixes that error.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
