### PR TITLE
Add Loki smoketests to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,14 @@ spec:
         enabled: true
         storage:
           strategy: ephemeral
+    logs:
+      loki:
+        enabled: true
+        replicationFactor: 1
+        flavor: 1x.extra-small
+        storage:
+          objectStorageSecret: test
+          storageClass: standard
   transports:
     qdr:
       enabled: true
@@ -121,6 +129,7 @@ node('ocp-agent') {
                                 "__local_build_enabled": "true",
                                 "__service_telemetry_snmptraps_enabled": "true",
                                 "__service_telemetry_storage_ephemeral_enabled": "true",
+                                "__deploy_minio_enabled": "true",
                                 "working_branch":"${working_branch}"
                             ]
                         )

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -190,3 +190,22 @@
     - loki-operator.clusterserviceversion.yaml
   when:
     - __service_telemetry_observability_strategy == "use_community"
+
+# This won't be needed with newest version of Loki-operator
+- name: Fix minio deployment
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/config/overlays/development/minio/deployment.yaml"
+    regexp: '/usr/bin/minio server /storage'
+    replace: 'minio server /storage'
+  when: 
+    - __service_telemetry_observability_strategy == "use_community"
+    - __deploy_minio_enabled | bool
+
+- name: Use quay.io for minio
+  replace:
+    path: "{{ playbook_dir }}/working/loki-operator/config/overlays/development/minio/deployment.yaml"
+    regexp: 'minio/minio'
+    replace: 'quay.io/infrawatch/minio:latest'
+  when: 
+    - __service_telemetry_observability_strategy == "use_community"
+    - __deploy_minio_enabled | bool

--- a/build/validate_deployment.sh
+++ b/build/validate_deployment.sh
@@ -15,6 +15,15 @@ case "${VALIDATION_SCOPE}" in
     "use_community")
         echo -e "\n* [info] Waiting for prometheus deployment to complete\n"
         until timeout 300 oc rollout status statefulset.apps/prometheus-default; do sleep 3; done
+		echo -e "\n* [info] Waiting for loki deployment to complete\n"
+		until timeout 300 oc rollout status statefulset.apps/loki-compactor-lokistack; do sleep 3; done
+		until timeout 300 oc rollout status statefulset.apps/loki-ingester-lokistack; do sleep 3; done
+		until timeout 300 oc rollout status statefulset.apps/loki-querier-lokistack; do sleep 3; done
+		until timeout 300 oc rollout status deployment.apps/loki-distributor-lokistack; do sleep 3; done
+		until timeout 300 oc rollout status deployment.apps/loki-query-frontend-lokistack; do sleep 3; done
+		# For some reason loki ingester waits a minute until it becomes ready after startup
+		echo -e "\n* [info] Waiting for loki ingester to be ready\n"
+		sleep 60
         echo -e "\n* [info] Waiting for elasticsearch deployment to complete \n"
         while true; do
             sleep 3
@@ -30,6 +39,7 @@ case "${VALIDATION_SCOPE}" in
         until timeout 300 oc rollout status deployment.apps/default-cloud1-coll-event-smartgateway; do sleep 3; done
         until timeout 300 oc rollout status deployment.apps/default-cloud1-ceil-event-smartgateway; do sleep 3; done
         until timeout 300 oc rollout status deployment.apps/default-cloud1-ceil-meter-smartgateway; do sleep 3; done
+		until timeout 300 oc rollout status deployment.apps/default-cloud1-rsys-log-smartgateway; do sleep 3; done
     ;;
 
     "none")
@@ -38,7 +48,6 @@ case "${VALIDATION_SCOPE}" in
         until timeout 300 oc rollout status deployment.apps/default-cloud1-ceil-meter-smartgateway; do sleep 3; done
     ;;
 esac
-
 echo -e "\n* [info] Waiting for all pods to show Ready/Complete\n"
 while oc get pods --selector '!openshift.io/build.name' | tail -n +2 | grep -v -E 'Running|Completed'; do
     sleep 3

--- a/tests/smoketest/rsyslog.conf
+++ b/tests/smoketest/rsyslog.conf
@@ -1,0 +1,32 @@
+template (name="rsyslog-record" type="list" option.jsonf="on")
+{
+    property(format="jsonf" dateFormat="rfc3339" name="timereported" outname="@timestamp" )
+    property(format="jsonf" name="hostname" outname="host" )
+    property(format="jsonf" name="syslogseverity" outname="severity" )
+    property(format="jsonf" name="syslogfacility-text" outname="facility" )
+    property(format="jsonf" name="syslogtag" outname="tag" )
+    property(format="jsonf" name="app-name" outname="source" )
+    property(format="jsonf" name="msg" outname="message" )
+    property(format="jsonf" name="$!metadata!filename" outname="file")
+    constant(format="jsonf" value="<<CLOUDNAME>>" outname="cloud")
+    constant(format="jsonf" value="<region-name>" outname="region")
+}
+
+global(workDirectory="/var/lib/rsyslog")
+module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
+
+module(load="imfile" PollingInterval="1")
+input(type="imfile"
+  file="/tmp/test.log"
+  tag="smoke.test"
+)
+
+module(load="omamqp1")
+*.* action(type="omamqp1"
+       host="amqp://default-interconnect.<<NAMESPACE>>.svc:5671"
+       target="/rsyslog/logs"
+       disableSASL="1"
+       maxRetries="0"
+       template="rsyslog-record")
+
+

