### PR TITLE
Expose minimal set of bridge controls for SGs

### DIFF
--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -322,6 +322,19 @@ spec:
                               debugEnabled:
                                 description: Enable console debugging. Default is 'false'.
                                 type: boolean
+                              bridge:
+                                description: Bridge configuration and tuning configurations.
+                                properties:
+                                  ringBufferCount:
+                                    description: sg-bridge ring buffer count. This affects the potential number of messages in queue, which can result in increased memory usage within the sg-bridge container.
+                                    type: integer
+                                  ringBufferSize:
+                                    description: sg-bridge ring buffer size. This affects the size of messages that can be passed between sg-bridge and sg-core.
+                                    type: integer
+                                  verbose:
+                                    description: Enable verbosity for debugging purposes.
+                                    type: boolean
+                                type: object
                             type: object
                           type: array
                       type: object

--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -48,20 +48,40 @@ spec:
           - collectorType: collectd
             subscriptionAddress: collectd/cloud1-telemetry
             debugEnabled: false
+            bridge:
+              ringBufferSize: 16384
+              ringBufferCount: 15000
+              verbose: false
           - collectorType: ceilometer
             subscriptionAddress: anycast/ceilometer/cloud1-metering.sample
             debugEnabled: false
+            bridge:
+              ringBufferSize: 16384
+              ringBufferCount: 15000
+              verbose: false
           - collectorType: sensubility
             subscriptionAddress: sensubility/cloud1-telemetry
             debugEnabled: false
+            bridge:
+              ringBufferSize: 16384
+              ringBufferCount: 15000
+              verbose: false
       events:
         collectors:
           - collectorType: collectd
             subscriptionAddress: collectd/cloud1-notify
             debugEnabled: false
+            bridge:
+              ringBufferSize: 16384
+              ringBufferCount: 15000
+              verbose: false
           - collectorType: ceilometer
             subscriptionAddress: anycast/ceilometer/cloud1-event.sample
             debugEnabled: false
+            bridge:
+              ringBufferSize: 16384
+              ringBufferCount: 15000
+              verbose: false
   graphing:
     enabled: false
     grafana:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -319,6 +319,24 @@ spec:
                             cloud object
                           items:
                             properties:
