### PR TITLE
TLS + token auth support SG metrics endpoint

### DIFF
--- a/roles/servicetelemetry/tasks/base_smartgateway.yml
+++ b/roles/servicetelemetry/tasks/base_smartgateway.yml
@@ -5,3 +5,7 @@
 - name: Deploy instance of Smart Gateway
   k8s:
     definition: "{{ lookup('template', manifest) | from_yaml }}"
+
+- name: Deploy SG-specific ServiceMonitor for metrics SGs
+  include_tasks: component_servicemonitor.yml
+  when: data_type == 'metrics'

--- a/roles/servicetelemetry/tasks/component_servicemonitor.yml
+++ b/roles/servicetelemetry/tasks/component_servicemonitor.yml
@@ -1,12 +1,12 @@
-- name: Create default Service Monitor manifest
+- name: Create SG-specific Service Monitor manifest
   set_fact:
-    servicemonitor_manifest: |
+    sg_specific_servicemonitor_manifest: |
       apiVersion: monitoring.coreos.com/v1
       kind: ServiceMonitor
       metadata:
         labels:
           app: smart-gateway
-        name: '{{ meta.name }}'
+        name: '{{ this_smartgateway }}'
         namespace: '{{ meta.namespace }}'
       spec:
         endpoints:
@@ -27,14 +27,26 @@
               - action: labeldrop
                 regex: publisher
                 sourcelabels: []
-            port: prom-http
+            port: prom-https
+            scheme: https
+            tlsConfig:
+              caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+              serverName: "{{ this_smartgateway }}.{{ meta.namespace }}.svc"
+            bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
         selector:
           matchLabels:
             app: smart-gateway
-  when: servicemonitor_manifest is not defined
+            smart-gateway: "{{ this_smartgateway }}"
 
 - name: Create ServiceMonitor to scrape Smart Gateway
   k8s:
     state: '{{ "present" if servicetelemetry_vars.backends.metrics.prometheus.enabled else "absent" }}'
     definition:
+      '{{ sg_specific_servicemonitor_manifest }}'
+
+- name: Create additional serviceMonitor if provided
+  k8s:
+    state: '{{ "present" if servicetelemetry_vars.backends.metrics.prometheus.enabled else "absent" }}'
+    definition:
       '{{ servicemonitor_manifest }}'
+  when: servicemonitor_manifest is defined

--- a/roles/servicetelemetry/tasks/main.yml
+++ b/roles/servicetelemetry/tasks/main.yml
@@ -25,10 +25,6 @@
   - name: Create Prometheus instance
     include_tasks: component_prometheus.yml
 
-  # create Service Monitor instance
-  - name: Create Service Monitor instance
-    include_tasks: component_servicemonitor.yml
-
   # --> alerting
   - name: Create Alertmanager instance
     include_tasks: component_alertmanager.yml

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -13,7 +13,7 @@ spec:
   size: {{ smartgateway_deployment_size }}
   applications:
   - config: |
-      host: 0.0.0.0
+      host: 127.0.0.1
       port: 8081
       withTimeStamp: true
     name: prometheus
@@ -22,10 +22,10 @@ spec:
   services:
   - name: {{ this_smartgateway }}
     ports:
-    - name: prom-http
-      port: 8081
+    - name: prom-https
+      port: 8083
       protocol: TCP
-      targetPort: 8081
+      targetPort: 8083
   transports:
   - config: |
       path: /tmp/smartgateway

--- a/tests/performance-test/dashboards/perftest-dashboard.yaml
+++ b/tests/performance-test/dashboards/perftest-dashboard.yaml
@@ -481,7 +481,7 @@ spec:
             "ymax": null,
             "ymin": null
           },
-          "tableColumn": "sg_total_msg_received_count{endpoint=\"prom-http\", service=\"default-cloud1-coll-meter-smartgateway\", source=\"SG\"}",
+          "tableColumn": "sg_total_msg_received_count{endpoint=\"prom-https\", service=\"default-cloud1-coll-meter-smartgateway\", source=\"SG\"}",
           "targets": [
             {
               "expr": "sg_total_msg_received_count",
@@ -780,7 +780,7 @@ spec:
             "ymax": null,
             "ymin": null
           },
-          "tableColumn": "collectd_qpid_router_status{endpoint=\"prom-http\", service=\"default-cloud1-ceil-meter-smartgateway\", source=\"Metric Listener\"}",
+          "tableColumn": "collectd_qpid_router_status{endpoint=\"prom-https\", service=\"default-cloud1-ceil-meter-smartgateway\", source=\"Metric Listener\"}",
           "targets": [
             {
               "expr": "collectd_qpid_router_status",
@@ -876,7 +876,7 @@ spec:
             "ymax": null,
             "ymin": null
           },
-          "tableColumn": "sg_total_metric_decode_count{endpoint=\"prom-http\", service=\"default-cloud1-coll-meter-smartgateway\", source=\"SG\"}",
+          "tableColumn": "sg_total_metric_decode_count{endpoint=\"prom-https\", service=\"default-cloud1-coll-meter-smartgateway\", source=\"SG\"}",
           "targets": [
             {
               "expr": "sg_total_metric_decode_count",

--- a/tests/smoketest/smoketest_collectd_entrypoint.sh
+++ b/tests/smoketest/smoketest_collectd_entrypoint.sh
@@ -47,7 +47,7 @@ echo; echo
 
 # The egrep exit code is the result of the test and becomes the container/pod/job exit code
 echo "*** [INFO] Checking for returned CPU metrics..."
-grep -E '"result":\[{"metric":{"__name__":"collectd_cpu_total","container":"sg-core","endpoint":"prom-http","host":"'"${POD}"'","plugin_instance":"0","service":"default-cloud1-coll-meter","type_instance":"user"},"values":\[\[.+,".+"\]' /tmp/query_output
+grep -E '"result":\[{"metric":{"__name__":"collectd_cpu_total","container":"sg-core","endpoint":"prom-https","host":"'"${POD}"'","plugin_instance":"0","service":"default-cloud1-coll-meter","type_instance":"user"},"values":\[\[.+,".+"\]' /tmp/query_output
 metrics_result=$?
 echo; echo
 
@@ -58,7 +58,7 @@ echo; echo
 
 # The egrep exit code is the result of the test and becomes the container/pod/job exit code
 echo "*** [INFO] Checking for returned healthcheck metrics..."
-grep -E '"result":\[{"metric":{"__name__":"sensubility_container_health_status","container":"sg-core","endpoint":"prom-http","host":"'"${POD}"'","process":"smoketest-svc","service":"default-cloud1-sens-meter"},"values":\[\[.+,".+"\]' /tmp/query_output
+grep -E '"result":\[{"metric":{"__name__":"sensubility_container_health_status","container":"sg-core","endpoint":"prom-https","host":"'"${POD}"'","process":"smoketest-svc","service":"default-cloud1-sens-meter"},"values":\[\[.+,".+"\]' /tmp/query_output
 metrics_result=$((metrics_result || $?))
 echo; echo
 


### PR DESCRIPTION
* Reconfigures SGs to listen on localhost only
* Reconfigures ServiceMonitor to use TLS + bearer token auth
* We need one ServiceMonitor per SG now so that the servername on the
  certificate matches