### PR TITLE
Differentiate default component versions for builds in stf-run-ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,12 +76,17 @@ spec:
                   name: elasticsearch-data
 """
 
+def working_branch = "master"
+
 node('ocp-agent') {
     container('exec') {
         dir('service-telemetry-operator') {
             stage ('Clone Upstream') {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     checkout scm
+                    working_branch = sh(script: 'git ls-remote --heads origin | grep $(git rev-parse HEAD) | cut -d / -f 3', returnStdout: true).toString().trim()
+                    // ansible script needs local branch to exist, not detached HEAD
+                    sh "git checkout -b ${working_branch}"
                 }
             }
             stage ('Create project') {
@@ -105,7 +110,8 @@ node('ocp-agent') {
                                 "__deploy_stf": "false",
                                 "__local_build_enabled": "true",
                                 "__service_telemetry_snmptraps_enabled": "true",
-                                "__service_telemetry_storage_ephemeral_enabled": "true"
+                                "__service_telemetry_storage_ephemeral_enabled": "true",
+                                "working_branch":"${working_branch}"
                             ]
                         )
                     }

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -21,3 +21,10 @@ sg_core_image_tag: latest
 sg_bridge_image_tag: latest
 prometheus_webhook_snmp_image_tag: latest
 namespace: service-telemetry
+
+# used when building images to default to correct version branch for STF subcomponents per STF version
+version_branches:
+  sgo: master
+  sg_core: master
+  sg_bridge: master
+  prometheus_webhook_snmp: master

--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -11,11 +11,11 @@
         dest: working/smart-gateway-operator
         version: "{{ sgo_branch | default(branch, true) }}"
   rescue:
-    - name: Get master branch because same-named doesn't exist
+    - name: "Get {{ version_branches.sgo }} branch because same-named doesn't exist"
       git:
         repo: https://github.com/infrawatch/smart-gateway-operator
         dest: working/smart-gateway-operator
-        version: master
+        version: "{{ version_branches.sgo }}"
 
 - name: Get sg-core
   block:
@@ -25,11 +25,11 @@
         dest: working/sg-core
         version: "{{ sg_core_branch | default(branch, true) }}"
   rescue:
-    - name: Get master branch because same-named doesn't exist
+    - name: "Get {{ version_branches.sg_core }} branch because same-named doesn't exist"
       git:
         repo: https://github.com/infrawatch/sg-core
         dest: working/sg-core
-        version: master
+        version: "{{ version_branches.sg_core }}"
 
 - name: Get sg-bridge
   block:
@@ -39,11 +39,11 @@
         dest: working/sg-bridge
         version: "{{ sg_bridge_branch | default(branch, true) }}"
   rescue:
-    - name: Get master branch because same-named doesn't exist
+    - name: "Get {{ version_branches.sg_bridge }} branch because same-named doesn't exist"
       git:
         repo: https://github.com/infrawatch/sg-bridge
         dest: working/sg-bridge
-        version: master
+        version: "{{ version_branches.sg_bridge }}"
 
 - name: Get prometheus-webhook-snmp
   block:
@@ -53,8 +53,8 @@
         dest: working/prometheus-webhook-snmp
         version: "{{ prometheus_webhook_snmp_branch | default(branch, true) }}"
   rescue:
-    - name: Get master branch because same-named doesn't exist
+    - name: "Get {{ version_branches.prometheus_webhook_snmp }} branch because same-named doesn't exist"
       git:
         repo: https://github.com/infrawatch/prometheus-webhook-snmp
         dest: working/prometheus-webhook-snmp
-        version: master
+        version: "{{ version_branches.prometheus_webhook_snmp }}"


### PR DESCRIPTION
Now that we maintain more than one STF version, the CI role must
differentiate between componenet versions when building STF
subcomponents rather than defaulting to the master branch.
Considering not all components always follow the
"stable-<stf-version>" convention for STF releases (sg-bridge &
prometheus-webhook-snmp for STF-1.3), it is easiest to map
components to their stable branch according to the STF version in the
default vars. This map will be adjusted according to the target STF stable
branch when backported
