### PR TITLE
Adding ability to deploy from bundle URLs

### DIFF
--- a/build/get_new_operator_sdk.sh
+++ b/build/get_new_operator_sdk.sh
@@ -9,5 +9,7 @@ OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/
 if [[ ! -f ${REL}/working/operator-sdk-${VERSION} ]]; then
 	curl -L ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} -o ${REL}/working/operator-sdk-${VERSION}
 	chmod +x ${REL}/working/operator-sdk-${VERSION}
+	rm ${REL}/working/operator-sdk
+	ln -s operator-sdk-${VERSION} ${REL}/working/operator-sdk
 fi
 

--- a/build/get_new_operator_sdk.sh
+++ b/build/get_new_operator_sdk.sh
@@ -7,6 +7,7 @@ VERSION="${1:-v1.5.0}"
 OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${VERSION}
 
 if [[ ! -f ${REL}/working/operator-sdk-${VERSION} ]]; then
+	mkdir ${REL}/working
 	curl -L ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} -o ${REL}/working/operator-sdk-${VERSION}
 	chmod +x ${REL}/working/operator-sdk-${VERSION}
 	rm ${REL}/working/operator-sdk

--- a/build/run-ci.yaml
+++ b/build/run-ci.yaml
@@ -1,6 +1,7 @@
 ---
 # run STF CI setup in CRC (already provisioned)
 - hosts: localhost
+  gather_facts: no
   connection: local
   tasks:
   - name: Run the STF CI system

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -21,7 +21,11 @@ choose to override:
 | Parameter name                                         | Values                   | Default                                               | Description                                                                                                         |
 | ------------------------------                         | ------------             | ---------                                             | ------------------------------------                                                                                |
 | `__deploy_stf`                                         | {true,false}             | true                                                  | Whether to deploy an instance of STF                                                                                |
-| `__local_build_enabled`                                | {true,false}             | true                                                  | Whether to deploySTF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch`               |
+| `__local_build_enabled`                                | {true,false}             | true                                                  | Whether to deploy STF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch`               |
+| `__deploy_from_bundles_enabled`                        | {true,false}             | false                                                |  Whether to deploy STF from OLM bundles (TODO: compat with __local_build_enabled) |
+
+| `__service_telemetry_bundle_image_path`                | <image_path>             | <none>                                                | Image path to Service Telemetry Operator bundle |
+| `__smart_gateway_bundle_image_path`                    | <image_path>             | <none>                                                | Image path to Smart Gateway Operator bundle |
 | `prometheus_webhook_snmp_branch`                       | <git_branch>             | master                                                | Which Prometheus Webhook SNMP git branch to checkout                                                                |
 | `sgo_branch`                                           | <git_branch>             | master                                                | Which Smart Gateway Operator git branch to checkout                                                                 |
 | `sg_core_branch`                                       | <git_branch>             | master                                                | Which Smart Gateway Core git branch to checkout                                                                     |
@@ -46,6 +50,7 @@ choose to override:
 | `__loki_skip_tls_verify`                               | {true,false}             | false                                                 | Whether to skip TLS verify for Loki S3 connection                                                                   |
 | `__golang_image_path`                                  | <image_path>             | quay.io/infrawatch/golang:1.16                        | Golang image path for building the loki-operator image                                                              |
 | `__loki_image_path`                                    | <image_path>             | quay.io/infrawatch/loki:2.2.1                         | Loki image path for Loki microservices                                                                              |
+
 
 
 Example Playbook
@@ -85,6 +90,16 @@ the following command:
 ```
 ansible-playbook --extra-vars __local_build_enabled=false run-ci.yaml
 ```
+
+You can deploy directly from pre-built bundles like this:
+```
+ansible-playbook -e __local_build_enabled=false -e __deploy_from_bundles_enabled=true run-ci.yaml
+```
+
+NOTE: When deploying from bundles, you must have an _authfile_ and _CA.pem_ for
+the registry already in place in the build directory, if required. If these
+are not required, add `--skip-tags bundle_registry_auth --skip-tags bundle_registry_tls_ca`
+to disable one or both.
 
 License
 -------

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -93,7 +93,10 @@ ansible-playbook --extra-vars __local_build_enabled=false run-ci.yaml
 
 You can deploy directly from pre-built bundles like this:
 ```
-ansible-playbook -e __local_build_enabled=false -e __deploy_from_bundles_enabled=true run-ci.yaml
+ansible-playbook -e __local_build_enabled=false -e __deploy_from_bundles_enabled=true \
+  -e __service_telemetry_bundle_image_path=<registry>/<namespace>/stf-service-telemetry-operator-bundle:<tag> \
+  -e __smart_gateway_bundle_image_path=<registry>/<namespace>/stf-smart-gateway-operator-bundle:<tag> \
+  run-ci.yaml
 ```
 
 NOTE: When deploying from bundles, you must have an _authfile_ and _CA.pem_ for

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -6,6 +6,7 @@ list_of_stf_objects:
   - smart-gateway
 
 __local_build_enabled: true
