### PR TITLE
Update stf-run-ci to match documentation (#268)

### DIFF
--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -26,23 +26,6 @@
         targetNamespaces:
         - "{{ namespace }}"
 
-- name: Enable AMQ Certificate Manager CatalogSource (redhat-operators-stf)
-  k8s:
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: CatalogSource
-      metadata:
-        name: redhat-operators-stf
-        namespace: openshift-marketplace
-      spec:
-        displayName: Red Hat STF Operators
-        image: quay.io/redhat-operators-stf/stf-catalog:stable
-        publisher: Red Hat
-        sourceType: grpc
-        updateStrategy:
-          registryPoll:
-            interval: 30m
-
 - name: Subscribe to AMQ Certificate Manager Operator
   k8s:
     definition:
@@ -52,12 +35,11 @@
         name: amq7-cert-manager-operator
         namespace: openshift-operators
       spec:
-        channel: alpha
+        channel: 1.x
         installPlanApproval: Automatic
         name: amq7-cert-manager-operator
-        source: redhat-operators-stf
+        source: redhat-operators
         sourceNamespace: openshift-marketplace
-        targetNamespaces: global
 
 - name: Enable OperatorHub.io for Elastic Cloud on Kubernetes
   k8s:
@@ -69,7 +51,7 @@
         namespace: openshift-marketplace
       spec:
         sourceType: grpc
-        image: quay.io/operator-framework/upstream-community-operators:latest
+        image: quay.io/operatorhubio/catalog:latest
         displayName: OperatorHub.io Operators
         publisher: OperatorHub.io
 
@@ -79,13 +61,13 @@
       apiVersion: operators.coreos.com/v1alpha1
       kind: Subscription
       metadata:
-        name: elastic-cloud-eck
+        name: elasticsearch-eck-operator-certified
         namespace: "{{ namespace }}"
       spec:
         channel: stable
         installPlanApproval: Automatic
-        name: elastic-cloud-eck
-        source: operatorhubio-operators
+        name: elasticsearch-eck-operator-certified
+        source: certified-operators
         sourceNamespace: openshift-marketplace
 
 - name: Subscribe to AMQ Interconnect Operator
@@ -97,7 +79,7 @@
         name: amq7-interconnect-operator
         namespace: "{{ namespace }}"
       spec:
-        channel: 1.2.0
+        channel: 1.10.x
         installPlanApproval: Automatic
         name: amq7-interconnect-operator
         source: redhat-operators


### PR DESCRIPTION
* Update stf-run-ci to match documentation
* Use certified-operators for ECK deployment

Update the manifests requested to align to our current documentation.

Cherry picked from commit dab6c1fba3cf90e901fd2957dbe8e004fdb10b30
Resolves: STF-581
