### PR TITLE
Add Loki-operator to STO

### DIFF
--- a/build/create_standard_pvs.sh
+++ b/build/create_standard_pvs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Create the standard storage class
+if ! oc describe sc standard; then
+	oc create -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard
+provisioner: kubernetes.io/no-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+EOF
+fi
+
+# Check how many PVs we need to patch
+AVAILABLE_STANDARD_PVS=`oc get pv | grep standard | grep Available | wc -l`
+REQUIRED_NEW_STANDARD_PVS=`expr $1 - $AVAILABLE_STANDARD_PVS`
+
+for (( i=0; i<$REQUIRED_NEW_STANDARD_PVS; i++ ))
+do
+	PV=`oc get pv | grep -v standard | grep Available -m 1 | awk '{print $1}'`
+	oc patch pv $PV -p '{"spec":{"storageClassName":"standard"}}'
+done

--- a/build/get_new_operator_sdk.sh
+++ b/build/get_new_operator_sdk.sh
@@ -3,7 +3,7 @@
 REL=$(dirname "$0")
 ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
 OS=$(uname | awk '{print tolower($0)}')
-VERSION="$1"
+VERSION="${1:-v1.5.0}"
 OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${VERSION}
 
 if [[ ! -f ${REL}/working/operator-sdk-${VERSION} ]]; then

--- a/build/get_new_operator_sdk.sh
+++ b/build/get_new_operator_sdk.sh
@@ -3,10 +3,11 @@
 REL=$(dirname "$0")
 ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
 OS=$(uname | awk '{print tolower($0)}')
-OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.5.0
+VERSION="$1"
+OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${VERSION}
 
-if [[ ! -f ${REL}/working/operator-sdk-v1.5.0 ]]; then
-	curl -L ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} -o ${REL}/working/operator-sdk-v1.5.0
-	chmod +x ${REL}/working/operator-sdk-v1.5.0
+if [[ ! -f ${REL}/working/operator-sdk-${VERSION} ]]; then
+	curl -L ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} -o ${REL}/working/operator-sdk-${VERSION}
+	chmod +x ${REL}/working/operator-sdk-${VERSION}
 fi
 

--- a/build/get_new_operator_sdk.sh
+++ b/build/get_new_operator_sdk.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+REL=$(dirname "$0")
+ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+OS=$(uname | awk '{print tolower($0)}')
+OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.5.0
+
+if [[ ! -f ${REL}/working/operator-sdk-v1.5.0 ]]; then
+	curl -L ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} -o ${REL}/working/operator-sdk-v1.5.0
+	chmod +x ${REL}/working/operator-sdk-v1.5.0
+fi
+

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -32,10 +32,10 @@ choose to override:
 | `__service_telemetry_metrics_enabled`           | {true,false}    | true                                             | Whether to enable metrics support in ServiceTelemetry                                                 |
 | `__service_telemetry_storage_ephemeral_enabled` | {true,false}    | false                                            | Whether to enable ephemeral storage support in ServiceTelemetry                                       |
 | `__service_telemetry_snmptraps_enabled`         | {true,false}    | true                                             | Whether to enable snmptraps delivery via Alertmanager receiver (prometheus-webhook-snmp)              |
-| `__service_telemetry_logs_enabled`              | {true,false}    | false     |                                      | Whether to enable logs support in ServiceTelemetry
+| `__service_telemetry_logs_enabled`              | {true,false}    | false                                            | Whether to enable logs support in ServiceTelemetry                                                    |
 | `__internal_registry_path`                      | <registry_path> | image-registry.openshift-image-registry.svc:5000 | Path to internal registry for image path                                                              |
-| `__deploy_minio_enabled`                        | {true,false}    | false     |                                      | Whether to deploy minio while deploying loki-operator for logging development purposes
-| `__loki_skip_tls_verify`                        | {true,false}    | false     |                                      | Whether to skip tls verify for Loki S3 connection
+| `__deploy_minio_enabled`                        | {true,false}    | false                                            | Whether to deploy minio while deploying loki-operator for logging development purposes                |
+| `__loki_skip_tls_verify`                        | {true,false}    | false                                            | Whether to skip tls verify for Loki S3 connection                                                     |
 
 
 Example Playbook

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -32,7 +32,10 @@ choose to override:
 | `__service_telemetry_metrics_enabled`           | {true,false}    | true                                             | Whether to enable metrics support in ServiceTelemetry                                                 |
 | `__service_telemetry_storage_ephemeral_enabled` | {true,false}    | false                                            | Whether to enable ephemeral storage support in ServiceTelemetry                                       |
 | `__service_telemetry_snmptraps_enabled`         | {true,false}    | true                                             | Whether to enable snmptraps delivery via Alertmanager receiver (prometheus-webhook-snmp)              |
+| `__service_telemetry_logs_enabled`              | {true,false}    | false     |                                      | Whether to enable logs support in ServiceTelemetry
 | `__internal_registry_path`                      | <registry_path> | image-registry.openshift-image-registry.svc:5000 | Path to internal registry for image path                                                              |
+| `__deploy_minio_enabled`                        | {true,false}    | false     |                                      | Whether to deploy minio while deploying loki-operator for logging development purposes
+| `__loki_skip_tls_verify`                        | {true,false}    | false     |                                      | Whether to skip tls verify for Loki S3 connection
 
 
 Example Playbook

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -35,7 +35,7 @@ choose to override:
 | `__service_telemetry_logs_enabled`              | {true,false}    | false                                            | Whether to enable logs support in ServiceTelemetry                                                    |
 | `__internal_registry_path`                      | <registry_path> | image-registry.openshift-image-registry.svc:5000 | Path to internal registry for image path                                                              |
 | `__deploy_minio_enabled`                        | {true,false}    | false                                            | Whether to deploy minio while deploying loki-operator for logging development purposes                |
