### PR TITLE
Replace golang image in loki-operator

### DIFF
--- a/.jenkins/agent/Dockerfile
+++ b/.jenkins/agent/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-jenkins-agent-base:latest
-
-COPY install-sdk.sh /install-sdk.sh
-RUN /install-sdk.sh
-RUN dnf install -y ansible && \
+RUN curl -LO "https://github.com/operator-framework/operator-sdk/releases/download/v0.19.4/operator-sdk-v0.19.4-x86_64-linux-gnu" && \
+    chmod +x operator-sdk-v0.19.4-x86_64-linux-gnu && mv operator-sdk-v0.19.4-x86_64-linux-gnu /usr/local/bin/operator-sdk
+RUN dnf install -y ansible golang && \
+    dnf groupinstall -y "Development Tools" -y && \
     ansible-galaxy collection install community.kubernetes && \
     python -m pip install openshift

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ node('ocp-agent') {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     openshift.withCluster() {
                         openshift.withProject(namespace) {
-                            timeout(time: 300, unit: 'SECONDS') {
+                            timeout(time: 800, unit: 'SECONDS') {
                                 openshift.create(stf_resource)
                                 sh "OCP_PROJECT=${namespace} ./build/validate_deployment.sh"
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,10 +67,10 @@ spec:
                   resources:
                     limits:
                       cpu: '2'
-                      memory: 4Gi
+                      memory: 2Gi
                     requests:
                       cpu: '1'
-                      memory: 2Gi
+                      memory: 1Gi
               volumes:
                 - emptyDir: {}
                   name: elasticsearch-data

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,23 +37,25 @@ spec:
       deploymentSize: 1
       web:
         enabled: false
-  elasticsearch_manifest: |
-    apiVersion: elasticsearch.k8s.elastic.co/v1beta1
+  elasticsearchManifest: |
+    apiVersion: elasticsearch.k8s.elastic.co/v1
     kind: Elasticsearch
     metadata:
       name: elasticsearch
       namespace: $namespace
     spec:
       version: 7.10.2
+      volumeClaimDeletePolicy: DeleteOnScaledownAndClusterDeletion
       http:
         tls:
           certificate:
             secretName: 'elasticsearch-es-cert'
       nodeSets:
         - config:
-            node.data: true
-            node.ingest: true
-            node.master: true
+            node.roles:
+              - master
+              - data
+              - ingest
             node.store.allow_mmap: true
           count: 1
           name: default

--- a/build/get_go.sh
+++ b/build/get_go.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+REL=$(dirname "$0")
+ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+OS=$(uname | awk '{print tolower($0)}')
+VERSION="${1:-1.16}"
+ARCHIVE_NAME="go"${VERSION}.${OS}-${ARCH}.tar.gz
+BINARY_NAME="go"${VERSION}
+GO_DL_URL=https://golang.org/dl/${ARCHIVE_NAME}
+
+
+if [[ ! -f ${REL}/working/go/bin/go ]]; then
+	curl -L ${GO_DL_URL} -o ${REL}/working/${ARCHIVE_NAME}
+	cd ${REL}/working
+	tar -xzf $ARCHIVE_NAME
+fi
+

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -36,8 +36,8 @@ choose to override:
 | `__internal_registry_path`                      | <registry_path> | image-registry.openshift-image-registry.svc:5000 | Path to internal registry for image path                                                              |
 | `__deploy_minio_enabled`                        | {true,false}    | false                                            | Whether to deploy minio while deploying loki-operator for logging development purposes                |
 | `__loki_skip_tls_verify`                        | {true,false}    | false                                            | Whether to skip TLS verify for Loki S3 connection                                                     |
-| `__golang_image_path`                           | <image_path>    | quay.io/jwysogla/golang:latest                   | Golang image path for building the loki-operator image                                                |
-| `__loki_image_path`                             | <image_path>    | quay.io/jwysogla/loki:latest                     | Loki image path for Loki microservices                                                                |
+| `__golang_image_path`                           | <image_path>    | quay.io/infrawatch/golang:1.16                   | Golang image path for building the loki-operator image                                                |
+| `__loki_image_path`                             | <image_path>    | quay.io/infrawatch/loki:2.2.1                    | Loki image path for Loki microservices                                                                |
 
 
 Example Playbook

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -36,6 +36,7 @@ choose to override:
 | `__internal_registry_path`                      | <registry_path> | image-registry.openshift-image-registry.svc:5000 | Path to internal registry for image path                                                              |
 | `__deploy_minio_enabled`                        | {true,false}    | false                                            | Whether to deploy minio while deploying loki-operator for logging development purposes                |
 | `__loki_skip_tls_verify`                        | {true,false}    | false                                            | Whether to skip TLS verify for Loki S3 connection                                                     |
+| `__golang_image_path`                           | <image_path>    | quay.io/jwysogla/golang:latest                   | Golang image path for building the loki-operator image                                                |
 
 
 Example Playbook

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -37,6 +37,7 @@ choose to override:
 | `__deploy_minio_enabled`                        | {true,false}    | false                                            | Whether to deploy minio while deploying loki-operator for logging development purposes                |
 | `__loki_skip_tls_verify`                        | {true,false}    | false                                            | Whether to skip TLS verify for Loki S3 connection                                                     |
 | `__golang_image_path`                           | <image_path>    | quay.io/jwysogla/golang:latest                   | Golang image path for building the loki-operator image                                                |
+| `__loki_image_path`                             | <image_path>    | quay.io/jwysogla/loki:latest                     | Loki image path for Loki microservices                                                                |
 
 
 Example Playbook

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -28,6 +28,7 @@ sg_bridge_image_tag: latest
 prometheus_webhook_snmp_image_tag: latest
 loki_operator_image_tag: latest
 new_operator_sdk_version: v1.5.0
+new_go_version: 1.16.3
 namespace: service-telemetry
 
 # Set a default commit hash to clone for loki-operator to freeze

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -18,6 +18,7 @@ __internal_registry_path: image-registry.openshift-image-registry.svc:5000
 
 __deploy_minio_enabled: false
 __loki_skip_tls_verify: false
+__golang_image_path: quay.io/jwysogla/golang:latest
 
 sgo_image_tag: latest
 sto_image_tag: latest
@@ -27,6 +28,7 @@ prometheus_webhook_snmp_image_tag: latest
 loki_operator_image_tag: latest
 new_operator_sdk_version: v1.5.0
 namespace: service-telemetry
+
 
 # used when building images to default to correct version branch for STF subcomponents per STF version
 version_branches:

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -19,6 +19,7 @@ __internal_registry_path: image-registry.openshift-image-registry.svc:5000
 __deploy_minio_enabled: false
 __loki_skip_tls_verify: false
 __golang_image_path: quay.io/jwysogla/golang:latest
+__loki_image_path: quay.io/jwysogla/loki:latest
 
 sgo_image_tag: latest
 sto_image_tag: latest

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -30,6 +30,10 @@ loki_operator_image_tag: latest
 new_operator_sdk_version: v1.5.0
 namespace: service-telemetry
 
+# Set a default commit hash to clone for loki-operator to freeze
+# the operator developement.
+loki_operator_branch: 700e275
+
 
 # used when building images to default to correct version branch for STF subcomponents per STF version
 version_branches:

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -18,8 +18,8 @@ __internal_registry_path: image-registry.openshift-image-registry.svc:5000
 
 __deploy_minio_enabled: false
 __loki_skip_tls_verify: false
-__golang_image_path: quay.io/jwysogla/golang:latest
-__loki_image_path: quay.io/jwysogla/loki:latest
+__golang_image_path: quay.io/infrawatch/golang:1.16
+__loki_image_path: quay.io/infrawatch/loki:2.2.1
 
 sgo_image_tag: latest
 sto_image_tag: latest

--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -69,9 +69,11 @@
         repo: https://github.com/viaq/loki-operator
         dest: working/loki-operator
         version: "{{ loki_operator_branch | default(branch, true) }}"
+        force: yes
   rescue:
     - name: "Get {{ version_branches.loki_operator }} branch because same-named doesn't exist"
       git:
         repo: https://github.com/viaq/loki-operator
         dest: working/loki-operator
         version: "{{ version_branches.loki_operator }}"
+        force: yes

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -81,6 +81,12 @@
       regexp: "golang:1.16"
       replace: "{{ __golang_image_path }}"
 
+  - name: Replace Loki image
+    replace:
+      path: "{{ playbook_dir }}/working/loki-operator/internal/manifests/var.go"
+      regexp: "docker.io/grafana/loki:\\d\\.\\d\\.\\d"
+      replace: "{{ __loki_image_path }}"
+
   - name: Create builds and artifacts
     include_tasks: create_builds.yml
     loop:

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -79,7 +79,7 @@
     replace:
       path: "{{ playbook_dir }}/working/loki-operator/Dockerfile"
       regexp: "golang:1.16"
-      replace: "quay.io/jwysogla/golang:latest"
+      replace: "{{ __golang_image_path }}"
 
   - name: Create builds and artifacts
     include_tasks: create_builds.yml

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -49,6 +49,9 @@
   - name: Get new operator sdk
     command: ./get_new_operator_sdk.sh "{{ new_operator_sdk_version }}"
 
+  - name: Get new go
+    command: ./get_go.sh "{{ new_go_version }}"
+
   - name: Setup supporting Operator subscriptions
     include_tasks: setup_base.yml
     tags:

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -75,6 +75,11 @@
     when:
     - __loki_skip_tls_verify | bool
 
+  - name: Replace loki-operator golang base image
+    replace:
+      path: "{{ playbook_dir }}/working/loki-operator/Dockerfile"
+      regexp: "golang:1.16"
+      replace: "quay.io/jwysogla/golang:latest"
 
   - name: Create builds and artifacts
     include_tasks: create_builds.yml

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -91,6 +91,7 @@
     params:
         REGISTRY_ORG: infrawatch
         OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
+        GOBIN: "{{ playbook_dir }}/working/go/bin"
 
 - name: Replace namespace in loki-operator CSV
   replace:
@@ -147,6 +148,7 @@
     params:
         REGISTRY_ORG: infrawatch
         OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
+        GOBIN: "{{ playbook_dir }}/working/go/bin"
 
 - name: Load Loki Operator bundle manifests
   command: oc apply -f working/loki-operator/bundle/manifests/{{ item }} -n "{{ namespace }}"

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -72,6 +72,18 @@
     regexp: '^.*modfile=operator-sdk.mod.*$'
     replace: ''
 
+- name: Prevent Loki Operator from replacing GOBIN
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/.bingo/Variables.mk"
+    regexp: '^GOBIN.*$'
+    replace: 'GOBIN  ?= $(shell go env GOBIN)'
+
+- name: Prevent Loki Operator from using system golang
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/.bingo/Variables.mk"
+    regexp: '^GO .*$'
+    replace: 'GO     ?= $(GOBIN)"/go"'
+
 - name: Prevent Loki Operator from putting authentication on /metrics
   replace:
     path: "{{ playbook_dir }}/working/loki-operator/config/overlays/openshift/kustomization.yaml"
@@ -93,6 +105,7 @@
         OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
         GOROOT: "{{ playbook_dir }}/working/go"
         GOTOOLDIR: "{{ playbook_dir }}/working/go/pkg/tool/linux_amd64"
+        GOBIN: "{{ playbook_dir }}/working/go/bin"
 
 - name: Replace namespace in loki-operator CSV
   replace:
@@ -151,6 +164,7 @@
         OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
         GOROOT: "{{ playbook_dir }}/working/go"
         GOTOOLDIR: "{{ playbook_dir }}/working/go/pkg/tool/linux_amd64"
+        GOBIN: "{{ playbook_dir }}/working/go/bin"
 
 - name: Load Loki Operator bundle manifests
   command: oc apply -f working/loki-operator/bundle/manifests/{{ item }} -n "{{ namespace }}"

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -91,7 +91,7 @@
     params:
         REGISTRY_ORG: infrawatch
         OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
-        GOBIN: "{{ playbook_dir }}/working/go/bin"
+        GOROOT: "{{ playbook_dir }}/working/go"
 
 - name: Replace namespace in loki-operator CSV
   replace:
@@ -148,7 +148,7 @@
     params:
         REGISTRY_ORG: infrawatch
         OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
-        GOBIN: "{{ playbook_dir }}/working/go/bin"
+        GOROOT: "{{ playbook_dir }}/working/go"
 
 - name: Load Loki Operator bundle manifests
   command: oc apply -f working/loki-operator/bundle/manifests/{{ item }} -n "{{ namespace }}"

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -92,6 +92,7 @@
         REGISTRY_ORG: infrawatch
         OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
         GOROOT: "{{ playbook_dir }}/working/go"
+        GOTOOLDIR: "{{ playbook_dir }}/working/go/pkg/tool/linux_amd64"
 
 - name: Replace namespace in loki-operator CSV
   replace:
@@ -149,6 +150,7 @@
         REGISTRY_ORG: infrawatch
         OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
         GOROOT: "{{ playbook_dir }}/working/go"
+        GOTOOLDIR: "{{ playbook_dir }}/working/go/pkg/tool/linux_amd64"
 
 - name: Load Loki Operator bundle manifests
   command: oc apply -f working/loki-operator/bundle/manifests/{{ item }} -n "{{ namespace }}"

--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -5,7 +5,7 @@ EPHEMERAL_STORAGE="${EPHEMERAL_STORAGE:-false}"
 oc new-project "${OCP_PROJECT}"
 ansible-playbook \
     --extra-vars namespace="${OCP_PROJECT}" \
-    --extra-vars __local_build_enabled=false \
+    --extra-vars __local_build_enabled=true \
     --extra-vars __service_telemetry_snmptraps_enabled=true \
     --extra-vars __service_telemetry_storage_ephemeral_enabled=${EPHEMERAL_STORAGE} \
     ${REL}/../build/run-ci.yaml

--- a/roles/servicetelemetry/templates/manifest_elasticsearch.j2
+++ b/roles/servicetelemetry/templates/manifest_elasticsearch.j2
@@ -1,55 +1,72 @@
-apiVersion: elasticsearch.k8s.elastic.co/v1beta1
+apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
   name: elasticsearch
   namespace: '{{ meta.namespace }}'
 spec:
-  version: 7.10.2
+  auth: {}
   http:
+    service:
+      metadata: {}
+      spec: {}
     tls:
       certificate:
-        secretName: 'elasticsearch-es-cert'
+        secretName: elasticsearch-es-cert
+  monitoring:
+    logs: {}
+    metrics: {}
   nodeSets:
-    - config:
-        node.data: true
-        node.ingest: true
-        node.master: true
-        node.store.allow_mmap: true
-      count: {{ servicetelemetry_vars.backends.events.elasticsearch.node_count }}
-      name: default
-      podTemplate:
-        metadata:
-          labels:
-            tuned.openshift.io/elasticsearch: elasticsearch
-        spec:
-          containers:
-            - name: elasticsearch
-              resources:
-                limits:
-                  cpu: '2'
-                  memory: 4Gi
-                requests:
-                  cpu: '1'
-                  memory: 4Gi
-{% if servicetelemetry_vars.backends.events.elasticsearch.storage.strategy == "ephemeral" %}
-          volumes:
-            - emptyDir: {}
-              name: elasticsearch-data
-{% endif %}
+  - count: {{ servicetelemetry_vars.backends.events.elasticsearch.node_count }}
+    name: default
+    config:
+      node.roles:
+      - master
+      - data
+      - ingest
+      node.store.allow_mmap: true
 {% if servicetelemetry_vars.backends.events.elasticsearch.storage.strategy == "persistent" %}
-      volumeClaimTemplates:
-        - metadata:
-            name: elasticsearch-data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.pvc_storage_request }}
-{% if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector %}
-            selector: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector }}
+    volumeClaimTemplates:
+      - metadata:
+          name: elasticsearch-data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.pvc_storage_request }}
+{%   if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector %}
+          selector: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector }}
+{%   endif %}
+{%   if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_class | length %}
+          storageClassName: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_class }}
+{%   endif %}
 {% endif %}
