### PR TITLE
Don't reference grafana.baseImage in CustomResource

### DIFF
--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -34,7 +34,6 @@ spec:
           persistent:
             storageSelector: {}
             pvcStorageRequest: 20Gi
-
     logs:
       loki:
         enabled: false
@@ -50,7 +49,6 @@ spec:
       adminPassword: secret
       adminUser: root
       disableSignoutMenu: false
-      baseImage: docker.io/grafana/grafana:8.1.2
   transports:
     qdr:
       enabled: true

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -73,7 +73,6 @@ metadata:
               "grafana": {
                 "adminPassword": "secret",
                 "adminUser": "root",
-                "baseImage": "docker.io/grafana/grafana:8.1.2",
                 "disableSignoutMenu": false,
                 "ingressEnabled": false
               }
@@ -100,8 +99,8 @@ metadata:
     description: Service Telemetry Framework. Umbrella Operator for instantiating
       the required dependencies and configuration of various components to build a
       Service Telemetry platform for telco grade monitoring.
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     olm.skipRange: '>=<<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>'
-    "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     operatorframework.io/suggested-namespace: service-telemetry
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible


### PR DESCRIPTION
When referencing the docker.io path in the CustomResource example,
issues happen when importing and performing a downstream build for
release.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