-| `__loki_skip_tls_verify`                        | {true,false}    | false                                            | Whether to skip tls verify for Loki S3 connection                                                     |
+| `__loki_skip_tls_verify`                        | {true,false}    | false                                            | Whether to skip TLS verify for Loki S3 connection                                                     |
 
 
 Example Playbook

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -13,11 +13,16 @@ __service_telemetry_high_availability_enabled: false
 __service_telemetry_metrics_enabled: true
 __service_telemetry_storage_ephemeral_enabled: false
 __service_telemetry_snmptraps_enabled: true
+__service_telemetry_logs_enabled: false
 __internal_registry_path: image-registry.openshift-image-registry.svc:5000
+
+__deploy_minio_enabled: false
+__loki_skip_tls_verify: false
 
 sgo_image_tag: latest
 sto_image_tag: latest
 sg_core_image_tag: latest
 sg_bridge_image_tag: latest
 prometheus_webhook_snmp_image_tag: latest
+loki_operator_image_tag: latest
 namespace: service-telemetry

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -25,4 +25,5 @@ sg_core_image_tag: latest
 sg_bridge_image_tag: latest
 prometheus_webhook_snmp_image_tag: latest
 loki_operator_image_tag: latest
+new_operator_sdk_version: v1.5.0
 namespace: service-telemetry

--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -58,3 +58,17 @@
         repo: https://github.com/infrawatch/prometheus-webhook-snmp
         dest: working/prometheus-webhook-snmp
         version: master
+
+- name: Get Loki Operator
+  block:
+    - name: Try cloning same-named branch or override branch
+      git:
+        repo: https://github.com/viaq/loki-operator
+        dest: working/loki-operator
+        version: "{{ loki_operator_branch | default(branch, true) }}"
+  rescue:
+    - name: Get master branch because same-named doesn't exist
+      git:
+        repo: https://github.com/viaq/loki-operator
+        dest: working/loki-operator
+        version: master

--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -59,6 +59,9 @@
         dest: working/prometheus-webhook-snmp
         version: master
 
+# Branches for Loki Operator don't work the same as with other repositories.
+# We don't have write access to the upstream repository to create our own
+# branches there.
 - name: Get Loki Operator
   block:
     - name: Try cloning same-named branch or override branch

--- a/build/stf-run-ci/tasks/deploy_stf.yml
+++ b/build/stf-run-ci/tasks/deploy_stf.yml
@@ -27,6 +27,14 @@
               enabled: {{ __service_telemetry_metrics_enabled }}
               storage:
                 strategy: {{ "ephemeral" if __service_telemetry_storage_ephemeral_enabled else "persistent" }}
+          logs:
+            loki:
+              enabled: {{ __service_telemetry_logs_enabled }}
+              replicationFactor: 1
+              size: 1x.extra-small
+              storage:
+                objectStorageSecret: test
+                storageClass: standard
         highAvailability:
           enabled: {{ __service_telemetry_high_availability_enabled }}
   when: service_telemetry_manifest is not defined

--- a/build/stf-run-ci/tasks/deploy_stf.yml
+++ b/build/stf-run-ci/tasks/deploy_stf.yml
@@ -31,7 +31,7 @@
             loki:
               enabled: {{ __service_telemetry_logs_enabled }}
               replicationFactor: 1
-              size: 1x.extra-small
+              flavor: 1x.extra-small
               storage:
                 objectStorageSecret: test
                 storageClass: standard

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -41,7 +41,7 @@
       - clone
 
   - name: Get new operator sdk
-    command: ./get_new_operator_sdk.sh
+    command: ./get_new_operator_sdk.sh "{{ new_operator_sdk_version }}"
 
   - name: Setup supporting Operator subscriptions
     include_tasks: setup_base.yml

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -48,7 +48,7 @@
     tags:
       - deploy
 
-    # TLS verifycation support doesn't seem to be implemented in the operator yet
+    # TLS verification support doesn't seem to be implemented in the operator yet
   - block:
     - name: Prepare for skip Loki TLS patch
       replace:
@@ -58,7 +58,7 @@
 \ \ \ \ \ insecure_skip_verify: true"
         replace: ""
 
-    - name: Skip Loki TLS veryfication
+    - name: Skip Loki TLS verification
       replace:
         path: "{{ playbook_dir }}/working/loki-operator/internal/manifests/internal/config/loki-config.yaml"
         regexp: "\ \ \ \ s3forcepathstyle: true"

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -50,7 +50,7 @@
 
     # TLS verifycation support doesn't seem to be implemented in the operator yet
   - block:
-    - name: Prepare for skip Loki tls patch
+    - name: Prepare for skip Loki TLS patch
       replace:
         path: "{{ playbook_dir }}/working/loki-operator/internal/manifests/internal/config/loki-config.yaml"
         regexp: "\ \ \ \ insecure: false\n
@@ -58,7 +58,7 @@
 \ \ \ \ \ insecure_skip_verify: true"
         replace: ""
 
-    - name: Skip Loki tls veryfication
+    - name: Skip Loki TLS veryfication
       replace:
         path: "{{ playbook_dir }}/working/loki-operator/internal/manifests/internal/config/loki-config.yaml"
         regexp: "\ \ \ \ s3forcepathstyle: true"

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -20,8 +20,14 @@
     nodes: "{{ lookup('k8s', kind='nodes') }}"
 
 - name: Find out if we are using crc
-  set_fact:
-    is_crc: "{{ True if 'crc' in nodes[0].metadata.labels[\"kubernetes.io/hostname\"] else False }}"
+  block:
+    - name: Try finding out for cluster with more than 1 node
+      set_fact:
+        is_crc: "{{ True if 'crc' in nodes[0].metadata.labels[\"kubernetes.io/hostname\"] else False }}"
+  rescue:
+    - name: Try finding out for cluster with only 1 node
+      set_fact:
+        is_crc: "{{ True if 'crc' in nodes.metadata.labels[\"kubernetes.io/hostname\"] else False }}"
 
 - name: Clear out existing CRDs so we don't conflict or fail merge
   k8s:

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -12,6 +12,16 @@
     sg_core_image_path: "{{ __internal_registry_path }}/{{ namespace }}/sg-core:{{ sg_core_image_tag }}"
     sg_bridge_image_path: "{{ __internal_registry_path }}/{{ namespace }}/sg-bridge:{{ sg_bridge_image_tag }}"
     prometheus_webhook_snmp_image_path: "{{ __internal_registry_path }}/{{ namespace }}/prometheus-webhook-snmp:{{ prometheus_webhook_snmp_image_tag }}"
