### PR TITLE
Adding ability to deploy from bundle URLs

### DIFF
--- a/build/get_new_operator_sdk.sh
+++ b/build/get_new_operator_sdk.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+REL=$(dirname "$0")
+ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+OS=$(uname | awk '{print tolower($0)}')
+VERSION="${1:-v1.5.0}"
+OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${VERSION}
+
+if [[ ! -f ${REL}/working/operator-sdk-${VERSION} ]]; then
+	mkdir ${REL}/working
+	curl -L ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} -o ${REL}/working/operator-sdk-${VERSION}
+	chmod +x ${REL}/working/operator-sdk-${VERSION}
+	rm ${REL}/working/operator-sdk
+	ln -s operator-sdk-${VERSION} ${REL}/working/operator-sdk
+fi
+

--- a/build/run-ci.yaml
+++ b/build/run-ci.yaml
@@ -1,6 +1,7 @@
 ---
 # run STF CI setup in CRC (already provisioned)
 - hosts: localhost
+  gather_facts: no
   connection: local
   tasks:
   - name: Run the STF CI system

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -22,6 +22,9 @@ choose to override:
 | ------------------------------                         | ------------    | ---------                                        | ------------------------------------                                                                  |
 | `__deploy_stf`                                         | {true,false}    | true                                             | Whether to deploy an instance of STF                                                                  |
 | `__local_build_enabled`                                | {true,false}    | true                                             | Whether to deploySTF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch` |
+| `__deploy_from_bundles_enabled`                        | {true,false}             | false                                                |  Whether to deploy STF from OLM bundles (TODO: compat with __local_build_enabled) |
+| `__service_telemetry_bundle_image_path`                | <image_path>             | <none>                                                | Image path to Service Telemetry Operator bundle |
+| `__smart_gateway_bundle_image_path`                    | <image_path>             | <none>                                                | Image path to Smart Gateway Operator bundle |
 | `prometheus_webhook_snmp_branch`                       | <git_branch>    | master                                           | Which Prometheus Webhook SNMP git branch to checkout                                                  |
 | `sgo_branch`                                           | <git_branch>    | master                                           | Which Smart Gateway Operator git branch to checkout                                                   |
 | `sg_branch`                                            | <git_branch>    | master                                           | Which Smart Gateway git branch to checkout                                                            |
@@ -72,6 +75,19 @@ the following command:
 ```
 ansible-playbook --extra-vars __local_build_enabled=false run-ci.yaml
 ```
+
+You can deploy directly from pre-built bundles like this:
+```
+ansible-playbook -e __local_build_enabled=false -e __deploy_from_bundles_enabled=true \
+  -e __service_telemetry_bundle_image_path=<registry>/<namespace>/stf-service-telemetry-operator-bundle:<tag> \
+  -e __smart_gateway_bundle_image_path=<registry>/<namespace>/stf-smart-gateway-operator-bundle:<tag> \
+  run-ci.yaml
+```
+
+NOTE: When deploying from bundles, you must have an _authfile_ and _CA.pem_ for
+the registry already in place in the build directory, if required. If these
+are not required, add `--skip-tags bundle_registry_auth --skip-tags bundle_registry_tls_ca`
+to disable one or both.
 
 License
 -------

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -6,6 +6,7 @@ list_of_stf_objects:
   - smart-gateway
 
 __local_build_enabled: true
+__deploy_from_bundles_enabled: false
 __deploy_stf: true
 
 __service_telemetry_events_enabled: true
@@ -14,6 +15,8 @@ __service_telemetry_metrics_enabled: true
 __service_telemetry_storage_ephemeral_enabled: false
 __service_telemetry_snmptraps_enabled: true
 __internal_registry_path: image-registry.openshift-image-registry.svc:5000
+__service_telemetry_bundle_image_path:
+__smart_gateway_bundle_image_path:
 
 sgo_image_tag: latest
 sto_image_tag: latest

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -13,26 +13,36 @@
     sg_bridge_image_path: "{{ __internal_registry_path }}/{{ namespace }}/sg-bridge:{{ sg_bridge_image_tag }}"
     prometheus_webhook_snmp_image_path: "{{ __internal_registry_path }}/{{ namespace }}/prometheus-webhook-snmp:{{ prometheus_webhook_snmp_image_tag }}"
 
-- name: Clear out existing CRDs so we don't conflict or fail merge
-  k8s:
-    state: absent
-    api_version: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    name: "{{ item }}"
-  loop:
-    - smartgateways.smartgateway.infra.watch
-    - servicetelemetrys.infra.watch
+- name: Clean up any existing global artifacts
+  include_tasks: pre-clean.yml
 
-- block:
+- name: Setup supporting Operator subscriptions
+  include_tasks: setup_base.yml
+  tags:
+    - deploy
+
+- name: Get new operator sdk
+  when: __local_build_enabled | bool or __deploy_from_bundles_enabled | bool or __deploy_loki_enabled | bool
+  command: ./get_new_operator_sdk.sh "{{ new_operator_sdk_version }}"
+
+- when: __local_build_enabled | bool
+  block:
   - name: Setup supporting repositories
     include_tasks: clone_repos.yml
     tags:
       - clone
 
-  - name: Setup supporting Operator subscriptions
-    include_tasks: setup_base.yml
-    tags:
-      - deploy
+  - name: Create base build list
+    set_fact:
+      build_list:
+        - { name: service-telemetry-operator, dockerfile_path: build/Dockerfile, image_reference_name: sto_image_path, working_build_dir: ../ }
+        - { name: smart-gateway-operator, dockerfile_path: build/Dockerfile, image_reference_name: sgo_image_path, working_build_dir: ./working/smart-gateway-operator }
+        - { name: sg-core, dockerfile_path: build/Dockerfile, image_reference_name: sg_core_image_path, working_build_dir: ./working/sg-core }
+        - { name: sg-bridge, dockerfile_path: build/Dockerfile, image_reference_name: sg_bridge_image_path, working_build_dir: ./working/sg-bridge }
+        - { name: prometheus-webhook-snmp, dockerfile_path: Dockerfile, image_reference_name: prometheus_webhook_snmp_image_path, working_build_dir: ./working/prometheus-webhook-snmp }
+
+  - debug:
+     var: build_list
 
   - name: Create builds and artifacts
     include_tasks: create_builds.yml
@@ -52,14 +62,14 @@
     tags:
       - deploy
 
-  when: __local_build_enabled | bool
-
 - block:
-  - name: Setup supporting Operator subscriptions
-    include_tasks: setup_base.yml
+  - name: Setup Service Telemetry Framework from supplied bundle URLs
+    include_tasks: setup_stf_from_bundles.yml
+    when: __deploy_from_bundles_enabled | bool
 
   - name: Setup Service Telemetry Framework from application registry
     include_tasks: setup_stf.yml
+    when: not __deploy_from_bundles_enabled | bool
 
   when: not __local_build_enabled | bool
 

--- a/build/stf-run-ci/tasks/pre-clean.yml
+++ b/build/stf-run-ci/tasks/pre-clean.yml
@@ -1,0 +1,31 @@
+# NOTE: This cleanup step prevents parallel CI jobs
+- name: Clear out existing CRDs so we don't conflict or fail merge
+  k8s:
+    state: absent
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: "{{ item }}"
+  loop:
+    - smartgateways.smartgateway.infra.watch
+    - servicetelemetrys.infra.watch
+    - lokistacks.loki.openshift.io
+  tags:
+    - clean-crds
+
+# The clusterroles and clusterrolebindings are global objects that can be left
+# behind by failed bundle installs
+- name: Remove all clusterrolebindings owned by OLM for this namespace
+  k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: clusterrolebindings
+    label_selectors:
+      - "olm.owner.namespace = {{ namespace }}"
+
+- name: Remove all clusterroles owned by OLM for this namespace
+  k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: clusterroles
+    label_selectors:
+      - "olm.owner.namespace = {{ namespace }}"

--- a/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
+++ b/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
@@ -1,0 +1,50 @@
+- name: Create pull secret
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        name: pull-secret
+        namespace: "{{ namespace }}"
+      data:
+        .dockerconfigjson: "{{ lookup('file', 'authfile') | b64encode }}"
+  tags:
+    - bundle_registry_auth
+
+- name: Create registry CA Cert
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: registry-tls-ca
+        namespace: "{{ namespace }}"
+      data:
+        cert.pem: "{{ lookup('file', 'CA.pem') | b64encode }}"
+  tags:
+    - bundle_registry_tls_ca
+
+- name: Patch the default service account to use our pull secret
+  kubernetes.core.k8s_json_patch:
+    kind: ServiceAccount
+    namespace: "{{ namespace }}"
+    name: default
+    patch:
+      - op: add
+        path: /imagePullSecrets
+        value:
+          - name: pull-secret
+  tags:
+    - bundle_registry_tls_ca
+
+- name: Deploy SGO via OLM bundle
+  shell:
+    cmd: "{{ playbook_dir }}/working/operator-sdk run bundle {{__smart_gateway_bundle_image_path}} --pull-secret-name=pull-secret --ca-secret-name=registry-tls-ca --namespace={{ namespace }}"
+
+- name: Deploy STO via OLM bundle
+  shell:
+    cmd: "{{ playbook_dir }}/working/operator-sdk run bundle {{ __service_telemetry_bundle_image_path}} --pull-secret-name=pull-secret --ca-secret-name=registry-tls-ca --namespace={{ namespace }}"


### PR DESCRIPTION
* Adding ability to deploy from bundle URLs

* Added ability to deploy with operator-sdk run bundle instead of from the upstream catalog or a local build
* Added a symlink to simplify calling operator-sdk
* Turned off facts gathering for performance
* Moved a couple when clauses for clarity

* Update build/stf-run-ci/tasks/pre-clean.yml
* Create working dir to download sdk into
* Add required bundle_image_path args to README
* Fixing smoketest

* Version of `oc` in jenkins image doesn't have the `--serviceaccount` option

Co-authored-by: Leif Madsen <lmadsen@redhat.com>

Cherry picks changes from d23f5ab

$ Resolved Conflicts:
$	build/get_new_operator_sdk.sh
$	build/stf-run-ci/README.md
$	build/stf-run-ci/tasks/main.yml
$	build/stf-run-ci/tasks/setup_stf_local_build.yml
$	tests/smoketest/smoketest.sh