### PR TITLE
Clean up storageClass selector issues (#289)

### DIFF
--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -18,22 +18,22 @@ Variables
 Not all variables are listed here, but these are the most common ones you might
 choose to override:
 
-| Parameter name                                  | Values          | Default                                          | Description                                                                                           |
-| ------------------------------                  | ------------    | ---------                                        | ------------------------------------                                                                  |
-| `__deploy_stf`                                  | {true,false}    | true                                             | Whether to deploy an instance of STF                                                                  |
-| `__local_build_enabled`                         | {true,false}    | true                                             | Whether to deploySTF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch` |
-| `prometheus_webhook_snmp_branch`                | <git_branch>    | master                                           | Which Prometheus Webhook SNMP git branch to checkout                                                  |
-| `sgo_branch`                                    | <git_branch>    | master                                           | Which Smart Gateway Operator git branch to checkout                                                   |
-| `sg_branch`                                     | <git_branch>    | master                                           | Which Smart Gateway git branch to checkout                                                            |
-| `sg_core_branch`                                | <git_branch>    | master                                           | Which Smart Gateway Core git branch to checkout                                                       |
-| `sg_bridge_branch`                              | <git_branch>    | master                                           | Which Smart Gateway Bridge git branch to checkout                                                     |
-| `__service_telemetry_events_enabled`            | {true,false}    | true                                             | Whether to enable events support in ServiceTelemetry                                                  |
-| `__service_telemetry_high_availability_enabled` | {true,false}    | false                                            | Whether to enable high availability support in ServiceTelemetry                                       |
-| `__service_telemetry_metrics_enabled`           | {true,false}    | true                                             | Whether to enable metrics support in ServiceTelemetry                                                 |
-| `__service_telemetry_storage_ephemeral_enabled` | {true,false}    | false                                            | Whether to enable ephemeral storage support in ServiceTelemetry                                       |
-| `__service_telemetry_snmptraps_enabled`         | {true,false}    | true                                             | Whether to enable snmptraps delivery via Alertmanager receiver (prometheus-webhook-snmp)              |
-| `__internal_registry_path`                      | <registry_path> | image-registry.openshift-image-registry.svc:5000 | Path to internal registry for image path                                                              |
-
+| Parameter name                                         | Values          | Default                                          | Description                                                                                           |
+| ------------------------------                         | ------------    | ---------                                        | ------------------------------------                                                                  |
+| `__deploy_stf`                                         | {true,false}    | true                                             | Whether to deploy an instance of STF                                                                  |
+| `__local_build_enabled`                                | {true,false}    | true                                             | Whether to deploySTF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch` |
+| `prometheus_webhook_snmp_branch`                       | <git_branch>    | master                                           | Which Prometheus Webhook SNMP git branch to checkout                                                  |
+| `sgo_branch`                                           | <git_branch>    | master                                           | Which Smart Gateway Operator git branch to checkout                                                   |
+| `sg_branch`                                            | <git_branch>    | master                                           | Which Smart Gateway git branch to checkout                                                            |
+| `sg_core_branch`                                       | <git_branch>    | master                                           | Which Smart Gateway Core git branch to checkout                                                       |
+| `sg_bridge_branch`                                     | <git_branch>    | master                                           | Which Smart Gateway Bridge git branch to checkout                                                     |
+| `__service_telemetry_events_enabled`                   | {true,false}    | true                                             | Whether to enable events support in ServiceTelemetry                                                  |
+| `__service_telemetry_high_availability_enabled`        | {true,false}    | false                                            | Whether to enable high availability support in ServiceTelemetry                                       |
+| `__service_telemetry_metrics_enabled`                  | {true,false}    | true                                             | Whether to enable metrics support in ServiceTelemetry                                                 |
+| `__service_telemetry_storage_ephemeral_enabled`        | {true,false}    | false                                            | Whether to enable ephemeral storage support in ServiceTelemetry                                       |
+| `__service_telemetry_snmptraps_enabled`                | {true,false}    | true                                             | Whether to enable snmptraps delivery via Alertmanager receiver (prometheus-webhook-snmp)              |
+| `__service_telemetry_storage_persistent_storage_class` | <storage_class> | <undefined>                                      | Set a custom storageClass to override the default provided by OpenShift platform                      |
+| `__internal_registry_path`                             | <registry_path> | image-registry.openshift-image-registry.svc:5000 | Path to internal registry for image path                                                              |
 
 Example Playbook
 ----------------

--- a/build/stf-run-ci/tasks/deploy_stf.yml
+++ b/build/stf-run-ci/tasks/deploy_stf.yml
@@ -13,6 +13,10 @@
           alertmanager:
             storage:
               strategy: {{ "ephemeral" if __service_telemetry_storage_ephemeral_enabled else "persistent" }}
+      {% if __service_telemetry_storage_persistent_storage_class is defined %}
+              persistent:
+                storageClass: {{ __service_telemetry_storage_persistent_storage_class }}
+      {% endif %}
             receivers:
               snmpTraps:
                 enabled: {{ __service_telemetry_snmptraps_enabled }}
@@ -22,11 +26,19 @@
               enabled: {{ __service_telemetry_events_enabled }}
               storage:
                 strategy: {{ "ephemeral" if __service_telemetry_storage_ephemeral_enabled else "persistent" }}
+      {% if __service_telemetry_storage_persistent_storage_class is defined %}
+                persistent:
+                  storageClass: {{ __service_telemetry_storage_persistent_storage_class }}
+      {% endif %}
           metrics:
             prometheus:
               enabled: {{ __service_telemetry_metrics_enabled }}
               storage:
                 strategy: {{ "ephemeral" if __service_telemetry_storage_ephemeral_enabled else "persistent" }}
+      {% if __service_telemetry_storage_persistent_storage_class is defined %}
+                persistent:
+                  storageClass: {{ __service_telemetry_storage_persistent_storage_class }}
+      {% endif %}
         highAvailability:
           enabled: {{ __service_telemetry_high_availability_enabled }}
   when: service_telemetry_manifest is not defined
@@ -39,4 +51,3 @@
   k8s:
     definition:
       '{{ service_telemetry_manifest }}'
-

--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -9,7 +9,6 @@ spec:
       storage:
         strategy: persistent
         persistent:
-          storageSelector: {}
           pvcStorageRequest: 20G
         receivers:
           snmpTraps:
@@ -24,7 +23,6 @@ spec:
           strategy: persistent
           retention: 24h
           persistent:
-            storageSelector: {}
             pvcStorageRequest: 20G
     events:
       elasticsearch:
@@ -32,7 +30,6 @@ spec:
         storage:
           strategy: persistent
           persistent:
-            storageSelector: {}
             pvcStorageRequest: 20Gi
   graphing:
     enabled: false

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -15,8 +15,7 @@ metadata:
               "alertmanager": {
                 "storage": {
                   "persistent": {
-                    "pvcStorageRequest": "20G",
-                    "storageSelector": {}
+                    "pvcStorageRequest": "20G"
                   },
                   "receivers": {
                     "snmpTraps": {
@@ -35,8 +34,7 @@ metadata:
                   "enabled": false,
                   "storage": {
                     "persistent": {
-                      "pvcStorageRequest": "20Gi",
-                      "storageSelector": {}
+                      "pvcStorageRequest": "20Gi"
                     },
                     "strategy": "persistent"
                   }
@@ -48,8 +46,7 @@ metadata:
                   "scrapeInterval": "10s",
                   "storage": {
                     "persistent": {
-                      "pvcStorageRequest": "20G",
-                      "storageSelector": {}
+                      "pvcStorageRequest": "20G"
                     },
                     "retention": "24h",
                     "strategy": "persistent"

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -14,7 +14,6 @@ servicetelemetry_defaults:
         strategy: persistent
         persistent:
           storage_class: ""
-          storage_selector: {}
           pvc_storage_request: 20G
       receivers:
         snmp_traps:
@@ -32,7 +31,6 @@ servicetelemetry_defaults:
           retention: 24h
           persistent:
             storage_class: ""
-            storage_selector: {}
             pvc_storage_request: 20G
     events:
       elasticsearch:
@@ -42,7 +40,6 @@ servicetelemetry_defaults:
           strategy: persistent
           persistent:
             storage_class: ""
-            storage_selector: {}
             pvc_storage_request: 20Gi
 
   transports:

--- a/roles/servicetelemetry/templates/manifest_alertmanager.j2
+++ b/roles/servicetelemetry/templates/manifest_alertmanager.j2
@@ -18,7 +18,7 @@ spec:
         resources:
           requests:
             storage: {{ servicetelemetry_vars.alerting.alertmanager.storage.persistent.pvc_storage_request }}
-{% if servicetelemetry_vars.alerting.alertmanager.storage.persistent.storage_selector %}
+{% if servicetelemetry_vars.alerting.alertmanager.storage.persistent.storage_selector is defined %}
         selector: {{ servicetelemetry_vars.alerting.alertmanager.storage.persistent.storage_selector }}
 {% endif %}
 {% if servicetelemetry_vars.alerting.alertmanager.storage.persistent.storage_class | length %}

--- a/roles/servicetelemetry/templates/manifest_elasticsearch.j2
+++ b/roles/servicetelemetry/templates/manifest_elasticsearch.j2
@@ -34,7 +34,7 @@ spec:
           resources:
             requests:
               storage: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.pvc_storage_request }}
-{%   if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector %}
+{%   if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector is defined %}
           selector: {{ servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_selector }}
 {%   endif %}
 {%   if servicetelemetry_vars.backends.events.elasticsearch.storage.persistent.storage_class | length %}

--- a/roles/servicetelemetry/templates/manifest_prometheus.j2
+++ b/roles/servicetelemetry/templates/manifest_prometheus.j2
@@ -28,7 +28,7 @@ spec:
         resources:
           requests:
             storage: {{ servicetelemetry_vars.backends.metrics.prometheus.storage.persistent.pvc_storage_request }}
-{% if servicetelemetry_vars.backends.metrics.prometheus.storage.persistent.storage_selector %}
+{% if servicetelemetry_vars.backends.metrics.prometheus.storage.persistent.storage_selector is defined %}
         selector: {{ servicetelemetry_vars.backends.metrics.prometheus.storage.persistent.storage_selector }}
 {% endif %}
 {% if servicetelemetry_vars.backends.metrics.prometheus.storage.persistent.storage_class | length %}


### PR DESCRIPTION
Clean up storageClass selector issues which can cause PVCs to fail when
the backing driver does not support a selector. Adds a new parameter to
the stf-run-ci so that a storageClass value can be passed to the
deployment. Removes the storage_selector defaults from the
servicetelemetry role so that selectors aren't always defined when not
specified.

Cherry picked from commit 73e0194e8bce04e0426969cd229020a758ab1dcd