+    loki_operator_image_path: "{{ __internal_registry_path }}/{{ namespace }}/loki-operator:{{ loki_operator_image_tag }}"
+    loki_operator_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/loki-operator-bundle:{{ loki_operator_image_tag }}"
+
+- name: Get the node hostnames
+  set_fact:
+    nodes: "{{ lookup('k8s', kind='nodes') }}"
+
+- name: Find out if we are using crc
+  set_fact:
+    is_crc: "{{ True if 'crc' in nodes[0].metadata.labels[\"kubernetes.io/hostname\"] else False }}"
 
 - name: Clear out existing CRDs so we don't conflict or fail merge
   k8s:
@@ -22,6 +32,7 @@
   loop:
     - smartgateways.smartgateway.infra.watch
     - servicetelemetrys.infra.watch
+    - lokistacks.loki.openshift.io
 
 - block:
   - name: Setup supporting repositories
@@ -29,10 +40,35 @@
     tags:
       - clone
 
+  - name: Get new operator sdk
+    command: ./get_new_operator_sdk.sh
+
   - name: Setup supporting Operator subscriptions
     include_tasks: setup_base.yml
     tags:
       - deploy
+
+    # TLS verifycation support doesn't seem to be implemented in the operator yet
+  - block:
+    - name: Prepare for skip Loki tls patch
+      replace:
+        path: "{{ playbook_dir }}/working/loki-operator/internal/manifests/internal/config/loki-config.yaml"
+        regexp: "\ \ \ \ insecure: false\n
+\ \ \ http_config:\n
+\ \ \ \ \ insecure_skip_verify: true"
+        replace: ""
+
+    - name: Skip Loki tls veryfication
+      replace:
+        path: "{{ playbook_dir }}/working/loki-operator/internal/manifests/internal/config/loki-config.yaml"
+        regexp: "\ \ \ \ s3forcepathstyle: true"
+        replace: "\ \ \ \ s3forcepathstyle: true\n
+\ \ \ insecure: false\n
+\ \ \ http_config:\n
+\ \ \ \ \ insecure_skip_verify: true"
+    when:
+    - __loki_skip_tls_verify | bool
+
 
   - name: Create builds and artifacts
     include_tasks: create_builds.yml
@@ -42,6 +78,8 @@
       - { name: sg-core, dockerfile_path: build/Dockerfile, image_reference_name: sg_core_image_path, working_build_dir: ./working/sg-core }
       - { name: sg-bridge, dockerfile_path: build/Dockerfile, image_reference_name: sg_bridge_image_path, working_build_dir: ./working/sg-bridge }
       - { name: prometheus-webhook-snmp, dockerfile_path: Dockerfile, image_reference_name: prometheus_webhook_snmp_image_path, working_build_dir: ./working/prometheus-webhook-snmp }
+      - { name: loki-operator-bundle, dockerfile_path: bundle.Dockerfile, image_reference_name: loki_operator_bundle_image_path, working_build_dir: ./working/loki-operator }
+      - { name: loki-operator, dockerfile_path: Dockerfile, image_reference_name: loki_operator_image_path, working_build_dir: ./working/loki-operator }
     loop_control:
       loop_var: artifact
     tags:

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -130,7 +130,7 @@
   replace:
     path: "{{ playbook_dir }}/working/loki-operator/config/overlays/development/minio/secret.yaml"
     regexp: 'default'
-    replace: 'service-telemetry'
+    replace: '{{ namespace }}'
 
 - block:
   - name: Remove minio deployment

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -90,7 +90,7 @@
     target: bundle
     params:
         REGISTRY_ORG: infrawatch
-        OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-v1.5.0"
+        OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
 
 - name: Replace namespace in loki-operator CSV
   replace:
@@ -146,7 +146,7 @@
     target: deploy
     params:
         REGISTRY_ORG: infrawatch
-        OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-v1.5.0"
+        OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
 
 - name: Load Loki Operator bundle manifests
   command: oc apply -f working/loki-operator/bundle/manifests/{{ item }} -n "{{ namespace }}"

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -64,3 +64,97 @@
 
 - name: Load Service Telemetry Operator CSV
   shell: oc apply -f working/service-telemetry-operator-bundle/manifests/service-telemetry-operator.clusterserviceversion.yaml -n "{{ namespace }}"