--- a/tests/smoketest/smoketest_job.yaml.template
+++ b/tests/smoketest/smoketest_job.yaml.template
@@ -5,7 +5,6 @@ metadata:
 spec:
   parallelism: 1
   completions: 1
-spec:
   template:
     metadata:
       labels:
@@ -79,4 +78,33 @@ spec:
       - name: ceilometer-publisher
         configMap:
           name: stf-smoketest-ceilometer-publisher
+          defaultMode: 0555
+
+      - name: smoketest-rsyslog
+        image: quay.io/jwysogla/rsyslog:latest
+        command:
+        - /smoketest_rsyslog_entrypoint.sh
+        env:
+        - name: CLOUDNAME
+          value: <<CLOUDNAME>>
+        - name: ELASTICSEARCH_AUTH_PASS
+          value: <<ELASTICSEARCH_AUTH_PASS>>
+        volumeMounts:
+        - name: rsyslog-entrypoint-script
+          mountPath: /smoketest_rsyslog_entrypoint.sh
+          subPath: smoketest_rsyslog_entrypoint.sh
+        - name: rsyslog-config
+          mountPath: /etc/rsyslog.conf
+          subPath: rsyslog-<<CLOUDNAME>>.conf
+      volumes:
+      - name: rsyslog-config
+        configMap:
+          name: stf-smoketest-rsyslog-config-<<CLOUDNAME>>
+          defaultMode: 0555
+      - name: healthcheck-log
+        configMap:
+          name: stf-smoketest-healthcheck-log
+      - name: rsyslog-entrypoint-script
+        configMap:
+          name: stf-smoketest-rsyslog-entrypoint-script
           defaultMode: 0555

--- a/tests/smoketest/smoketest_job.yaml.template
+++ b/tests/smoketest/smoketest_job.yaml.template
@@ -81,7 +81,7 @@ spec:
           defaultMode: 0555
 
       - name: smoketest-rsyslog
-        image: quay.io/jwysogla/rsyslog:latest
+        image: quay.io/infrawatch/rsyslog:latest
         command:
         - /smoketest_rsyslog_entrypoint.sh
         env:

--- a/tests/smoketest/smoketest_rsyslog_entrypoint.sh
+++ b/tests/smoketest/smoketest_rsyslog_entrypoint.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+
+ELASTICSEARCH=${ELASTICSEARCH:-"elasticsearch-es-http:9200"}
+ELASTICSEARCH_AUTH_PASS=${ELASTICSEARCH_AUTH_PASS:-""}
+LOKI=${LOKI:-"loki-query-frontend-http-lokistack:3100"}
+INGESTER=${INGESTER:-"loki-ingester-http-lokistack:3100"}
+CLOUDNAME=${CLOUDNAME:-"smoke1"}
+CURRENT_TIME=`date -d now +%s`000000000
+CONTROL_LOG_MSG="logmessage"$CURRENT_TIME
+QUERY="http://${LOKI}/loki/api/v1/query_range --data-urlencode 'query={cloud=\""$CLOUDNAME"\"}'"
+
+echo "*** [INFO] Generating logs"
+touch /tmp/test.log
+while true
+do
+  echo "[$(date +'%Y-%m-%d %H:%M')] WARNING Something bad might happen" >> /tmp/test.log
+  echo "[$(date +'%Y-%m-%d %H:%M')] :ERROR: Something bad happened" >> /tmp/test.log
+  echo "[$(date +'%Y-%m-%d %H:%M')] [DEBUG] Wubba lubba dub dub" >> /tmp/test.log
+  echo $CONTROL_LOG_MSG >> /tmp/test.log
+  sleep 10
+done &
+echo
+
+echo "*** [INFO] Running rsyslog"
+rsyslogd -n &
+echo
+
+echo "*** [INFO] Sleeping for 30 seconds to give enough time for logs to get to Loki"
+sleep 30s
+echo
+
+echo "*** [INFO] Flushing the in-memory chunks"
+curl -XPOST -s "http://${INGESTER}/flush"
+sleep 10s
+echo
+
+echo "*** [INFO] Generated logfile for debugging"
+cat /tmp/test.log
+echo; echo
+
+echo "*** [INFO] List of labels for debugging..."
+curl -s "http://${LOKI}/loki/api/v1/labels"
+echo
+
+echo "*** [INFO] Get logs for this test from Loki..."
+LOGS=$(curl -Gs "http://${LOKI}/loki/api/v1/query_range" --data-urlencode "query={cloud=\"${CLOUDNAME}\"}")
+echo
+
+echo "*** [INFO] Logs returned from Loki"
+echo "${LOGS}"
+echo
+
+LOG_COUNT=`echo "${LOGS}" | grep -c ${CONTROL_LOG_MSG} || true`
+
+# check if we got logs back for this test
+logs_result=1
+if [ "$LOG_COUNT" -ge "1" ]; then
+    logs_result=0
+fi
+
+echo "[INFO] Verification exit codes (0 is passing, non-zero is a failure): logs=${logs_result}"
+echo; echo
+
+if [ "$logs_result" = "0" ]; then
+    echo "*** [INFO] Testing completed with success"
+    exit 0
+else
+    echo "*** [INFO] Testing completed without success"
+    exit 1
+fi


### PR DESCRIPTION
This PR adds smoketests for Loki testing to the CI. There are changes to the Jenkinsfile to use the loki-operator to deploy minimal flavor of Loki (only the operator was deployed before). And then a similar approach as logging integration testing in sg-core is used - I used an rsyslog container to generate some logs, which are then checked, if they arrived to Loki.