### PR TITLE
Fix syntax for fqdn_canonical hiera path

### DIFF
--- a/tests/infrared/16/enable-stf.yaml.template
+++ b/tests/infrared/16/enable-stf.yaml.template
@@ -81,5 +81,5 @@ custom_templates:
             # rather than host IP, ensuring metrics in the dashboard remain uniform
             collectd::plugin::memcached::instances:
               local:
-                host: "%{hiera(fqdn_canonical)}"
+                host: "%{hiera('fqdn_canonical')}"
                 port: 11211


### PR DESCRIPTION
Cherry picked from commit dc42acecc74b236ab997263e3bd19f15de3b4e58
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
