### PR TITLE
Allow version of ElasticSearch to be specified (#303)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ spec:
       name: elasticsearch
       namespace: $namespace
     spec:
-      version: 7.10.2
+      version: 7.16.1
       volumeClaimDeletePolicy: DeleteOnScaledownAndClusterDeletion
       http:
         tls:

--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -127,6 +127,9 @@ spec:
                     enabled:
                       description: Enable ElasticSearch as a storage backend for events
                       type: boolean
+                    version:
+                      description: Version of ElasticSearch to deploy. Elasticsearch licensing has changed as of version 7.11. See https://www.elastic.co/pricing/faq/licensing for details.
+                      type: string
                     nodeCount:
                       description: Elasticsearch node count
                       type: string

--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -27,6 +27,7 @@ spec:
     events:
       elasticsearch:
         enabled: false
+        version: 7.16.1
         storage:
           strategy: persistent
           persistent:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -103,6 +103,11 @@ spec:
                           - persistent
                           type: string
                       type: object
+                    version:
+                      description: Version of ElasticSearch to deploy. Elasticsearch
+                        licensing has changed as of version 7.11. See https://www.elastic.co/pricing/faq/licensing
+                        for details.
+                      type: string
                   type: object
               type: object
             metrics:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -37,7 +37,8 @@ metadata:
                       "pvcStorageRequest": "20Gi"
                     },
                     "strategy": "persistent"
-                  }
+                  },
+                  "version": "7.16.1"
                 }
               },
               "metrics": {

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -35,6 +35,7 @@ servicetelemetry_defaults:
     events:
       elasticsearch:
         enabled: false
+        version: 7.16.1
         node_count: 1
         storage:
           strategy: persistent

--- a/roles/servicetelemetry/templates/manifest_elasticsearch.j2
+++ b/roles/servicetelemetry/templates/manifest_elasticsearch.j2
@@ -68,5 +68,5 @@ spec:
       certificate: {}
   updateStrategy:
     changeBudget: {}
-  version: 7.10.2
+  version: {{ servicetelemetry_vars.backends.events.elasticsearch.version }}
   volumeClaimDeletePolicy: DeleteOnScaledownOnly


### PR DESCRIPTION
* Allow version of ElasticSearch to be specified

* Update roles/servicetelemetry/templates/manifest_elasticsearch.j2

* Update deploy/crds/infra.watch_servicetelemetrys_crd.yaml

Co-authored-by: Chris Sibbitt <csibbitt@redhat.com>

* Sync CRD to bundle

* Update ES target version to latest

* Update deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml

Co-authored-by: Chris Sibbitt <csibbitt@redhat.com>

* Update deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml

Co-authored-by: Chris Sibbitt <csibbitt@redhat.com>

* Update Jenkinsfile to latest ES

Co-authored-by: Chris Sibbitt <csibbitt@redhat.com>

Cherry picked from commit 39c77c71e093903cc25213c0021ec507a9a727bd
Resolves: rhbz#2032661
