### PR TITLE
Added required module to agent Dockerfile and rebuilt according to README

### DIFF
--- a/.jenkins/agent/Dockerfile
+++ b/.jenkins/agent/Dockerfile
@@ -4,4 +4,4 @@ RUN curl -LO "https://github.com/operator-framework/operator-sdk/releases/downlo
 RUN dnf install -y ansible golang && \
     dnf groupinstall -y "Development Tools" -y && \
     ansible-galaxy collection install community.kubernetes && \
-    python -m pip install openshift
+    python -m pip install openshift kubernetes


### PR DESCRIPTION
This commit is really just to record that I did this action.

I'm not 100% sure what happened here. Pushing this image did not (immediately?) fix the problem we were having, and I'm still a bit confused why I saw ansible 1.9 inside this container, but am seeing 1.12 during job executions. Both versions work for me.