### PR TITLE
Preserve unknown fields (disable pruning) in CRD

### DIFF
--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -370,6 +370,7 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: Status results of an instance of Service Telemetry
             properties:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -408,6 +408,7 @@ spec:
                     type: object
                 type: object
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: Status results of an instance of Service Telemetry
             properties:


### PR DESCRIPTION
Preserve unknown fields (disable pruning) in the CRD which allows
manifest overrides such as alertmanagerConfigManifest. Without this
option in our CRD, the additional fields that are not specified in the
CRD schema are pruned, thereby resulting in a regression of
functionality between STF 1.3 and STF 1.4.
