### PR TITLE
Enable Ceilometer events

### DIFF
--- a/tests/infrared/16/enable-stf.yaml.template
+++ b/tests/infrared/16/enable-stf.yaml.template
@@ -20,9 +20,9 @@ custom_templates:
         ManagePolling: true
         ManagePipeline: true
 
-        # required to set valid parameter due to typo in ceilometer-write-qdr.yaml
-        # and will be resolved in a future release
+        # enable Ceilometer metrics and events
         CeilometerQdrPublishMetrics: true
+        CeilometerQdrPublishEvents: true
 
         # enable collection of API status
         CollectdEnableSensubility: true


### PR DESCRIPTION
The upstream ceilometer-write-qdr for Train is not in sync with the contents
deployed downstream for ceilometer-write-qdr.yaml. The upstream implements the
Publish parameters, but the current 16.1 deployment does not provide those.
Added appropriate configuration required for RHOSP16.1.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>