-{% if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_class | length %}
-            storageClassName: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_class }}
+    podTemplate:
+      metadata:
+        labels:
+          tuned.openshift.io/elasticsearch: elasticsearch
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: "1"
+              memory: 4Gi
+{% if servicetelemetry_vars.backends.events.elasticsearch.storage.strategy == "ephemeral" %}
+        volumes:
+        - emptyDir: {}
+          name: elasticsearch-data
 {% endif %}
-{% endif %}
+  transport:
+    service:
+      metadata: {}
+      spec: {}
+    tls:
+      certificate: {}
+  updateStrategy:
+    changeBudget: {}
+  version: 7.10.2
+  volumeClaimDeletePolicy: DeleteOnScaledownOnly

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -25,8 +25,8 @@ for ((i=1; i<=NUMCLOUDS; i++)); do
 done
 REL=$(dirname "$0")
 
-if [ -z $OCP_PROJECT+x} ]; then
-    oc project $OCP_PROJECT 
+if [ -z ${OCP_PROJECT+x} ]; then
+    oc project $OCP_PROJECT
 else
     OCP_PROJECT=$(oc project -q)
 fi
@@ -69,7 +69,7 @@ done
 
 oc delete pod curl
 SNMP_WEBHOOK_POD=$(oc get pod -l "app=default-snmp-webhook" -ojsonpath='{.items[0].metadata.name}')
-trapoutput=$(oc logs $SNMP_WEBHOOK_POD | grep 'Sending SNMP trap')
+oc logs "$SNMP_WEBHOOK_POD" | grep 'Sending SNMP trap'
 SNMP_WEBHOOK_STATUS=$?
 
 echo "*** [INFO] Showing oc get all..."
@@ -124,7 +124,7 @@ if $CLEANUP; then
 fi
 echo
 
-if [ $SNMP_WBHOOK_POD -eq 0 ]; then
+if [ $SNMP_WEBHOOK_STATUS -ne 0 ]; then
     echo "*** [FAILURE] SNMP Webhook failed"
     exit 1
 fi


### PR DESCRIPTION
I added a replace to the stf-run-ci, which replaces the golang base image used to build the loki-operator for the same image hosted on quay.io instead of docker.io. This should make the loki-operator buildable behind Red Hat firewall and it should fix the #255 issue.