### PR TITLE
Create pattern for clouds.name verification (#272)

### DIFF
--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -48,8 +48,8 @@ spec:
                       description: Storage strategy. One of 'ephemeral' or 'persistent'. Persistent storage must be made available by the platform.
                       type: string
                       enum:
-                        - ephemeral
-                        - persistent
+                      - ephemeral
+                      - persistent
                     persistent:
                       properties:
                         storageClass:
@@ -94,8 +94,8 @@ spec:
                           description: Storage strategy. One of 'ephemeral' or 'persistent'. Persistent storage must be made available by the platform.
                           type: string
                           enum:
-                            - ephemeral
-                            - persistent
+                          - ephemeral
+                          - persistent
                         retention:
                           description: Time duration Prometheus shall retain data for. Default
                             is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)`
@@ -136,6 +136,9 @@ spec:
                         strategy:
                           description: Storage strategy. One of 'ephemeral' or 'persistent'. Persistent storage must be made available by the platform.
                           type: string
+                          enum:
+                          - ephemeral
+                          - persistent
                         persistent:
                           description: Persistent storage configuration for ElasticSearch
                           properties:
@@ -189,6 +192,7 @@ spec:
                 adminPassword:
                   description: Grafana admin password
                   type: string
+                  format: password
                 adminUser:
                   description: Grafana admin user
                   type: string
@@ -207,6 +211,7 @@ spec:
               name:
                 description: Name of the cloud object
                 type: string
+                pattern: ^[a-zA-Z0-9]{1,10}$
               metrics:
                 description: Metrics related configuration for this cloud object.
                 properties:
@@ -215,8 +220,12 @@ spec:
                     items:
                       properties:
                         collectorType:
-                          description: Set the collector type, value of 'ceilometer' or 'collectd'.
+                          description: Set the collector type, value of 'ceilometer', 'collectd' or 'sensubility'.
                           type: string
+                          enum:
+                          - ceilometer
+                          - collectd
+                          - sensubility
                         subscriptionAddress:
                           description: Address to subscribe on the data transport to receive telemetry.
                           type: string
@@ -237,8 +246,8 @@ spec:
                           description: Set the collector type, value of 'ceilometer' or 'collectd'.
                           type: string
                           enum:
-                            - ceilometer
-                            - collectd
+                          - ceilometer
+                          - collectd
                         subscriptionAddress:
                           description: Address to subscribe on the data transport to receive notifications.
                           type: string

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -98,6 +98,9 @@ spec:
                         strategy:
                           description: Storage strategy. One of 'ephemeral' or 'persistent'.
                             Persistent storage must be made available by the platform.
+                          enum:
+                          - ephemeral
+                          - persistent
                           type: string
                       type: object
                   type: object
@@ -188,8 +191,12 @@ spec:
                     items:
                       properties:
                         collectorType:
-                          description: Set the collector type, value of 'ceilometer'
-                            or 'collectd'.
+                          description: Set the collector type, value of 'ceilometer',
+                            'collectd' or 'sensubility'.
+                          enum:
+                          - ceilometer
+                          - collectd
+                          - sensubility
                           type: string
                         debugEnabled:
                           description: Enable console debugging. Default is 'false'.
@@ -203,6 +210,7 @@ spec:
                 type: object
               name:
                 description: Name of the cloud object
+                pattern: ^[a-zA-Z0-9]{1,10}$
                 type: string
             type: object
           type: array
@@ -223,6 +231,7 @@ spec:
               properties:
                 adminPassword:
                   description: Grafana admin password
+                  format: password
                   type: string
                 adminUser:
                   description: Grafana admin user


### PR DESCRIPTION
* Create pattern for clouds.name verification

Add a pattern configuration to the clouds.name CRD interface to limit
the available length and naming convention verification.

Adds some additional small verification components to the
ServiceTelemetry CRD.

Resolves: rhbz#2011603
Signed-off-by: Leif Madsen <lmadsen@redhat.com>

* Limit cloud name to 10 characters

Limit the cloud name to 10 characters to try and keep the total length
limit to 19 characters, combined with the ServiceTelemetry object name +
cloud name which is combined as part of the Smart Gateway instantiation.
A combined length of greater than 19 characters between the
ServiceTelemetry object name and the cloud name will result in a pod
name length of greater than 63 characters, resulting in it not being
scheduled.

* Fix typo and make enum alignment consistent

Cherry picked from commit b7d9e076c3358f0de4b1ffcf1a075b63c29720a9
