### PR TITLE
Set olm.maxOpenShiftVersion to 4.8

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -90,6 +90,7 @@ metadata:
       the required dependencies and configuration of various components to build a
       Service Telemetry platform for telco grade monitoring.
     olm.skipRange: '>=<<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>'
+    "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     operatorframework.io/suggested-namespace: service-telemetry
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible


### PR DESCRIPTION
Operators which use CRD v1beta1 are not compatible with Kubernetes 1.22
/ OpenShift 4.9 as Kubernetes has dropped support for
CustomResourceDefinition v1beta1, and must be upgraded to v1.

Setting this CSV annotation will result in OpenShift cluster upgrades
being blocked when an Operator is installed that doesn't meet the new
CRD API version in order to avoid a broken system.

A future version of STF will provide support for CRD v1 and support for
OCP 4.9.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