+
+# --- Loki Operator ---
+- name: Prevent Loki Operator from building operator-sdk
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/.bingo/Variables.mk"
+    regexp: '^.*modfile=operator-sdk.mod.*$'
+    replace: ''
+
+- name: Prevent Loki Operator from putting authentication on /metrics
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/config/overlays/openshift/kustomization.yaml"
+    regexp: '{{ item }}'
+    replace: ''
+  loop:
+    - "patchesStrategicMerge:"
+    - "- manager_auth_proxy_patch.yaml"
+    - "- manager_related_image_patch.yaml"
+    - "- manager_run_flags_patch.yaml"
+    - "- prometheus_service_monitor_patch.yaml"
+
+- name: Generate Loki Operator CSV
+  make:
+    chdir: "{{ playbook_dir }}/working/loki-operator"
+    target: bundle
+    params:
+        REGISTRY_ORG: infrawatch
+        OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-v1.5.0"
+
+- name: Replace namespace in loki-operator CSV
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/bundle/manifests/loki-operator.clusterserviceversion.yaml"
+    regexp: 'placeholder'
+    replace: '{{ namespace }}'
+
+- name: Replace image path in loki-operator CSV
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/bundle/manifests/loki-operator.clusterserviceversion.yaml"
+    regexp: '{{ item }}'
+    replace: '{{ loki_operator_image_path }}'
+  loop:
+    - quay.io/infrawatch/loki-operator:v0.0.1
+    - quay.io/openshift-logging/loki-operator:v0.0.1
+
+- name: Replace namespace in loki-operator
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/config/overlays/development/kustomization.yaml"
+    regexp: 'default'
+    replace: '{{ namespace }}'
+
+- name: Remove additional manager deployment
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/config/overlays/development/kustomization.yaml"
+    regexp: '^.*manager'
+    replace: ''
+
+- name: Setup PVs for Loki in crc
+  shell:
+    cmd: ./create_standard_pvs.sh 3
+  when:
+  - is_crc | bool
+  - __service_telemetry_logs_enabled | bool
+
+- name: Replace namespace in S3 secret
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/config/overlays/development/minio/secret.yaml"
+    regexp: 'default'
+    replace: 'service-telemetry'
+
+- block:
+  - name: Remove minio deployment
+    replace:
+      path: "{{ playbook_dir }}/working/loki-operator/config/overlays/development/kustomization.yaml"
+      regexp: '^.*minio'
+      replace: ''
+  when: not __deploy_minio_enabled | bool
+
+- name: Deploy Loki Operator
+  make:
+    chdir: "{{ playbook_dir }}/working/loki-operator"
+    target: deploy
+    params:
+        REGISTRY_ORG: infrawatch
+        OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-v1.5.0"
+
+- name: Load Loki Operator bundle manifests
+  command: oc apply -f working/loki-operator/bundle/manifests/{{ item }} -n "{{ namespace }}"
+  loop:
+  - loki.openshift.io_lokistacks.yaml
+  - loki-operator-controller-manager-metrics-service_v1_service.yaml
+  - loki-operator-manager-config_v1_configmap.yaml
+  - loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+  - loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+  - loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+  - loki-operator.clusterserviceversion.yaml

--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -159,7 +159,7 @@ spec:
                   description: Logs storage backend Loki
                   properties:
                     enabled:
-                      description: Enable Loki as a storage backend for logs
+                      description: ---TESTING ONLY--- Enable Loki as a storage backend for logs
                       type: boolean
                     replicationFactor:
                       description: Loki replication factor

--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -152,6 +152,72 @@ spec:
                       type: object
                   type: object
               type: object
+            logs:
+              description: Logs related backend configuration.
+              properties:
+                loki:
+                  description: Logs storage backend Loki
+                  properties:
+                    enabled:
+                      description: Enable Loki as a storage backend for logs
+                      type: boolean
+                    replicationFactor:
+                      description: Loki replication factor
+                      type: string
+                    flavor:
+                      description: Loki flavor
+                      enum:
+                      - 1x.extra-small
+                      - 1x.small
+                      - 1x.medium
+                      type: string
+                    storage:
+                      description: Logs storage configuration for Loki
+                      properties:
+                        objectStorageSecret:
+                          description: Secret containing informaiton required for S3 object storage
+                          type: string
+                        storageClass:
+                          description: Storage class used for temporary log storage before they are forwarded to object storage or when querying.
+                          type: string
+                      type: object
+                    compactor:
+                      description: Template for the compactor microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    distributor:
+                      description: Template for the distributor microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    ingester:
+                      description: Template for the ingester microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    querier:
+                      description: Template for the querier microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    queryFrontend:
+                      description: Template for the query frontend microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                  type: object
+              type: object
           type: object
         transports:
           description: Data transport configuration
@@ -242,6 +308,29 @@ spec:
                         debugEnabled:
                           description: Enable console debugging. Default is 'false'.
                           type: boolean
+                      type: object
+                    type: array
+                type: object
+              logs:
+                description: Logs related configuration for this cloud object.
+                properties:
+                  collectors:
+                    description: List of available logs collectors for this cloud
+                      object.
+                    items:
+                      properties:
+                        collectorType:
+                          description: Set the collector type, value of 'rsyslog'
+                          enum:
+                          - rsyslog
+                          type: string
+                        debugEnabled:
+                          description: Enable console debugging. Default is 'false'.
+                          type: boolean
+                        subscriptionAddress:
+                          description: Address to subscribe on the data transport
+                            to receive notifications.
+                          type: string
                       type: object
                     type: array
                 type: object

--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -34,6 +34,15 @@ spec:
           persistent:
             storageSelector: {}
             pvcStorageRequest: 20Gi
+
+    logs:
+      loki:
+        enabled: false
+        flavor: 1.extra-small
+        replicationFactor: 1
+        storage:
+          objectStorageSecret: test
+          storageClass: standard
   graphing:
     enabled: false
     grafana:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -161,8 +161,8 @@ spec:
                     replicationFactor:
                       description: Loki replication factor
                       type: string
-                    size:
-                      description: Loki size
+                    flavor:
+                      description: Loki flavor
                       enum:
                       - 1x.extra-small
                       - 1x.small
@@ -208,13 +208,6 @@ spec:
                       type: object
                     queryFrontend:
                       description: Template for the query frontend microservice
-                      properties:
-                        replicas:
-                          description: Number of replicas for this microservice
-                          type: string
-                      type: object
-                    compactor:
-                      description: Template for the compactor microservice
                       properties:
                         replicas:
                           description: Number of replicas for this microservice

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -149,6 +149,79 @@ spec:
                       type: object
                   type: object
               type: object
+            logs:
+              description: Logs related backend configuration.
+              properties:
+                loki:
+                  description: Logs storage backend Loki
+                  properties:
+                    enabled:
+                      description: Enable Loki as a storage backend for logs
+                      type: boolean
+                    replicationFactor:
+                      description: Loki replication factor
+                      type: string
+                    size:
+                      description: Loki size
+                      enum:
+                      - 1x.extra-small
+                      - 1x.small
+                      - 1x.medium
+                      type: string
+                    storage:
+                      description: Logs storage configuration for Loki
+                      properties:
+                        objectStorageSecret:
+                          description: Secret containing informaiton required for S3 object storage
+                          type: string
+                        storageClassName:
+                          description: Storage class used for temporary log storage before they are forwarded to object storage or when querying.
+                          type: string
+                      type: object
+                    compactor:
+                      description: Template for the compactor microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    distributor:
+                      description: Template for the distributor microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    ingester:
+                      description: Template for the ingester microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    querier:
+                      description: Template for the querier microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    queryFrontend:
+                      description: Template for the query frontend microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    compactor:
+                      description: Template for the compactor microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                  type: object
+              type: object
           type: object
         clouds:
           description: A list of cloud objects
