### PR TITLE
Smoketest and CI fixes (#282)

### DIFF
--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -16,41 +16,43 @@
 # Generate an array of cloud names to use
 NUMCLOUDS=${NUMCLOUDS:-1}
 CLOUDNAMES=()
+OCP_PROJECT=${OCP_PROJECT:-}
 
 CLEANUP=${CLEANUP:-true}
 
 for ((i=1; i<=NUMCLOUDS; i++)); do
   NAME="smoke${i}"
-  CLOUDNAMES+=(${NAME})
+  CLOUDNAMES+=("${NAME}")
 done
 REL=$(dirname "$0")
 
-if [ -z ${OCP_PROJECT+x} ]; then
-    oc project $OCP_PROJECT
+if [ -n "${OCP_PROJECT}" ]; then
+    oc project "$OCP_PROJECT"
 else
     OCP_PROJECT=$(oc project -q)
 fi
 
+echo "*** [INFO] Working in project ${OCP_PROJECT}"
 
 echo "*** [INFO] Getting ElasticSearch authentication password"
 ELASTICSEARCH_AUTH_PASS=$(oc get secret elasticsearch-es-elastic-user -ogo-template='{{ .data.elastic | base64decode }}')
 
 echo "*** [INFO] Setting namepsace for collectd-sensubility config"
-sed "s/<<NAMESPACE>>/${OCP_PROJECT}/g" ${REL}/collectd-sensubility.conf > /tmp/collectd-sensubility.conf
+sed "s/<<NAMESPACE>>/${OCP_PROJECT}/g" "${REL}/collectd-sensubility.conf" > /tmp/collectd-sensubility.conf
 
 echo "*** [INFO] Creating configmaps..."
 oc delete configmap/stf-smoketest-healthcheck-log configmap/stf-smoketest-collectd-config configmap/stf-smoketest-sensubility-config configmap/stf-smoketest-collectd-entrypoint-script configmap/stf-smoketest-ceilometer-publisher configmap/stf-smoketest-ceilometer-entrypoint-script job/stf-smoketest || true
-oc create configmap stf-smoketest-healthcheck-log --from-file ${REL}/healthcheck.log
-oc create configmap stf-smoketest-collectd-config --from-file ${REL}/minimal-collectd.conf.template
+oc create configmap stf-smoketest-healthcheck-log --from-file "${REL}/healthcheck.log"
+oc create configmap stf-smoketest-collectd-config --from-file "${REL}/minimal-collectd.conf.template"
 oc create configmap stf-smoketest-sensubility-config --from-file /tmp/collectd-sensubility.conf
-oc create configmap stf-smoketest-collectd-entrypoint-script --from-file ${REL}/smoketest_collectd_entrypoint.sh
-oc create configmap stf-smoketest-ceilometer-publisher --from-file ${REL}/ceilometer_publish.py
-oc create configmap stf-smoketest-ceilometer-entrypoint-script --from-file ${REL}/smoketest_ceilometer_entrypoint.sh
+oc create configmap stf-smoketest-collectd-entrypoint-script --from-file "${REL}/smoketest_collectd_entrypoint.sh"
+oc create configmap stf-smoketest-ceilometer-publisher --from-file "${REL}/ceilometer_publish.py"
+oc create configmap stf-smoketest-ceilometer-entrypoint-script --from-file "${REL}/smoketest_ceilometer_entrypoint.sh"
 
 echo "*** [INFO] Creating smoketest jobs..."
 oc delete job -l app=stf-smoketest
 for NAME in "${CLOUDNAMES[@]}"; do
-    oc create -f <(sed -e "s/<<CLOUDNAME>>/${NAME}/;s/<<ELASTICSEARCH_AUTH_PASS>>/${ELASTICSEARCH_AUTH_PASS}/" ${REL}/smoketest_job.yaml.template)
+    oc create -f <(sed -e "s/<<CLOUDNAME>>/${NAME}/;s/<<ELASTICSEARCH_AUTH_PASS>>/${ELASTICSEARCH_AUTH_PASS}/" "${REL}/smoketest_job.yaml.template")
 done
 
 echo "*** [INFO] Triggering an alertmanager notification..."
@@ -100,6 +102,8 @@ oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-meter" -o jsonpath='
 oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-meter" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
 oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-event" -o jsonpath='{.items[0].metadata.name}')" -c bridge
 oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-event" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
+oc logs "$(oc get pod -l "smart-gateway=default-cloud1-sens-meter" -o jsonpath='{.items[0].metadata.name}')" -c bridge
+oc logs "$(oc get pod -l "smart-gateway=default-cloud1-sens-meter" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
 echo
 
 echo "*** [INFO] Logs from smart gateway operator..."
@@ -120,7 +124,7 @@ echo
 
 echo "*** [INFO] Cleanup resources..."
 if $CLEANUP; then
-    oc delete job/stf-smoketest-${NAME}
+    oc delete "job/stf-smoketest-${NAME}"
 fi
 echo
 

--- a/tests/smoketest/smoketest_ceilometer_entrypoint.sh
+++ b/tests/smoketest/smoketest_ceilometer_entrypoint.sh
@@ -12,7 +12,7 @@ POD=$(hostname)
 echo "*** [INFO] My pod is: ${POD}"
 
 # Run ceilometer_publisher script
-python3 /ceilometer_publish.py default-interconnect:5671 driver=amqp&topic=metric driver=amqp&topic=event
+python3 /ceilometer_publish.py default-interconnect:5671 'driver=amqp&topic=metering' 'driver=amqp&topic=event'
 
 # Sleeping to produce data
 echo "*** [INFO] Sleeping for 20 seconds to produce all metrics and events"


### PR DESCRIPTION
* Fix issues with OCP_PROJECT in smoketest.sh

Fix issues with OCP_PROJECT not being set and verified properly in the
smoketest.sh script. Instead of relying on -z and word expansion,
explicitly set the OCP_PROJECT variable, substituting the value if
OCP_PROJECT has been previously set through and environment variable,
otherwise set the value to empty.

Adjust the 'if' statement to look for non-zero length to either change
to the project (implied by setting the project name), or use the
existing project returned from 'oc project -q' as the working project.

Additional fixes for the smoketest.sh script to bring it in compliance
with Shellcheck suggestions.

* Don't parse ampersand in bash script

Fixes a bug where passing parameters from the ceilometer smoketest
entrypoint was not working because ampersands were being used without
quoting. This resulted in the passed parameters getting ignored and the
defaults used.

In this patch you can see we were passing 'metric' in the entrypoint
script. This was being ignored, but the smoketest worked because the
defaults resulting in the metering.sample address being used. Since this
is what the Service Telemetry Operator uses by default, we never saw the
incorrect address being specified, which would have resulted in the
smoketests failing.

By wrapping the parameters in single quotes, we can now modify this to
be a different address if necessary. The 'metric' address name has also
been updated to 'metering' as expected by the Service Telemetry
Operator.

Thanks to Paul Leimer with helping to track this down!