### PR TITLE
Expose bridge parameters for events and logs SGs

### DIFF
--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -357,6 +357,19 @@ spec:
                               debugEnabled:
                                 description: Enable console debugging. Default is 'false'.
                                 type: boolean
+                              bridge:
+                                description: Bridge configuration and tuning configurations.
+                                properties:
+                                  ringBufferCount:
+                                    description: sg-bridge ring buffer count. This affects the potential number of messages in queue, which can result in increased memory usage within the sg-bridge container.
+                                    type: integer
+                                  ringBufferSize:
+                                    description: sg-bridge ring buffer size. This affects the size of messages that can be passed between sg-bridge and sg-core.
+                                    type: integer
+                                  verbose:
+                                    description: Enable verbosity for debugging purposes.
+                                    type: boolean
+                                type: object
                             type: object
                           type: array
                       type: object
@@ -380,6 +393,19 @@ spec:
                                 description: Address to subscribe on the data transport
                                   to receive notifications.
                                 type: string
+                              bridge:
+                                description: Bridge configuration and tuning configurations.
+                                properties:
+                                  ringBufferCount:
+                                    description: sg-bridge ring buffer count. This affects the potential number of messages in queue, which can result in increased memory usage within the sg-bridge container.
+                                    type: integer
+                                  ringBufferSize:
+                                    description: sg-bridge ring buffer size. This affects the size of messages that can be passed between sg-bridge and sg-core.
+                                    type: integer
+                                  verbose:
+                                    description: Enable verbosity for debugging purposes.
+                                    type: boolean
+                                type: object
                             type: object
                           type: array
                       type: object


### PR DESCRIPTION
Expose the bridge tuning parameters for both events and logs Smart
Gateways, the same as what is done for metrics Smart Gateways. This
fixes a regression implemented in #312.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