@@ -197,6 +270,29 @@ spec:
                         subscriptionAddress:
                           description: Address to subscribe on the data transport
                             to receive telemetry.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              logs:
+                description: Logs related configuration for this cloud object.
+                properties:
+                  collectors:
+                    description: List of available logs collectors for this cloud
+                      object.
+                    items:
+                      properties:
+                        collectorType:
+                          description: Set the collector type, value of 'rsyslog'
+                          enum:
+                          - rsyslog
+                          type: string
+                        debugEnabled:
+                          description: Enable console debugging. Default is 'false'.
+                          type: boolean
+                        subscriptionAddress:
+                          description: Address to subscribe on the data transport
+                            to receive notifications.
                           type: string
                       type: object
                     type: array

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -102,6 +102,75 @@ spec:
                       type: object
                   type: object
               type: object
+            logs:
+              description: Logs related backend configuration.
+              properties:
+                loki:
+                  description: Logs storage backend Loki
+                  properties:
+                    compactor:
+                      description: Template for the compactor microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    distributor:
+                      description: Template for the distributor microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    enabled:
+                      description: '---TESTING ONLY--- Enable Loki as a storage backend
+                        for logs'
+                      type: boolean
+                    flavor:
+                      description: Loki flavor
+                      enum:
+                      - 1x.extra-small
+                      - 1x.small
+                      - 1x.medium
+                      type: string
+                    ingester:
+                      description: Template for the ingester microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    querier:
+                      description: Template for the querier microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    queryFrontend:
+                      description: Template for the query frontend microservice
+                      properties:
+                        replicas:
+                          description: Number of replicas for this microservice
+                          type: string
+                      type: object
+                    replicationFactor:
+                      description: Loki replication factor
+                      type: string
+                    storage:
+                      description: Logs storage configuration for Loki
+                      properties:
+                        objectStorageSecret:
+                          description: Secret containing informaiton required for
+                            S3 object storage
+                          type: string
+                        storageClass:
+                          description: Storage class used for temporary log storage
+                            before they are forwarded to object storage or when querying.
+                          type: string
+                      type: object
+                  type: object
+              type: object
             metrics:
               description: Metrics related backend configuration.
               properties:
@@ -149,72 +218,6 @@ spec:
                       type: object
                   type: object
               type: object
-            logs:
-              description: Logs related backend configuration.
-              properties:
-                loki:
-                  description: Logs storage backend Loki
-                  properties:
-                    enabled:
-                      description: Enable Loki as a storage backend for logs
-                      type: boolean
-                    replicationFactor:
-                      description: Loki replication factor
-                      type: string
-                    flavor:
-                      description: Loki flavor
-                      enum:
-                      - 1x.extra-small
-                      - 1x.small
-                      - 1x.medium
-                      type: string
-                    storage:
-                      description: Logs storage configuration for Loki
-                      properties:
-                        objectStorageSecret:
-                          description: Secret containing informaiton required for S3 object storage
-                          type: string
-                        storageClass:
-                          description: Storage class used for temporary log storage before they are forwarded to object storage or when querying.
-                          type: string
-                      type: object
-                    compactor:
-                      description: Template for the compactor microservice
-                      properties:
-                        replicas:
-                          description: Number of replicas for this microservice
-                          type: string
-                      type: object
-                    distributor:
-                      description: Template for the distributor microservice
-                      properties:
-                        replicas:
-                          description: Number of replicas for this microservice
-                          type: string
-                      type: object
-                    ingester:
-                      description: Template for the ingester microservice
-                      properties:
-                        replicas:
-                          description: Number of replicas for this microservice
-                          type: string
-                      type: object
-                    querier:
-                      description: Template for the querier microservice
-                      properties:
-                        replicas:
-                          description: Number of replicas for this microservice
-                          type: string
-                      type: object
-                    queryFrontend:
-                      description: Template for the query frontend microservice
-                      properties:
-                        replicas:
-                          description: Number of replicas for this microservice
-                          type: string
-                      type: object
-                  type: object
-              type: object
           type: object
         clouds:
           description: A list of cloud objects
@@ -245,28 +248,6 @@ spec:
                       type: object
                     type: array
                 type: object
-              metrics:
-                description: Metrics related configuration for this cloud object.
-                properties:
-                  collectors:
-                    description: List of available metrics collectors for this cloud
-                      object
-                    items:
-                      properties:
-                        collectorType:
-                          description: Set the collector type, value of 'ceilometer'
-                            or 'collectd'.
-                          type: string
-                        debugEnabled:
-                          description: Enable console debugging. Default is 'false'.
-                          type: boolean
-                        subscriptionAddress:
-                          description: Address to subscribe on the data transport
-                            to receive telemetry.
-                          type: string
-                      type: object
-                    type: array
-                type: object
               logs:
                 description: Logs related configuration for this cloud object.
                 properties:
@@ -286,6 +267,28 @@ spec:
                         subscriptionAddress:
                           description: Address to subscribe on the data transport
                             to receive notifications.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              metrics:
+                description: Metrics related configuration for this cloud object.
+                properties:
+                  collectors:
+                    description: List of available metrics collectors for this cloud
+                      object
+                    items:
+                      properties:
+                        collectorType:
+                          description: Set the collector type, value of 'ceilometer'
+                            or 'collectd'.
+                          type: string
+                        debugEnabled:
+                          description: Enable console debugging. Default is 'false'.
+                          type: boolean
+                        subscriptionAddress:
+                          description: Address to subscribe on the data transport
+                            to receive telemetry.
                           type: string
                       type: object
                     type: array

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -174,7 +174,7 @@ spec:
                         objectStorageSecret:
                           description: Secret containing informaiton required for S3 object storage
                           type: string
