### PR TITLE
Adjustments for role_binding in SG for CI (#327)

### DIFF
--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -60,13 +60,17 @@
     regexp: 'placeholder'
     replace: '{{ namespace }}'
 
-- name: Load Service Telemetry Operator RBAC
-  command: oc apply -f ../deploy/{{ item }} -n "{{ namespace }}"
-  loop:
-    - service_account.yaml
-    - role.yaml
-    - role_binding.yaml
-    - olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+- block:
+  - name: Load Service Telemetry Operator RBAC
+    command: oc apply -f ../deploy/{{ item }} -n "{{ namespace }}"
+    loop:
+      - service_account.yaml
+      - role.yaml
+      - role_binding.yaml
+      - olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+
+  - name: Revert local change to role_binding.yaml
+    shell: git checkout -- "{{ playbook_dir }}/../deploy/role_binding.yaml"
 
 - name: Replace namespace in STO CSV
   replace:


### PR DESCRIPTION
* Adjustments for role_binding in SG for CI

Update the stf-run-ci playbooks to account for the namespace:
placeholder that has been added to role_binding.yaml as part of the
oauth-proxy work. Before this change, the deployment of SGO would fail
in the CSV due to a missing ClusterRoleBinding attaching to the
service-account in the appropriate namespace. This change causes the
role_binding.yaml to be updated to the installation namespace so that
the service account is referenced in the role binding properly.

Also sneak in a small change that reverts the local in place change to
the role_binding.yaml for the local repository.

* Fix where change reversion happens

Also fix a missing path separator in the git checkout -- command.

Cherry picked from commit 59ab1ca09d225384edc7fabbdd26fe95fa59c74d
