### PR TITLE
Version updates for new CI features

### DIFF
--- a/.jenkins/agent/Dockerfile
+++ b/.jenkins/agent/Dockerfile
@@ -1,7 +1,8 @@
 FROM quay.io/openshift/origin-jenkins-agent-base:latest
 RUN curl -LO "https://github.com/operator-framework/operator-sdk/releases/download/v0.19.4/operator-sdk-v0.19.4-x86_64-linux-gnu" && \
     chmod +x operator-sdk-v0.19.4-x86_64-linux-gnu && mv operator-sdk-v0.19.4-x86_64-linux-gnu /usr/local/bin/operator-sdk
-RUN dnf install -y ansible golang && \
+RUN dnf install -y ansible golang python38 && \
     dnf groupinstall -y "Development Tools" -y && \
-    ansible-galaxy collection install community.kubernetes && \
-    python -m pip install openshift kubernetes
+    alternatives --set python /usr/bin/python3.8 && \
+    python -m pip install openshift kubernetes "ansible-core~=2.12" && \
+    ansible-galaxy collection install -f kubernetes.core community.general


### PR DESCRIPTION
I revived upstream CI earlier today by rebuilding this container (possibly with a new module installation?).

It didn't work with my latest code from https://github.com/infrawatch/service-telemetry-operator/pull/336 though.

I needed kubernetes.core >= 2.2.0 which wasn't coming along with our current setup, so I found this solution that works.

This image has already been built and is live on the CI server, so I'm going to self-merge this, but wanted to draw attention to the tooling in use in upstream CI to support the latest features, namely:

Python 3.8 modules
--
ansible-core-2.12.5
kubernetes-23.6.0
openshift-0.13.1

Ansible Core 2.12 Collections
--
kubernetes.core:2.3.1
community.general:4.8.0

@elfiesmelfie , I'm not sure how this compares to your jumphost environment, but I know the jenkins job that I currently use to call your roles asks to install "ansible >= 2.9" which I think will do 2.10 at best (I haven't checked what it actually installs yet). I run 2.10 locally, but had trouble getting it to work in the Jenkins container, so just kept rolling forward with ansible-core. 

As long as what we end up with downstream CI works, I don't care too much if it matches what I've produced here. Notably, it's prety normal for upstream to be ahead by a couple versions so we get a heads-up of changes.

CC: @mgirgisf 