### PR TITLE
Expose bridge parameters for events and logs SGs (#326)

### DIFF
--- a/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/crds/infra.watch_servicetelemetrys_crd.yaml
@@ -357,6 +357,19 @@ spec:
                               debugEnabled:
                                 description: Enable console debugging. Default is 'false'.
                                 type: boolean
+                              bridge:
+                                description: Bridge configuration and tuning configurations.
+                                properties:
+                                  ringBufferCount:
+                                    description: sg-bridge ring buffer count. This affects the potential number of messages in queue, which can result in increased memory usage within the sg-bridge container.
+                                    type: integer
+                                  ringBufferSize:
+                                    description: sg-bridge ring buffer size. This affects the size of messages that can be passed between sg-bridge and sg-core.
+                                    type: integer
+                                  verbose:
+                                    description: Enable verbosity for debugging purposes.
+                                    type: boolean
+                                type: object
                             type: object
                           type: array
                       type: object
@@ -380,6 +393,19 @@ spec:
                                 description: Address to subscribe on the data transport
                                   to receive notifications.
                                 type: string
+                              bridge:
+                                description: Bridge configuration and tuning configurations.
+                                properties:
+                                  ringBufferCount:
+                                    description: sg-bridge ring buffer count. This affects the potential number of messages in queue, which can result in increased memory usage within the sg-bridge container.
+                                    type: integer
+                                  ringBufferSize:
+                                    description: sg-bridge ring buffer size. This affects the size of messages that can be passed between sg-bridge and sg-core.
+                                    type: integer
+                                  verbose:
+                                    description: Enable verbosity for debugging purposes.
+                                    type: boolean
+                                type: object
                             type: object
                           type: array
                       type: object

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
@@ -269,6 +269,24 @@ spec:
                             cloud object.
                           items:
                             properties:
+                              bridge:
+                                description: Bridge configuration and tuning configurations.
+                                properties:
+                                  ringBufferCount:
+                                    description: sg-bridge ring buffer count. This
+                                      affects the potential number of messages in
+                                      queue, which can result in increased memory
+                                      usage within the sg-bridge container.
+                                    type: integer
+                                  ringBufferSize:
+                                    description: sg-bridge ring buffer size. This
+                                      affects the size of messages that can be passed
+                                      between sg-bridge and sg-core.
+                                    type: integer
+                                  verbose:
+                                    description: Enable verbosity for debugging purposes.
+                                    type: boolean
+                                type: object
                               collectorType:
                                 description: Set the collector type, value of 'ceilometer'
                                   or 'collectd'.
@@ -295,6 +313,24 @@ spec:
                             cloud object.
                           items:
                             properties:
+                              bridge:
+                                description: Bridge configuration and tuning configurations.
+                                properties:
+                                  ringBufferCount:
+                                    description: sg-bridge ring buffer count. This
+                                      affects the potential number of messages in
+                                      queue, which can result in increased memory
+                                      usage within the sg-bridge container.
+                                    type: integer
+                                  ringBufferSize:
+                                    description: sg-bridge ring buffer size. This
+                                      affects the size of messages that can be passed
+                                      between sg-bridge and sg-core.
+                                    type: integer
+                                  verbose:
+                                    description: Enable verbosity for debugging purposes.
+                                    type: boolean
+                                type: object
                               collectorType:
                                 description: Set the collector type, value of 'rsyslog'
                                 enum:

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -83,6 +83,10 @@ servicetelemetry_defaults:
 
   # 'clouds' object is not partially updatable like other objects. If 'clouds'
   # object is defined then the default is overwritten.
+
+  # NOTE: if you reference any of these parameters in your templates, then be
+  # sure to define a `| default(...)` for the parameter in case `clouds`
+  # structure is not fully populated.
   clouds:
     - name: cloud1
       metrics:

--- a/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_events.j2
@@ -25,9 +25,9 @@ spec:
     name: elasticsearch
   bridge:
     amqpUrl: amqp://{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ this_collector.subscription_address }}
-    ringBufferSize: {{ this_collector.bridge.ring_buffer_size }}
-    ringBufferCount: {{ this_collector.bridge.ring_buffer_count }}
-    verbose: {{ this_collector.bridge.verbose }}
+    ringBufferSize: {{ this_collector.bridge.ring_buffer_size | default(16384) }}
+    ringBufferCount: {{ this_collector.bridge.ring_buffer_count | default(15000) }}
+    verbose: {{ this_collector.bridge.verbose | default(false) }}
   transports:
   - config: |
       path: /tmp/smartgateway

--- a/roles/servicetelemetry/templates/manifest_smartgateway_logs.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_logs.j2
@@ -22,9 +22,9 @@ spec:
     amqpUrl: amqp://{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ this_collector.subscription_address }}
     amqpBlock: true
     socketBlock: true
-    ringBufferSize: {{ this_collector.bridge.ring_buffer_size }}
-    ringBufferCount: {{ this_collector.bridge.ring_buffer_count }}
-    verbose: {{ this_collector.bridge.verbose }}
+    ringBufferSize: {{ this_collector.bridge.ring_buffer_size | default(135048) }}
+    ringBufferCount: {{ this_collector.bridge.ring_buffer_count | default(15000) }}
+    verbose: {{ this_collector.bridge.verbose | default(false) }}
   transports:
   - config: |
       path: /tmp/smartgateway

--- a/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
+++ b/roles/servicetelemetry/templates/manifest_smartgateway_metrics.j2
@@ -19,9 +19,9 @@ spec:
     name: prometheus
   bridge:
     amqpUrl: amqp://{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5673/{{ this_collector.subscription_address }}
-    ringBufferSize: {{ this_collector.bridge.ring_buffer_size }}
-    ringBufferCount: {{ this_collector.bridge.ring_buffer_count }}
-    verbose: {{ this_collector.bridge.verbose }}
+    ringBufferSize: {{ this_collector.bridge.ring_buffer_size | default(16384) }}
+    ringBufferCount: {{ this_collector.bridge.ring_buffer_count | default(15000) }}
+    verbose: {{ this_collector.bridge.verbose | default(false)}}
   services:
   - name: {{ this_smartgateway }}
     ports:


### PR DESCRIPTION
* Expose bridge parameters for events and logs SGs

Expose the bridge tuning parameters for both events and logs Smart
Gateways, the same as what is done for metrics Smart Gateways. This
fixes a regression implemented in #312.

Signed-off-by: Leif Madsen <lmadsen@redhat.com>

* Update manifests for bundle via operator-sdk

operator-sdk generate bundle --default-channel unstable --channels unstable --manifests --metadata

* Also cover situation when defaults are not defined in ServiceTelemetry manifest

* Add note about  default() is necessary for clouds

Add a note that makes it clear if the defaults for the clouds parameter
are added to, then be sure to implement a default() filter in the
templates that reference the clouds.* parameters.

The reason is that the clouds paramater is not updatable partially like
the rest of the structure. If an admin only partially defines the
parameters in the clouds list item, then it's possible for referenced
sub-params to be empty, and thus cause failure when the parameter is
referenced. This would go for all list objects.

In the case of Service Telemetry Operator, nested lists are only used in
the clouds parameter.

* Fix invalid indentation

Cherry picked from commit 97f2a86cf519a71731fc7456f59be2fa10bb7a5b
Signed-off-by: Leif Madsen <lmadsen@redhat.com>
