### PR TITLE
Add baseImage parameter to Grafana parameter

### DIFF
--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -258,6 +258,9 @@ spec:
                 adminUser:
                   description: Grafana admin user
                   type: string
+                baseImage:
+                  description: Path to the base container image used to instantiate a Grafana instance
+                  type: string
               type: object
           type: object
         cloudsRemoveOnMissing:

--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -50,6 +50,7 @@ spec:
       adminPassword: secret
       adminUser: root
       disableSignoutMenu: false
+      baseImage: docker.io/grafana/grafana:8.1.2
   transports:
     qdr:
       enabled: true

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -319,6 +319,10 @@ spec:
                 adminUser:
                   description: Grafana admin user
                   type: string
+                baseImage:
+                  description: Path to the base container image used to instantiate
+                    a Grafana instance
+                  type: string
                 disableSignoutMenu:
                   description: Whether to disable the Grafana signout menu
                   type: boolean

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -73,6 +73,7 @@ metadata:
               "grafana": {
                 "adminPassword": "secret",
                 "adminUser": "root",
+                "baseImage": "docker.io/grafana/grafana:8.1.2",
                 "disableSignoutMenu": false,
                 "ingressEnabled": false
               }
@@ -262,6 +263,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Graphing
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Set Grafana base image when instantiating an instance of Grafana
+        displayName: Grafana Base Image
+        path: graphing.grafana.baseImage
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Graphing
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:graphing.enabled:true
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Disable signout menu in Grafana
         displayName: Disable Grafana Signout Menu
         path: graphing.grafana.disableSignoutMenu

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -77,6 +77,7 @@ servicetelemetry_defaults:
       admin_password: secret
       admin_user: root
       disable_signout_menu: false
+      base_image: docker.io/grafana/grafana:8.1.2
 
   # 'clouds' object is not partially updatable like other objects. If 'clouds'
   # object is defined then the default is overwritten.

--- a/roles/servicetelemetry/templates/manifest_grafana.j2
+++ b/roles/servicetelemetry/templates/manifest_grafana.j2
@@ -4,6 +4,7 @@ metadata:
   name: {{ meta.name }}
   namespace: {{ meta.namespace }}
 spec:
+  baseImage: {{ servicetelemetry_vars.graphing.grafana.base_image }}
   ingress:
     enabled: {{ servicetelemetry_vars.graphing.grafana.ingress_enabled }}
   config:


### PR DESCRIPTION
Add the baseImage parameter to the graphing.grafana spec parameters of
the ServiceTelemetry object. Defaults to docker.io/grafana/grafana:8.1.2
but can be overridden at deployment time.

Resolves: rhbz#1998551