### PR TITLE
Set default branches for repositories

### DIFF
--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -39,9 +39,9 @@ loki_operator_branch: 700e275
 
 # used when building images to default to correct version branch for STF subcomponents per STF version
 version_branches:
-  sgo: master
-  sg_core: master
-  sg_bridge: master
+  sgo: stable-1.4
+  sg_core: stable-1.4
+  sg_bridge: stable-1.4
   prometheus_webhook_snmp: master
   loki_operator: master
 


### PR DESCRIPTION
Update the default branches to use when executing the test framework.
This should have been changed when we release STF 1.4.