+                              bridge:
+                                description: Bridge configuration and tuning configurations.
+                                properties:
+                                  ringBufferCount:
+                                    description: sg-bridge ring buffer count. This
+                                      affects the potential number of messages in
+                                      queue, which can result in increased memory
+                                      usage within the sg-bridge container.
+                                    type: integer
+                                  ringBufferSize:
+                                    description: sg-bridge ring buffer size. This
+                                      affects the size of messages that can be passed
+                                      between sg-bridge and sg-core.
+                                    type: integer
+                                  verbose:
+                                    description: Enable verbosity for debugging purposes.
+                                    type: boolean
+                                type: object
                               collectorType:
                                 description: Set the collector type, value of 'ceilometer',
                                   'collectd' or 'sensubility'.

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -71,11 +71,21 @@ metadata:
                 "events": {
                   "collectors": [
                     {
+                      "bridge": {
+                        "ringBufferCount": 15000,
+                        "ringBufferSize": 16384,
+                        "verbose": false
+                      },
                       "collectorType": "collectd",
                       "debugEnabled": false,
                       "subscriptionAddress": "collectd/cloud1-notify"
                     },
                     {
+                      "bridge": {
+                        "ringBufferCount": 15000,
+                        "ringBufferSize": 16384,
+                        "verbose": false
+                      },
                       "collectorType": "ceilometer",
                       "debugEnabled": false,
                       "subscriptionAddress": "anycast/ceilometer/cloud1-event.sample"
@@ -85,16 +95,31 @@ metadata:
                 "metrics": {
                   "collectors": [
                     {
+                      "bridge": {
+                        "ringBufferCount": 15000,
+                        "ringBufferSize": 16384,
+                        "verbose": false
+                      },
                       "collectorType": "collectd",
                       "debugEnabled": false,
                       "subscriptionAddress": "collectd/cloud1-telemetry"
                     },
                     {
+                      "bridge": {
+                        "ringBufferCount": 15000,
+                        "ringBufferSize": 16384,
+                        "verbose": false
+                      },
                       "collectorType": "ceilometer",
                       "debugEnabled": false,
                       "subscriptionAddress": "anycast/ceilometer/cloud1-metering.sample"
                     },
                     {
+                      "bridge": {
+                        "ringBufferCount": 15000,
+                        "ringBufferSize": 16384,
+                        "verbose": false
+                      },
                       "collectorType": "sensubility",
                       "debugEnabled": false,
                       "subscriptionAddress": "sensubility/cloud1-telemetry"

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -90,25 +90,49 @@ servicetelemetry_defaults:
           - collector_type: collectd
             subscription_address: collectd/cloud1-telemetry
             debug_enabled: false
+            bridge:
+              ring_buffer_size: 16384
+              ring_buffer_count: 15000
+              verbose: false
           - collector_type: ceilometer
             subscription_address: anycast/ceilometer/cloud1-metering.sample
             debug_enabled: false
+            bridge:
+              ring_buffer_size: 16384
+              ring_buffer_count: 15000
+              verbose: false
           - collector_type: sensubility
             subscription_address: sensubility/cloud1-telemetry
             debug_enabled: false
+            bridge:
+              ring_buffer_size: 16384
+              ring_buffer_count: 15000
+              verbose: false
       events:
         collectors:
           - collector_type: collectd
             subscription_address: collectd/cloud1-notify
             debug_enabled: false
+            bridge:
+              ring_buffer_size: 16384
+              ring_buffer_count: 15000
+              verbose: false
           - collector_type: ceilometer
             subscription_address: anycast/ceilometer/cloud1-event.sample
             debug_enabled: false
+            bridge:
+              ring_buffer_size: 16384
+              ring_buffer_count: 15000
+              verbose: false
       logs:
         collectors:
           - collector_type: rsyslog
             subscription_address: rsyslog/cloud1-logs
             debug_enabled: false
+            bridge:
+              ring_buffer_size: 135048
+              ring_buffer_count: 15000
+              verbose: false
 
 
 # These variables are outside of the defaults. Their values will be

--- a/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
@@ -25,6 +25,9 @@ spec:
     name: elasticsearch
   bridge:
     amqpUrl: amqp://{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ this_collector.subscription_address }}
+    ringBufferSize: {{ this_collector.bridge.ring_buffer_size }}
+    ringBufferCount: {{ this_collector.bridge.ring_buffer_count }}
+    verbose: {{ this_collector.bridge.verbose }}
   transports:
   - config: |
       path: /tmp/smartgateway

--- a/roles/servicetelemetry/templates/manifest_smartgateway_logs.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_logs.j2
@@ -22,7 +22,9 @@ spec:
     amqpUrl: amqp://{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ this_collector.subscription_address }}
     amqpBlock: true
     socketBlock: true
-    ringBufferSize: 135048
+    ringBufferSize: {{ this_collector.bridge.ring_buffer_size }}
+    ringBufferCount: {{ this_collector.bridge.ring_buffer_count }}
+    verbose: {{ this_collector.bridge.verbose }}
   transports:
   - config: |
       path: /tmp/smartgateway

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -19,6 +19,9 @@ spec:
     name: prometheus
   bridge:
     amqpUrl: amqp://{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ this_collector.subscription_address }}
+    ringBufferSize: {{ this_collector.bridge.ring_buffer_size }}
+    ringBufferCount: {{ this_collector.bridge.ring_buffer_count }}
+    verbose: {{ this_collector.bridge.verbose }}
   services:
   - name: {{ this_smartgateway }}
     ports:


### PR DESCRIPTION
Expose a minimal set of bridge controls for sg-bridge in the clouds
collectors configuration. Exposes the ringBufferCount, ringBufferSize
and verbose options. Sets the default values to an increased value of
16384 which seemed to be safe in testing and deal with most of the
buffer overflows that were resulting in corrupted messages being passed
to sg-core. The values can now be tuned to match the environment easily.

Discussion also referenced originally in
https://github.com/infrawatch/smart-gateway-operator/pull/91. This
change helps satisfy for changes in sg-core that allows it to receive
larger message sizes per https://github.com/infrawatch/sg-core/pull/74.