+__deploy_from_bundles_enabled: false
 __deploy_stf: true
 
 __service_telemetry_events_enabled: true
@@ -16,6 +17,8 @@ __service_telemetry_snmptraps_enabled: true
 __service_telemetry_logs_enabled: false
 __service_telemetry_observability_strategy: use_community
 __internal_registry_path: image-registry.openshift-image-registry.svc:5000
+__service_telemetry_bundle_image_path:
+__smart_gateway_bundle_image_path:
 
 __deploy_minio_enabled: false
 __deploy_loki_enabled: false

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -15,6 +15,11 @@
     loki_operator_image_path: "{{ __internal_registry_path }}/{{ namespace }}/loki-operator:{{ loki_operator_image_tag }}"
     loki_operator_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/loki-operator-bundle:{{ loki_operator_image_tag }}"
 
+- name: Fail on mutually exclusive flags
+  fail:
+    msg: __deploy_from_bundles_enabled not currently supported with __local_build_enabled (but should be)
+  when: __local_build_enabled | bool and __deploy_from_bundles_enabled | bool
+
 - name: Get the node hostnames
   set_fact:
     nodes: "{{ lookup('k8s', kind='nodes') }}"
@@ -29,18 +34,20 @@
       set_fact:
         is_crc: "{{ True if 'crc' in nodes.metadata.labels[\"kubernetes.io/hostname\"] else False }}"
 
-- name: Clear out existing CRDs so we don't conflict or fail merge
-  k8s:
-    state: absent
-    api_version: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    name: "{{ item }}"
-  loop:
-    - smartgateways.smartgateway.infra.watch
-    - servicetelemetrys.infra.watch
-    - lokistacks.loki.grafana.com
+- name: Clean up any existing global artifacts
+  include_tasks: pre-clean.yml
 
-- block:
+- name: Setup supporting Operator subscriptions
+  include_tasks: setup_base.yml
+  tags:
+    - deploy
+
+- name: Get new operator sdk
+  when: __local_build_enabled | bool or __deploy_from_bundles_enabled | bool or __deploy_loki_enabled | bool
+  command: ./get_new_operator_sdk.sh "{{ new_operator_sdk_version }}"
+
+- when: __local_build_enabled | bool
+  block:
   - name: Setup supporting repositories
     include_tasks: clone_repos.yml
     tags:
@@ -51,17 +58,9 @@
       command: rm -rf "{{ playbook_dir }}/working/loki-operator"
       command: mv "{{ playbook_dir }}/working/loki/{{ loki_operator_folder }}" "{{ playbook_dir }}/working/loki-operator"
 
-    - name: Get new operator sdk
-      command: ./get_new_operator_sdk.sh "{{ new_operator_sdk_version }}"
-
     - name: Get new go
       command: ./get_go.sh "{{ new_go_version }}"
     when: __deploy_loki_enabled | bool
-
-  - name: Setup supporting Operator subscriptions
-    include_tasks: setup_base.yml
-    tags:
-      - deploy
 
     # TLS verification support doesn't seem to be implemented in the operator yet
   - block:
@@ -147,14 +146,15 @@
     include_tasks: setup_stf_local_build.yml
     tags:
       - deploy
-  when: __local_build_enabled | bool
 
 - block:
-  - name: Setup supporting Operator subscriptions
-    include_tasks: setup_base.yml
+  - name: Setup Service Telemetry Framework from supplied bundle URLs
+    include_tasks: setup_stf_from_bundles.yml
+    when: __deploy_from_bundles_enabled | bool
 
   - name: Setup Service Telemetry Framework from application registry
     include_tasks: setup_stf.yml
+    when: not __deploy_from_bundles_enabled | bool
 
   when: not __local_build_enabled | bool
 

--- a/build/stf-run-ci/tasks/pre-clean.yml
+++ b/build/stf-run-ci/tasks/pre-clean.yml
@@ -12,7 +12,7 @@
   tags:
     - clean-crds
 
-# The clusterroles and clusterrolebindings are clobal objects that can be left
+# The clusterroles and clusterrolebindings are global objects that can be left
 # behind by failed bundle installs
 - name: Remove all clusterrolebindings owned by OLM for this namespace
   k8s:

