### PR TITLE
Verify ElasticSearch API exists

### DIFF
--- a/roles/servicetelemetry/tasks/component_clouds.yml
+++ b/roles/servicetelemetry/tasks/component_clouds.yml
@@ -49,6 +49,11 @@
     - this_cloud.events is defined
     - this_cloud.events.collectors is defined
     - this_cloud.events is iterable
+  # TODO: it should be possible to deploy the eventing SGs when ElasticSearch
+  # is not available, but currently the template for smartgateway_events
+  # expects to have information about a local ES instance on cluster.
+  # https://github.com/infrawatch/service-telemetry-operator/issues/274
+  when: has_elasticsearch_api | bool
 
 - name: Deploy Logs Smart Gateway instance
   vars:

--- a/roles/servicetelemetry/tasks/main.yml
+++ b/roles/servicetelemetry/tasks/main.yml
@@ -20,16 +20,18 @@
   include_tasks: component_servicemonitor.yml
 
 # --> backends.events
+- name: Check if we have elasticsearch CRD
+  set_fact:
+    has_elasticsearch_api: "{{ True if 'elasticsearch.k8s.elastic.co' in api_groups else False }}"
+
 - name: Deploy ElasticSearch events backend
   block:
-  # TODO: check for availability of elasticsearches.elasticsearch.k8s.elastic.co to
-  #       determine if we can create ElasticSearch and related certificates. Can't
-  #       directly look up the CustomResourceDefinition because it requires ClusterRole scope.
   - name: Setup Certificates for ElasticSearch
     include_tasks: component_certificates.yml
 
   - name: Setup ElasticSearch
     include_tasks: component_elasticsearch.yml
+  when: has_elasticsearch_api | bool
 
 # --> alerting
 - name: Create Alertmanager instance

--- a/roles/servicetelemetry/tasks/pre.yml
+++ b/roles/servicetelemetry/tasks/pre.yml
@@ -1,9 +1,16 @@
+- name: Clear the fact cache before looking up cluster information
+  meta: clear_facts
+
 - name: Get information about the cluster
   set_fact:
     api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
   when:
   - not is_openshift
   - not is_k8s
+
+- name: Show existing API groups available to us
+  debug:
+    var: api_groups
 
 - name: Determine the cluster type
   set_fact:


### PR DESCRIPTION
Verify the ElasticSearch API exists before executing changes on the
cluster that rely on Elastic Cloud on Kubernetes Operator to exist.

Clear out the fact cache before looking up the available api_groups on
the cluster, otherwise adding/removing the *.k8s.elastic.co can cause
issues due to fact caching in Ansible.

Wrap logic that requests an ElasticSearch instance and the eventing
Smart Gateways to verify the 'has_elasticsearch_api' parameter is set to
a value of true, otherwise, skip those steps.

Closes: rhbz#1959166
