### PR TITLE
Drop grafana.baseImage from CR example

### DIFF
--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -68,7 +68,6 @@ spec:
       adminPassword: secret
       adminUser: root
       disableSignoutMenu: false
-      baseImage: docker.io/grafana/grafana:8.1.5
   transports:
     qdr:
       enabled: true

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -108,7 +108,6 @@ metadata:
               "grafana": {
                 "adminPassword": "secret",
                 "adminUser": "root",
-                "baseImage": "docker.io/grafana/grafana:8.1.5",
                 "disableSignoutMenu": false,
                 "ingressEnabled": false
               }


### PR DESCRIPTION
Drop the grafana.baseImage path in the CR example to help with
downstream builds. There is still a default value defined in the
servicetelemetry role. This primarily affects the population of the OCP
UI interface.