--- a/build/stf-run-ci/tasks/pre-clean.yml
+++ b/build/stf-run-ci/tasks/pre-clean.yml
@@ -1,0 +1,31 @@
+# NOTE: This cleanup step prevents parallel CI jobs
+- name: Clear out existing CRDs so we don't conflict or fail merge
+  k8s:
+    state: absent
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: "{{ item }}"
+  loop:
+    - smartgateways.smartgateway.infra.watch
+    - servicetelemetrys.infra.watch
+    - lokistacks.loki.openshift.io
+  tags:
+    - clean-crds
+
+# The clusterroles and clusterrolebindings are clobal objects that can be left
+# behind by failed bundle installs
+- name: Remove all clusterrolebindings owned by OLM for this namespace
+  k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: clusterrolebindings
+    label_selectors:
+      - "olm.owner.namespace = {{ namespace }}"
+
+- name: Remove all clusterroles owned by OLM for this namespace
+  k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: clusterroles
+    label_selectors:
+      - "olm.owner.namespace = {{ namespace }}"

--- a/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
+++ b/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
@@ -1,0 +1,50 @@
+- name: Create pull secret
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        name: pull-secret
+        namespace: "{{ namespace }}"
+      data:
+        .dockerconfigjson: "{{ lookup('file', 'authfile') | b64encode }}"
+  tags:
+    - bundle_registry_auth
+
+- name: Create registry CA Cert
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: registry-tls-ca
+        namespace: "{{ namespace }}"
+      data:
+        cert.pem: "{{ lookup('file', 'CA.pem') | b64encode }}"
+  tags:
+    - bundle_registry_tls_ca
+
+- name: Patch the default service account to use our pull secret
+  kubernetes.core.k8s_json_patch:
+    kind: ServiceAccount
+    namespace: "{{ namespace }}"
+    name: default
+    patch:
+      - op: add
+        path: /imagePullSecrets
+        value:
+          - name: pull-secret
+  tags:
+    - bundle_registry_tls_ca
+
+- name: Deploy SGO via OLM bundle
+  shell:
+    cmd: "{{ playbook_dir }}/working/operator-sdk run bundle {{__smart_gateway_bundle_image_path}} --pull-secret-name=pull-secret --ca-secret-name=registry-tls-ca --namespace={{ namespace }}"
+
+- name: Deploy STO via OLM bundle
+  shell:
+    cmd: "{{ playbook_dir }}/working/operator-sdk run bundle {{ __service_telemetry_bundle_image_path}} --pull-secret-name=pull-secret --ca-secret-name=registry-tls-ca --namespace={{ namespace }}"

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -119,7 +119,7 @@
       target: bundle
       params:
           REGISTRY_ORG: infrawatch
-          OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
+          OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk"
           GOROOT: "{{ playbook_dir }}/working/go"
           GOTOOLDIR: "{{ playbook_dir }}/working/go/pkg/tool/linux_amd64"
           GOBIN: "{{ playbook_dir }}/working/go/bin"
@@ -192,7 +192,7 @@
       target: deploy
       params:
           REGISTRY_ORG: infrawatch
-          OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk-{{ new_operator_sdk_version }}"
+          OPERATOR_SDK: "{{ playbook_dir }}/working/operator-sdk"
           GOROOT: "{{ playbook_dir }}/working/go"
           GOTOOLDIR: "{{ playbook_dir }}/working/go/pkg/tool/linux_amd64"
           GOBIN: "{{ playbook_dir }}/working/go/bin"

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -59,7 +59,8 @@ for NAME in "${CLOUDNAMES[@]}"; do
 done
 
 echo "*** [INFO] Triggering an alertmanager notification..."
-oc run curl --serviceaccount=prometheus-k8s --restart='Never' --image=quay.io/infrawatch/busyboxplus:curl -- sh -c "curl -k -H \"Content-Type: application/json\" -H \"Authorization: Bearer \$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" -d '[{\"labels\":{\"alertname\":\"Testalert1\"}}]' https://default-alertmanager-proxy:9095/api/v1/alerts"
+PROMETHEUS_K8S_TOKEN=$(oc serviceaccounts get-token prometheus-k8s)
+oc run curl --restart='Never' --image=quay.io/infrawatch/busyboxplus:curl -- sh -c "curl -k -H \"Content-Type: application/json\" -H \"Authorization: Bearer ${PROMETHEUS_K8S_TOKEN}\" -d '[{\"labels\":{\"alertname\":\"Testalert1\"}}]' https://default-alertmanager-proxy:9095/api/v1/alerts"
 # it takes some time to get the alert delivered, continuing with other tests
 
 


### PR DESCRIPTION
* Added ability to deploy with `operator-sdk run bundle` instead of from the upstream catalog or a local build
* Added a symlink to simplify calling operator-sdk
* Turned off facts gathering for performance
* Moved a couple when clauses for clarity