### PR TITLE
User user/pass vars instead of magic authfile for bundle images

### DIFF
--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -96,13 +96,16 @@ You can deploy directly from pre-built bundles like this:
 ansible-playbook -e __local_build_enabled=false -e __deploy_from_bundles_enabled=true \
   -e __service_telemetry_bundle_image_path=<registry>/<namespace>/stf-service-telemetry-operator-bundle:<tag> \
   -e __smart_gateway_bundle_image_path=<registry>/<namespace>/stf-smart-gateway-operator-bundle:<tag> \
+  -e pull_secret_registry=<registry> \
+  -e pull_secret_user=<username> \
+  -e pull_secret_pass=<password>
   run-ci.yaml
 ```
 
-NOTE: When deploying from bundles, you must have an _authfile_ and _CA.pem_ for
-the registry already in place in the build directory, if required. If these
-are not required, add `--skip-tags bundle_registry_auth --skip-tags bundle_registry_tls_ca`
-to disable one or both.
+NOTE: When deploying from bundles, you must have a _CA.pem_ for
+the registry already in place in the build directory, if required. If this is
+not required, add `--skip-tags bundle_registry_tls_ca`. If no login is required
+to your bundle image registry, add `--skip-tags bundle_registry_auth`
 
 License
 -------

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -35,6 +35,9 @@ loki_operator_image_tag: latest
 new_operator_sdk_version: v1.11.0
 new_go_version: 1.16.3
 namespace: service-telemetry
+pull_secret_registry:
+pull_secret_user:
+pull_secret_pass:
 
 # Set a default commit hash to clone for loki-operator to freeze
 # the operator developement.

--- a/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
+++ b/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
@@ -1,15 +1,40 @@
-- name: Create pull secret
-  k8s:
-    state: present
-    definition:
-      apiVersion: v1
+- block:
+  - name: Get existing Pull Secret from openshift config
+    k8s_info:
+      api_version: v1
       kind: Secret
-      type: kubernetes.io/dockerconfigjson
-      metadata:
-        name: pull-secret
-        namespace: "{{ namespace }}"
-      data:
-        .dockerconfigjson: "{{ lookup('file', 'authfile') | b64encode }}"
+      namespace: openshift-config
+      name: pull-secret
+    register: pull_secret
+
+  - name: Decode docker config json
+    set_fact:
+      dockerconfigjson: "{{ pull_secret.resources[0].data['.dockerconfigjson'] | b64decode }}"
+
+  - name: Merge registry creds into auth section of docker config
+    set_fact:
+      new_dockerauths: "{{ dockerconfigjson['auths'] | combine( {
+        pull_secret_registry:{
+              'auth': (pull_secret_user ~ ':' ~ pull_secret_pass) | b64encode
+            }
+        }) }}"
+
+  - name: Create new docker config
+    set_fact:
+      new_dockerconfigjson: "{{ dockerconfigjson | combine({'auths': new_dockerauths}) }}"
+
+  - name: Create Pull Secret for bundle registry access
+    k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Secret
+        type: kubernetes.io/dockerconfigjson
+        metadata:
+          name: pull-secret
+          namespace: "{{ namespace }}"
+        data:
+          .dockerconfigjson: "{{ new_dockerconfigjson | tojson | b64encode }}"
   tags:
     - bundle_registry_auth
 


### PR DESCRIPTION
Provides a simpler interface to pull bundles from a private registry. I started automating the process of creating this authfile because I need to call this CI role from downstream; and realized the code I was writing made more sense here.