### PR TITLE
Adjustments for role_binding in SG for CI

### DIFF
--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -42,9 +42,6 @@
 - name: Load Smart Gateway Operator CSV
   shell: oc apply -f working/smart-gateway-operator-bundle/manifests/smart-gateway-operator.clusterserviceversion.yaml -n "{{ namespace }}"
 
-- name: Revert local change to role_binding.yaml
-  shell: git checkout -- "{{ playbook_dir }}../deploy/role_binding.yaml"
-
 # --- Service Telemetry Operator ---
 - name: Generate Service Telemetry Operator CSV
   shell:
@@ -63,13 +60,17 @@
     regexp: 'placeholder'
     replace: '{{ namespace }}'
 
-- name: Load Service Telemetry Operator RBAC
-  command: oc apply -f ../deploy/{{ item }} -n "{{ namespace }}"
-  loop:
-    - service_account.yaml
-    - role.yaml
-    - role_binding.yaml
-    - olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+- block:
+  - name: Load Service Telemetry Operator RBAC
+    command: oc apply -f ../deploy/{{ item }} -n "{{ namespace }}"
+    loop:
+      - service_account.yaml
+      - role.yaml
+      - role_binding.yaml
+      - olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+
+  - name: Revert local change to role_binding.yaml
+    shell: git checkout -- "{{ playbook_dir }}/../deploy/role_binding.yaml"
 
 - name: Replace namespace in STO CSV
   replace:


### PR DESCRIPTION
Update the stf-run-ci playbooks to account for the namespace:
placeholder that has been added to role_binding.yaml as part of the
oauth-proxy work. Before this change, the deployment of SGO would fail
in the CSV due to a missing ClusterRoleBinding attaching to the
service-account in the appropriate namespace. This change causes the
role_binding.yaml to be updated to the installation namespace so that
the service account is referenced in the role binding properly.

Also sneak in a small change that reverts the local in place change to
the role_binding.yaml for the local repository.
