### PR TITLE
Adjust Elasticsearch CustomResource template

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,23 +37,25 @@ spec:
       deploymentSize: 1
       web:
         enabled: false
-  elasticsearch_manifest: |
-    apiVersion: elasticsearch.k8s.elastic.co/v1beta1
+  elasticsearchManifest: |
+    apiVersion: elasticsearch.k8s.elastic.co/v1
     kind: Elasticsearch
     metadata:
       name: elasticsearch
       namespace: $namespace
     spec:
       version: 7.10.2
+      volumeClaimDeletePolicy: DeleteOnScaledownAndClusterDeletion
       http:
         tls:
           certificate:
             secretName: 'elasticsearch-es-cert'
       nodeSets:
         - config:
-            node.data: true
-            node.ingest: true
-            node.master: true
+            node.roles:
+              - master
+              - data
+              - ingest
             node.store.allow_mmap: true
           count: 1
           name: default

--- a/roles/servicetelemetry/templates/manifest_elasticsearch.j2
+++ b/roles/servicetelemetry/templates/manifest_elasticsearch.j2
@@ -1,55 +1,72 @@
-apiVersion: elasticsearch.k8s.elastic.co/v1beta1
+apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
   name: elasticsearch
   namespace: '{{ meta.namespace }}'
 spec:
-  version: 7.10.2
+  auth: {}
   http:
+    service:
+      metadata: {}
+      spec: {}
     tls:
       certificate:
-        secretName: 'elasticsearch-es-cert'
+        secretName: elasticsearch-es-cert
+  monitoring:
+    logs: {}
+    metrics: {}
   nodeSets:
-    - config:
-        node.data: true
-        node.ingest: true
-        node.master: true
-        node.store.allow_mmap: true
-      count: {{ servicetelemetry_vars.backends.events.elasticsearch.node_count }}
-      name: default
-      podTemplate:
-        metadata:
-          labels:
-            tuned.openshift.io/elasticsearch: elasticsearch
-        spec:
-          containers:
-            - name: elasticsearch
-              resources:
-                limits:
-                  cpu: '2'
-                  memory: 4Gi
-                requests:
-                  cpu: '1'
-                  memory: 4Gi
-{% if servicetelemetry_vars.backends.events.elasticsearch.storage.strategy == "ephemeral" %}
-          volumes:
-            - emptyDir: {}
-              name: elasticsearch-data
-{% endif %}
+  - count: {{ servicetelemetry_vars.backends.events.elasticsearch.node_count }}
+    name: default
+    config:
+      node.roles:
+      - master
+      - data
+      - ingest
+      node.store.allow_mmap: true
 {% if servicetelemetry_vars.backends.events.elasticsearch.storage.strategy == "persistent" %}
-      volumeClaimTemplates:
-        - metadata:
-            name: elasticsearch-data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.pvc_storage_request }}
-{% if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector %}
-            selector: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector }}
+    volumeClaimTemplates:
+      - metadata:
+          name: elasticsearch-data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.pvc_storage_request }}
+{%   if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector %}
+          selector: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector }}
+{%   endif %}
+{%   if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_class | length %}
+          storageClassName: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_class }}
+{%   endif %}
 {% endif %}
-{% if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_class | length %}
-            storageClassName: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_class }}
+    podTemplate:
+      metadata:
+        labels:
+          tuned.openshift.io/elasticsearch: elasticsearch
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: "1"
+              memory: 4Gi
+{% if servicetelemetry_vars.backends.events.elasticsearch.storage.strategy == "ephemeral" %}
+        volumes:
+        - emptyDir: {}
+          name: elasticsearch-data
 {% endif %}
-{% endif %}
+  transport:
+    service:
+      metadata: {}
+      spec: {}
+    tls:
+      certificate: {}
+  updateStrategy:
+    changeBudget: {}
+  version: 7.10.2
+  volumeClaimDeletePolicy: DeleteOnScaledownOnly

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -124,7 +124,7 @@ if $CLEANUP; then
 fi
 echo
 
-if [ $SNMP_WEBHOOK_STATUS -eq 0 ]; then
+if [ $SNMP_WEBHOOK_STATUS -ne 0 ]; then
     echo "*** [FAILURE] SNMP Webhook failed"
     exit 1
 fi

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -25,8 +25,8 @@ for ((i=1; i<=NUMCLOUDS; i++)); do
 done
 REL=$(dirname "$0")
 
-if [ -z $OCP_PROJECT+x} ]; then
-    oc project $OCP_PROJECT 
+if [ -z ${OCP_PROJECT+x} ]; then
+    oc project $OCP_PROJECT
 else
     OCP_PROJECT=$(oc project -q)
 fi
@@ -69,7 +69,7 @@ done
 
 oc delete pod curl
 SNMP_WEBHOOK_POD=$(oc get pod -l "app=default-snmp-webhook" -ojsonpath='{.items[0].metadata.name}')
-trapoutput=$(oc logs $SNMP_WEBHOOK_POD | grep 'Sending SNMP trap')
+oc logs "$SNMP_WEBHOOK_POD" | grep 'Sending SNMP trap'
 SNMP_WEBHOOK_STATUS=$?
 
 echo "*** [INFO] Showing oc get all..."
@@ -124,7 +124,7 @@ if $CLEANUP; then
 fi
 echo
 
-if [ $SNMP_WBHOOK_POD -eq 0 ]; then
+if [ $SNMP_WEBHOOK_STATUS -eq 0 ]; then
     echo "*** [FAILURE] SNMP Webhook failed"
     exit 1
 fi


### PR DESCRIPTION
Adjust the Elasticsearch CustomResource template to be compatible with
ECK 1.7.1. This change bumps the Elasticsearch API interface to v1 from
v1beta1. Required adjustments to support the new API interface have been
implemented in the manifest_elasticsearch.yaml.j2 file.

Changes include:

* move volumeClaimTemplates to the same level as the nodeSet definition
* add empty object names based on the generated CustomResource after
  creating the Elasticsearch object
* adjust the syntax used for node.roles configuration
* adds volumeClaimDeletePolicy configuration based on recommendations in
  ECK documentation
  * uses DeleteOnScaledownOnly which preserves the PV even when the
    elasticsearch instance is removed (for safety)
* fixes indentation across the podTemplate configuration to allow
  ephemeral storage to work again (should fix CI)

Resolves: STF-540
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
