### PR TITLE
Fix linting by locking versions (#113)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Ansible
-        run: python -m pip install ansible
+        run: python -m pip install 'ansible <= 2.9'
 
       - name: Install operator_sdk.util dependency for Ansible role linting
         run: ansible-galaxy collection install operator_sdk.util
 
       - name: Install ansible-lint
-        run: pip install ansible-lint
+        run: pip install 'ansible-lint < 6.0.0'
 
       - name: Lint Ansible roles/servicetelemetry/ directory
         run: ${HOME}/.local/bin/ansible-lint roles/servicetelemetry


### PR DESCRIPTION
Lock versions installed as part of the CI linting system as new rules
existing for newer Ansible Runner versions (which we're not using).

Cherry picked from commit 737a30e7c56ef492242731d92600297738397a93
--> infrawatch/smart-gateway-operator.git
