### PR TITLE
Use openstack-monitoring as default namespace

### DIFF
--- a/build/ocp_metadata.sh
+++ b/build/ocp_metadata.sh
@@ -5,7 +5,7 @@
 # NOTE: Strongly suggest that the destination tag in OCP is "latest" for testing
 # purposes, otherwise additional procedures are required to force a pull of an
 # updated container image
-OCP_PROJECT=${OCP_PROJECT:-service-telemetry}
+OCP_PROJECT=${OCP_PROJECT:-openstack-monitoring}
 OCP_REGISTRY=${OCP_REGISTRY:-$(oc registry info)}
 OCP_REGISTRY_INTERNAL=${OCP_REGISTRY_INTERNAL:-$(oc registry info --internal=true)}
 OCP_TAG=${OCP_TAG:-latest}

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -29,7 +29,7 @@ prometheus_webhook_snmp_image_tag: latest
 loki_operator_image_tag: latest
 new_operator_sdk_version: v1.5.0
 new_go_version: 1.16.3
-namespace: service-telemetry
+namespace: openstack-monitoring
 
 # Set a default commit hash to clone for loki-operator to freeze
 # the operator developement.

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Setup default values
   set_fact:
     branch: "{{ working_branch | default('master') }}"
-    namespace: "{{ working_namespace | default('service-telemetry') }}"
+    namespace: "{{ working_namespace | default('openstack-monitoring') }}"
 
 - name: Set default image paths for local builds
   set_fact:

--- a/deploy/alerts/alerts.yaml
+++ b/deploy/alerts/alerts.yaml
@@ -6,7 +6,6 @@ metadata:
     prometheus: stf-default
     role: alert-rules
   name: prometheus-alarm-rules
-  namespace: service-telemetry
 spec:
   groups:
     - name: ./openstack.rules

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -138,7 +138,7 @@ metadata:
       Service Telemetry platform for telco grade monitoring.
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     olm.skipRange: '>=<<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>'
-    operatorframework.io/suggested-namespace: service-telemetry
+    operatorframework.io/suggested-namespace: openstack-monitoring
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible
     repository: https://github.com/infrawatch/service-telemetry-operator

--- a/deploy/operator_group.yaml
+++ b/deploy/operator_group.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: service-telemetry-operator-group
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   targetNamespaces:
-  - service-telemetry
+  - openstack-monitoring

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,7 +51,7 @@ buildah login --tls-verify=false -u openshift -p "${TOKEN}" "${REGISTRY}"
 Create a working project for the application.
 
 ```
-oc new-project service-telemetry
+oc new-project openstack-monitoring
 ```
 
 ## Build the operator
@@ -101,7 +101,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: amq7-interconnect-operator
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   channel: 1.2.0
   installPlanApproval: Automatic
@@ -163,7 +163,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: smartgateway-operator
-  namespace: service-telemetry
+  namespace: openstack-monitoring
 spec:
   channel: stable
   installPlanApproval: Automatic
@@ -197,7 +197,7 @@ oc apply -f deploy/olm-catalog/service-telemetry-operator/${CSV_VERSION}/infra.w
 
 oc apply -f <(sed "\
     s|image: .\+/service-telemetry-operator:.\+$|image: ${INTERNAL_REGISTRY}/service-telemetry/service-telemetry-operator:latest|g;
-    s|namespace: placeholder|namespace: service-telemetry|g"\
+    s|namespace: placeholder|namespace: openstack-monitoring|g"\
     "deploy/olm-catalog/service-telemetry-operator/${CSV_VERSION}/service-telemetry-operator.v${CSV_VERSION}.clusterserviceversion.yaml")
 ```
 

--- a/tests/performance-test/dashboards/perftest-dashboard.yaml
+++ b/tests/performance-test/dashboards/perftest-dashboard.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: grafana
   name: perftest-dashboard
-  namespace: service-telemetry
 spec:
   name: perftest-dashboard.json
   json: |

--- a/tests/performance-test/dashboards/prom2-dashboard.yaml
+++ b/tests/performance-test/dashboards/prom2-dashboard.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: grafana
   name: prom2-dashboard
-  namespace: service-telemetry
 spec:
   name: prom2-dashboard.json
   json: |

--- a/tests/performance-test/deploy/datasources.yaml
+++ b/tests/performance-test/deploy/datasources.yaml
@@ -2,7 +2,6 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDataSource
 metadata:
   name: performance-test-datasource
-  namespace: service-telemetry
 spec:
   datasources:
     - name: OCPPrometheus

--- a/tests/performance-test/job.yaml
+++ b/tests/performance-test/job.yaml
@@ -14,9 +14,9 @@ spec:
       restartPolicy: Never
       containers:
       - name: generator
-        #image: image-registry.openshift-image-registry.svc:5000/service-telemetry/generator:latest
+        #image: image-registry.openshift-image-registry.svc:5000/openstack-monitoring/generator:latest
         image: quay.io/infrawatch/generator:latest
-        command: [ '/gen', '-i','generator','SLEEP','-c',"COUNT",'-t','10','-o','5','-m','100','-a','collectd/telemetry', 'default-interconnect.service-telemetry.svc', '5672']
+        command: [ '/gen', '-i','generator','SLEEP','-c',"COUNT",'-t','10','-o','5','-m','100','-a','collectd/telemetry', 'default-interconnect', '5672']
         resources:
           limits:
             memory: "1Gi"

--- a/tests/performance-test/legacy/dashboards/legacy-perftest-dashboard.yaml
+++ b/tests/performance-test/legacy/dashboards/legacy-perftest-dashboard.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: grafana
   name: perftest-dashboard-legacy
-  namespace: service-telemetry
 spec:
   name: perftest-dashboard.json
   json: |

--- a/tests/performance-test/legacy/dashboards/prom2-dashboard.yaml
+++ b/tests/performance-test/legacy/dashboards/prom2-dashboard.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: grafana
   name: prom2-dashboard
-  namespace: service-telemetry
 spec:
   name: prom2-dashboard.json
   json: |

--- a/tests/performance-test/legacy/deploy/qdr-servicemonitor.yml
+++ b/tests/performance-test/legacy/deploy/qdr-servicemonitor.yml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: default-interconnect
-  namespace: service-telemetry
   labels:
     app: smart-gateway
 spec:

--- a/tests/smoketest/README.md
+++ b/tests/smoketest/README.md
@@ -9,7 +9,7 @@ validate our builds before merging changes to this repo.
 
 ## Usage
 
-1. Have `oc` pointing at your service-telemetry project and run `./smoketest.sh`
+1. Have `oc` pointing at your openstack-monitoring project and run `./smoketest.sh`
 1. Run `oc get jobs` and check the result of the stf-smoketest job
 1. (If necessary) Check the logs of the stf-smoketest pod
 


### PR DESCRIPTION
Migrate to using openstack-monitoring as the default namespace. The
namespace service-telemetry doesn't mean a lot at first glance. The use
of openstack-monitoring makes it more clear the purpose of the
components in the namespace.