-                        storageClassName:
+                        storageClass:
                           description: Storage class used for temporary log storage before they are forwarded to object storage or when querying.
                           type: string
                       type: object

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
                   "replicationFactor": 1,
                   "storage": {
                     "objectStorageSecret": "test",
-                    "storageClassName": "standard"
+                    "storageClass": "standard"
                     }
                   }
                 }
@@ -401,7 +401,7 @@ spec:
         - urn:alm:descriptor:io.kubernetes:Secret
       - description: Storage class configuration for Loki persistent storage
         displayName: Loki storage class
-        path: backends.logs.loki.storage.storageClassName
+        path: backends.logs.loki.storage.storageClass
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
         - urn:alm:descriptor:io.kubernetes:StorageClass

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -42,6 +42,17 @@ metadata:
                   }
                 }
               },
+              "logs": {
+                "loki": {
+                  "enabled": false,
+                  "flavor": "1.extra-small",
+                  "replicationFactor": 1,
+                  "storage": {
+                    "objectStorageSecret": "test",
+                    "storageClass": "standard"
+                  }
+                }
+              },
               "metrics": {
                 "prometheus": {
                   "enabled": true,
@@ -53,18 +64,6 @@ metadata:
                     },
                     "retention": "24h",
                     "strategy": "persistent"
-                  }
-                }
-              },
-              "logs": {
-                "loki": {
-                  "enabled": false,
-                  "flavor": "1.extra-small",
-                  "replicationFactor": 1,
-                  "storage": {
-                    "objectStorageSecret": "test",
-                    "storageClass": "standard"
-                    }
                   }
                 }
               }
@@ -373,15 +372,14 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: Loki replication factor.
-          Choose how many ingesters and queriers to create.
+      - description: Loki replication factor. Choose how many ingesters and queriers
+          to create.
         displayName: Loki replication factor
         path: backends.logs.loki.replicationFactor
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Loki flavor.
-          Choose flavor of the loki deployment. This determines
+      - description: Loki flavor. Choose flavor of the loki deployment. This determines
           how much resources each loki microservice has.
         displayName: Loki flavor
         path: backends.logs.loki.flavor
@@ -438,7 +436,6 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-
       statusDescriptors:
       - description: Conditions provided by deployment
         displayName: Conditions
@@ -551,6 +548,7 @@ spec:
           - elasticsearch.k8s.elastic.co
           - certmanager.k8s.io
           - integreatly.org
