### PR TITLE
Align deployments to cloud1

### DIFF
--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -47,21 +47,21 @@ spec:
       metrics:
         collectors:
           - collectorType: collectd
-            subscriptionAddress: collectd/telemetry
+            subscriptionAddress: collectd/cloud1-telemetry
             debugEnabled: false
           - collectorType: ceilometer
-            subscriptionAddress: anycast/ceilometer/metering.sample
+            subscriptionAddress: anycast/ceilometer/cloud1-metering.sample
             debugEnabled: false
           - collectorType: sensubility
-            subscriptionAddress: sensubility/telemetry
+            subscriptionAddress: sensubility/cloud1-telemetry
             debugEnabled: false
       events:
         collectors:
           - collectorType: collectd
-            subscriptionAddress: collectd/notify
+            subscriptionAddress: collectd/cloud1-notify
             debugEnabled: false
           - collectorType: ceilometer
-            subscriptionAddress: anycast/ceilometer/event.sample
+            subscriptionAddress: anycast/ceilometer/cloud1-event.sample
             debugEnabled: false
   graphing:
     enabled: false

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -75,12 +75,12 @@ metadata:
                     {
                       "collectorType": "collectd",
                       "debugEnabled": false,
-                      "subscriptionAddress": "collectd/notify"
+                      "subscriptionAddress": "collectd/cloud1-notify"
                     },
                     {
                       "collectorType": "ceilometer",
                       "debugEnabled": false,
-                      "subscriptionAddress": "anycast/ceilometer/event.sample"
+                      "subscriptionAddress": "anycast/ceilometer/cloud1-event.sample"
                     }
                   ]
                 },
@@ -89,17 +89,17 @@ metadata:
                     {
                       "collectorType": "collectd",
                       "debugEnabled": false,
-                      "subscriptionAddress": "collectd/telemetry"
+                      "subscriptionAddress": "collectd/cloud1-telemetry"
                     },
                     {
                       "collectorType": "ceilometer",
                       "debugEnabled": false,
-                      "subscriptionAddress": "anycast/ceilometer/metering.sample"
+                      "subscriptionAddress": "anycast/ceilometer/cloud1-metering.sample"
                     },
                     {
                       "collectorType": "sensubility",
                       "debugEnabled": false,
-                      "subscriptionAddress": "sensubility/telemetry"
+                      "subscriptionAddress": "sensubility/cloud1-telemetry"
                     }
                   ]
                 },

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -86,26 +86,26 @@ servicetelemetry_defaults:
       metrics:
         collectors:
           - collector_type: collectd
-            subscription_address: collectd/telemetry
+            subscription_address: collectd/cloud1-telemetry
             debug_enabled: false
           - collector_type: ceilometer
-            subscription_address: anycast/ceilometer/metering.sample
+            subscription_address: anycast/ceilometer/cloud1-metering.sample
             debug_enabled: false
           - collector_type: sensubility
-            subscription_address: sensubility/telemetry
+            subscription_address: sensubility/cloud1-telemetry
             debug_enabled: false
       events:
         collectors:
           - collector_type: collectd
-            subscription_address: collectd/notify
+            subscription_address: collectd/cloud1-notify
             debug_enabled: false
           - collector_type: ceilometer
-            subscription_address: anycast/ceilometer/event.sample
+            subscription_address: anycast/ceilometer/cloud1-event.sample
             debug_enabled: false
       logs:
         collectors:
           - collector_type: rsyslog
-            subscription_address: rsyslog/logs
+            subscription_address: rsyslog/cloud1-logs
             debug_enabled: false
 
 

--- a/tests/infrared/README.md
+++ b/tests/infrared/README.md
@@ -9,7 +9,6 @@ to an STF instance all on one (large) baremetal machine.
 1. Set VIRTHOST and have key based SSH access to root@$VIRTHOST
 1. Set AMQP_HOST and AMQP_PORT
 1. Run `infrared-openstack.sh` to install OSP on $VIRTHOST
-(Cry when it fails; try to pick up where it left off)
 
 ## Verification
 

--- a/tests/smoketest/ceilometer_publish.py
+++ b/tests/smoketest/ceilometer_publish.py
@@ -295,8 +295,8 @@ def publish_data(metering_connection, events_connection):
 
 if __name__ == '__main__':
     qdr_connection = sys.argv[1] if len(sys.argv) > 1 else '127.0.0.1:5672'
-    metering_setting = sys.argv[2] if len(sys.argv) > 2 else 'driver=amqp&topic=metering'
-    events_setting = sys.argv[3] if len(sys.argv) > 3 else 'driver=amqp&topic=event'
+    metering_setting = sys.argv[2] if len(sys.argv) > 2 else 'driver=amqp&topic=cloud1-metering'
+    events_setting = sys.argv[3] if len(sys.argv) > 3 else 'driver=amqp&topic=cloud1-event'
 
     metering_connection = f'notifier://{qdr_connection}/?{metering_setting}'
     events_connection = f'notifier://{qdr_connection}/?{events_setting}'

--- a/tests/smoketest/collectd-sensubility.conf
+++ b/tests/smoketest/collectd-sensubility.conf
@@ -11,7 +11,7 @@ checks={"check-container-health":{"command":"cat /healthcheck.log","handlers":[]
 
 [amqp1]
 connection=amqp://default-interconnect.<<NAMESPACE>>.svc:5671
-results_channel=sensubility/telemetry
+results_channel=sensubility/cloud1-telemetry
 client_name=smoketest.redhat.com
 results_format=smartgateway
 

--- a/tests/smoketest/minimal-collectd.conf.template
+++ b/tests/smoketest/minimal-collectd.conf.template
@@ -14,11 +14,11 @@ LoadPlugin amqp1
     Host "default-interconnect"
     Port "5671"
     Address "collectd"
-    <Instance "telemetry">
+    <Instance "cloud1-telemetry">
         Format JSON
         PreSettle false
     </Instance>
-    <Instance "notify">
+    <Instance "cloud1-notify">
         Format JSON
         PreSettle false
         Notify true

--- a/tests/smoketest/smoketest_ceilometer_entrypoint.sh
+++ b/tests/smoketest/smoketest_ceilometer_entrypoint.sh
@@ -12,7 +12,7 @@ POD=$(hostname)
 echo "*** [INFO] My pod is: ${POD}"
 
 # Run ceilometer_publisher script
-python3 /ceilometer_publish.py default-interconnect:5671 'driver=amqp&topic=metering' 'driver=amqp&topic=event'
+python3 /ceilometer_publish.py default-interconnect:5671 'driver=amqp&topic=cloud1-metering' 'driver=amqp&topic=cloud1-event'
 
 # Sleeping to produce data
 echo "*** [INFO] Sleeping for 20 seconds to produce all metrics and events"

--- a/tests/smoketest/smoketest_job.yaml.template
+++ b/tests/smoketest/smoketest_job.yaml.template
@@ -37,7 +37,7 @@ spec:
           subPath: smoketest_collectd_entrypoint.sh
         securityContext:
           allowPrivilegeEscalation: false
-            
+
       - name: smoketest-ceilometer
         image: quay.io/tripleomaster/openstack-ceilometer-notification:current-tripleo
         command:


### PR DESCRIPTION
Align testing and default configurations to a unified subscription
address and naming. Smoke tests, test cloud deployment scripts and
default ServiceTelemetry object are now populated with a standard naming
configuration.