+          - loki.openshift.io
           resources:
           - '*'
           verbs:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -59,7 +59,7 @@ metadata:
               "logs": {
                 "loki": {
                   "enabled": false,
-                  "size": "1.extra-small",
+                  "flavor": "1.extra-small",
                   "replicationFactor": 1,
                   "storage": {
                     "objectStorageSecret": "test",
@@ -382,11 +382,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Loki size.
-          Choose size of the loki deployment. This determines
+      - description: Loki flavor.
+          Choose flavor of the loki deployment. This determines
           how much resources each loki microservice has.
-        displayName: Loki size
-        path: backends.logs.loki.size
+        displayName: Loki flavor
+        path: backends.logs.loki.flavor
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
         - urn:alm:descriptor:com.tectonic.ui:select:1x.extra-small

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -367,8 +367,6 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
-
-
       - description: Enable Loki storage for logs backend.
         displayName: Loki enabled
         path: backends.logs.loki.enabled

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -55,6 +55,18 @@ metadata:
                     "strategy": "persistent"
                   }
                 }
+              },
+              "logs": {
+                "loki": {
+                  "enabled": false,
+                  "size": "1.extra-small",
+                  "replicationFactor": 1,
+                  "storage": {
+                    "objectStorageSecret": "test",
+                    "storageClassName": "standard"
+                    }
+                  }
+                }
               }
             },
             "graphing": {
@@ -355,6 +367,80 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
+
+
+      - description: Enable Loki storage for logs backend.
+        displayName: Loki enabled
+        path: backends.logs.loki.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Loki replication factor.
+          Choose how many ingesters and queriers to create.
+        displayName: Loki replication factor
+        path: backends.logs.loki.replicationFactor
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Loki size.
+          Choose size of the loki deployment. This determines
+          how much resources each loki microservice has.
+        displayName: Loki size
+        path: backends.logs.loki.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:select:1x.extra-small
+        - urn:alm:descriptor:com.tectonic.ui:select:1x.small
+        - urn:alm:descriptor:com.tectonic.ui:select:1x.medium
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Secret containing information required for S3 object storage.
+        displayName: Loki object storage secret
+        path: backends.logs.loki.storage.objectStorageSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Storage class configuration for Loki persistent storage
+        displayName: Loki storage class
+        path: backends.logs.loki.storage.storageClassName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+      - description: Number of compactor Loki microservice replicas
+        displayName: Compactor replicas
+        path: backends.logs.loki.compactor.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Number of compactor Loki microservice replicas
+        displayName: Distributor replicas
+        path: backends.logs.loki.distributor.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Number of compactor Loki microservice replicas
+        displayName: Ingester replicas
+        path: backends.logs.loki.ingester.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Number of compactor Loki microservice replicas
+        displayName: Querier replicas
+        path: backends.logs.loki.querier.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Number of compactor Loki microservice replicas
+        displayName: Query frontend replicas
+        path: backends.logs.loki.queryFrontend.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Backends
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+
       statusDescriptors:
       - description: Conditions provided by deployment
         displayName: Conditions

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -33,6 +33,7 @@ rules:
   - elasticsearch.k8s.elastic.co
   - certmanager.k8s.io
   - integreatly.org
+  - loki.openshift.io
   resources:
   - '*'
   verbs:

--- a/docs/loki.md
+++ b/docs/loki.md
@@ -1,0 +1,75 @@
+# How to run SGO with Loki
+A few examples about how to deploy with Loki for logging support.
+
+## Deploy SGO + Loki with minio for storage
+This is less resource intensive. Useful for development in crc.
+```
+ansible-playbook --extra-vars __service_telemetry_logs_enabled=true --extra-vars __deploy_minio_enabled=true run-ci.yaml
+```
+
+## Deploy SGO + Loki with OCS for storage
+This is more production like setup. It's more resource demanding and cannot be run in crc. This assumes OCS is already deployed.
+
+### Create an object bucket claim
+```
+oc apply -f - <<EOF
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: loki-s3-storage
+spec:
+  additionalConfig:
+    bucketclass: noobaa-default-bucket-class
+  generateBucketName: loki-s3-storage
+  storageClassName: openshift-storage.noobaa.io
+EOF
+```
+
+### Find the required information to connect to OCS
+```
+oc extract secret/loki-s3-storage --to=-
+oc extract configmap/loki-s3-storage --to=-
+```
+
+### Example output
+```
+oc extract secret/loki-s3-storage --to=-
+# AWS_SECRET_ACCESS_KEY
+u6fA9Nkh2D7jS7qNBSU0zKEAfLKx2QnMu71jMfpR
+# AWS_ACCESS_KEY_ID
+q2Jv3EvxOkavqw1TRhdD
+ 
+oc extract configmap/loki-s3-storage --to=-
+# BUCKET_NAME
+loki-s3-storage-8d19e1e7-c889-46f7-8654-3cef0aeb08a1
+# BUCKET_PORT
+443
+# BUCKET_REGION
+ 
+# BUCKET_SUBREGION
+ 
+# BUCKET_HOST
+s3.openshift-storage.svc
+```
+
+### Create a secret with S3 credentials for the loki-operator
+```
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <name of the secret>
+stringData:
+  endpoint: https://<BUCKET_HOST from previous commands>:<BUCKET_PORT from previous commands>
+  bucketnames: <BUCKET_NAME from previous commands>
+  access_key_id: <AWS_ACCESS_KEY_ID from previous commands>
+  access_key_secret: <AWS_SECRET_ACCESS_KEY from previous commands>
+type: Opaque
+EOF
+```
+
+### Deploy SGO + Loki
+```
+ansible-playbook --extra-vars __service_telemetry_logs_enabled=true --extra-vars __loki_skip_tls_verify=true run-ci.yaml
+```
+

--- a/docs/loki.md
+++ b/docs/loki.md
@@ -8,7 +8,7 @@ ansible-playbook --extra-vars __service_telemetry_logs_enabled=true --extra-vars
 ```
 
 ## Deploy SGO + Loki with OCS for storage
-This is more production like setup. It's more resource demanding and cannot be run in crc. This assumes OCS is already deployed.
+This is more a production-like setup. It's more resource demanding and cannot be run in crc. This assumes OCS is already deployed.
 
 ### Create an object bucket claim
 ```

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -48,6 +48,7 @@ servicetelemetry_defaults:
       loki:
         enabled: false
         replication_factor: 1
+        flavor: 1x.extra-small
         storage:
           object_storage_secret: ""
           storage_class: ""

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -44,6 +44,23 @@ servicetelemetry_defaults:
             storage_class: ""
             storage_selector: {}
             pvc_storage_request: 20Gi
+    logs:
+      loki:
+        enabled: false
+        node_count: 1
+        storage:
+          object_storage_secret: ""
+          storage_class: ""
+        compactor:
+          replicas: ""
+        distributor:
+          replicas: ""
+        ingester:
+          replicas: ""
+        querier:
+          replicas: ""
+        query_frontend:
+          replicas: ""
 
   transports:
     qdr:
@@ -82,6 +99,11 @@ servicetelemetry_defaults:
             debug_enabled: false
           - collector_type: ceilometer
             subscription_address: anycast/ceilometer/event.sample
+            debug_enabled: false
+      logs:
+        collectors:
+          - collector_type: rsyslog
+            subscription_address: rsyslog/logs
             debug_enabled: false
 
 

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -47,7 +47,7 @@ servicetelemetry_defaults:
     logs:
       loki:
         enabled: false
-        node_count: 1
+        replication_factor: 1
         storage:
           object_storage_secret: ""
           storage_class: ""

--- a/roles/servicetelemetry/tasks/component_clouds.yml
+++ b/roles/servicetelemetry/tasks/component_clouds.yml
@@ -49,3 +49,19 @@
     - this_cloud.events is defined
     - this_cloud.events.collectors is defined
     - this_cloud.events is iterable
+
+- name: Deploy Logs Smart Gateway instance
+  vars:
+    data_type: 'logs'
+    manifest: './manifest_smartgateway_logs.j2'
+    this_smartgateway: "{{ meta.name }}-{{ this_cloud.name }}-{{ this_collector.collector_type[:4] }}-log"
+  include_tasks: base_smartgateway.yml
+  loop: "{{ this_cloud.logs.collectors }}"
+  loop_control:
+    loop_var: this_collector
+    label: "{{ this_collector.collector_type }}"
+  when:
+  - servicetelemetry_vars.backends.logs.loki.enabled
+  - this_cloud.logs is defined
+  - this_cloud.logs.collectors is defined
+  - this_cloud.logs is iterable

--- a/roles/servicetelemetry/tasks/component_loki.yml
+++ b/roles/servicetelemetry/tasks/component_loki.yml
@@ -1,0 +1,14 @@
+- name: Lookup template
+  debug:
+    msg: "{{ lookup('template', './manifest_loki.j2') | from_yaml }}"
+
+- name: Set default Loki manifest
+  set_fact:
+    loki_manifest: "{{ lookup('template', './manifest_loki.j2') | from_yaml }}"
+  when: loki_manifest is not defined
+
+- name: Create an instance of Loki
+  k8s:
+    state: '{{ "present" if servicetelemetry_vars.backends.logs.loki.enabled else "absent" }}'
+    definition:
+      '{{ loki_manifest }}'

--- a/roles/servicetelemetry/tasks/main.yml
+++ b/roles/servicetelemetry/tasks/main.yml
@@ -35,6 +35,10 @@
 - name: Create Alertmanager instance
   include_tasks: component_alertmanager.yml
 
+# --> backends.logs
+- name: Create Loki instance
+  include_tasks: component_loki.yml
+
 # --> graphing
 - name: Deploy graphing
   block:

--- a/roles/servicetelemetry/templates/manifest_grafana_ds.j2
+++ b/roles/servicetelemetry/templates/manifest_grafana_ds.j2
@@ -48,4 +48,14 @@ spec:
         timeField: generated
         esVersion: 70
 {% endif %}
+
+{% if servicetelemetry_vars.backends.logs.loki.enabled %}
+    - access: proxy
+      editable: true
+      isDefault: false
+      name: STFLoki
+      type: loki
+      url: 'http://loki-query-frontend-http-lokistack:3100'
+      version: 1
+{% endif %}
   name: {{ meta.name }}-ds-stf.yaml

--- a/roles/servicetelemetry/templates/manifest_loki.j2
+++ b/roles/servicetelemetry/templates/manifest_loki.j2
@@ -4,7 +4,7 @@ metadata:
   name: lokistack
   namespace: '{{ meta.namespace }}'
 spec:
-  size: {{ servicetelemetry_vars.backends.logs.loki.size }}
+  size: {{ servicetelemetry_vars.backends.logs.loki.flavor }}
   replicationFactor: {{ servicetelemetry_vars.backends.logs.loki.replication_factor }}
   storage:
     secret:

--- a/roles/servicetelemetry/templates/manifest_loki.j2
+++ b/roles/servicetelemetry/templates/manifest_loki.j2
@@ -1,0 +1,39 @@
+apiVersion: loki.openshift.io/v1beta1
+kind: LokiStack
+metadata:
+  name: lokistack
+  namespace: '{{ meta.namespace }}'
+spec:
+  size: {{ servicetelemetry_vars.backends.logs.loki.size }}
+  replicationFactor: {{ servicetelemetry_vars.backends.logs.loki.replication_factor }}
+  storage:
+    secret:
+      name: {{ servicetelemetry_vars.backends.logs.loki.storage.object_storage_secret }}
+  storageClassName: {{ servicetelemetry_vars.backends.logs.loki.storage.storage_class }}
+{% if servicetelemetry_vars.backends.logs.loki.compactor.replicas | length or
+      servicetelemetry_vars.backends.logs.loki.distributor.replicas | length or
+      servicetelemetry_vars.backends.logs.loki.ingester.replicas | length or
+      servicetelemetry_vars.backends.logs.loki.querier.replicas | length or
+      servicetelemetry_vars.backends.logs.loki.query_frontend.replicas | length %}
+  template:
+{% if servicetelemetry_vars.backends.logs.loki.compactor.replicas | length %}
+    compactor:
+      replicas: {{ servicetelemetry_vars.backends.logs.loki.compactor.replicas }}
+{% endif %}
+{% if servicetelemetry_vars.backends.logs.loki.distributor.replicas | length %}
+    distributor:
+      replicas: {{ servicetelemetry_vars.backends.logs.loki.distributor.replicas }}
+{% endif %}
+{% if servicetelemetry_vars.backends.logs.loki.ingester.replicas | length %}
+    ingester:
+      replicas: {{ servicetelemetry_vars.backends.logs.loki.ingester.replicas }}
+{% endif %}
+{% if servicetelemetry_vars.backends.logs.loki.querier.replicas | length %}
+    querier:
+      replicas: {{ servicetelemetry_vars.backends.logs.loki.querier.replicas }}
+{% endif %}
+{% if servicetelemetry_vars.backends.logs.loki.query_frontend.replicas | length %}
+    queryFrontend:
+      replicas: {{ servicetelemetry_vars.backends.logs.loki.query_frontend.replicas }}
+{% endif %}
+{% endif %}

--- a/roles/servicetelemetry/templates/manifest_smartgateway_logs.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_logs.j2
@@ -1,0 +1,32 @@
+apiVersion: smartgateway.infra.watch/v2
+kind: SmartGateway
+metadata:
+  name: '{{ this_smartgateway }}'
+  namespace: '{{ meta.namespace }}'
+spec:
+{% if this_collector.debug_enabled is defined and this_collector.debug_enabled %}
+  logLevel: "debug"
+{% else %}
+  logLevel: "info"
+{% endif %}
+  handleErrors: true
+  size: {{ smartgateway_deployment_size }}
+  applications:
+  - config: |
+      connection: http://loki-distributor-http-lokistack.{{ meta.namespace }}.svc.cluster.local:3100
+      batchSize: {{ loki_batch_size | default('20') }}
+      maxWaitTime: {{ loki_max_wait_time | default('100') }}
+    name: loki
+  bridge:
+    amqpUrl: amqp://{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ this_collector.subscription_address }}
+  transports:
+  - config: |
+      path: /tmp/smartgateway
+    handlers:
+    - name: logs
+      config: |
+        timestampField: "@timestamp"
+        messageField: "message"
+        severityField: "severity"
+        hostnameField: "host"
+    name: socket


### PR DESCRIPTION
This PR adds possibility to deploy STO with loki-operator and deploy Loki and log SG with it.

A few basic configuration options for the loki-operator are exposed through STO configuration. More options can be easily added later when needed.

Build and deployment is temporarily added to the stf-run-ci ansible role for easier development. This won't be needed once the operator is released. The loki-operator is currently under development, so I made a few workarounds to make some things work.
The main workarounds are:

- Remove authentication from /metrics - this seemed to prevent loki microservices from communicating with each other
- Remove operator-sdk build - I wasn't able to build operator-sdk, so I'm downloading a prebuilt binary instead.
- Skip tls verification - There doesn't seem to be an option to verify OCS certificate yet, so the config file is patched to skip it.

I added examples for deploying with minio to crc and with OCS to something like PSI to the docs.