### PR TITLE
Adding a base_dir variable (#343)

### DIFF
--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -35,4 +35,10 @@ version_branches:
   sg_core: stable-1.3
   sg_bridge: stable-1.2
   prometheus_webhook_snmp: stable-1.3
-  
+
+sgo_repository: https://github.com/infrawatch/smart-gateway-operator
+sg_core_repository: https://github.com/infrawatch/sg-core
+sg_bridge_repository: https://github.com/infrawatch/sg-bridge
+prometheus_webhook_snmp_repository: https://github.com/infrawatch/prometheus-webhook-snmp
+
+base_dir: ''

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -21,9 +21,14 @@
   tags:
     - deploy
 
+- name: Set default base dir if not provided
+  set_fact:
+    base_dir: "{{ playbook_dir }}"
+  when: base_dir | length == 0
+
 - name: Get new operator sdk
   when: __local_build_enabled | bool or __deploy_from_bundles_enabled | bool or __deploy_loki_enabled | bool
-  command: ./get_new_operator_sdk.sh "{{ new_operator_sdk_version }}"
+  command: "{{ base_dir }}/get_new_operator_sdk.sh {{ new_operator_sdk_version }}"
 
 - when: __local_build_enabled | bool
   block:

--- a/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
+++ b/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
@@ -68,8 +68,8 @@
 
 - name: Deploy SGO via OLM bundle
   shell:
-    cmd: "{{ playbook_dir }}/working/operator-sdk run bundle {{__smart_gateway_bundle_image_path}} --pull-secret-name=pull-secret --ca-secret-name=registry-tls-ca --namespace={{ namespace }}"
+    cmd: "{{ base_dir }}/working/operator-sdk run bundle {{__smart_gateway_bundle_image_path}} --pull-secret-name=pull-secret --ca-secret-name=registry-tls-ca --namespace={{ namespace }}"
 
 - name: Deploy STO via OLM bundle
   shell:
-    cmd: "{{ playbook_dir }}/working/operator-sdk run bundle {{ __service_telemetry_bundle_image_path}} --pull-secret-name=pull-secret --ca-secret-name=registry-tls-ca --namespace={{ namespace }}"
+    cmd: "{{ base_dir }}/working/operator-sdk run bundle {{ __service_telemetry_bundle_image_path}} --pull-secret-name=pull-secret --ca-secret-name=registry-tls-ca --namespace={{ namespace }}"

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -5,7 +5,7 @@
   shell:
     chdir: working/smart-gateway-operator/build
     cmd: |
-      WORKING_DIR="{{ playbook_dir }}/working/smart-gateway-operator-bundle" \
+      WORKING_DIR="{{ base_dir }}/working/smart-gateway-operator-bundle" \
       RELATED_IMAGE_CORE_SMARTGATEWAY={{ sg_core_image_path | parse_image | quote }} \
       RELATED_IMAGE_BRIDGE_SMARTGATEWAY={{ sg_bridge_image_path | parse_image | quote }} \
       RELATED_IMAGE_CORE_SMARTGATEWAY_TAG={{ sg_core_image_path | parse_tag | quote }} \
@@ -29,7 +29,7 @@
 
 - name: Replace namespace in SGO CSV
   replace:
-    path: "{{ playbook_dir }}/working/smart-gateway-operator-bundle/manifests/smart-gateway-operator.clusterserviceversion.yaml"
+    path: "{{ base_dir }}/working/smart-gateway-operator-bundle/manifests/smart-gateway-operator.clusterserviceversion.yaml"
     regexp: 'placeholder'
     replace: '{{ namespace }}'
 
@@ -39,9 +39,9 @@
 # --- Service Telemetry Operator ---
 - name: Generate Service Telemetry Operator CSV
   shell:
-    chdir: "{{ playbook_dir }}"
+    chdir: "{{ base_dir }}"
     cmd: |
-      WORKING_DIR="{{ playbook_dir }}/working/service-telemetry-operator-bundle" \
+      WORKING_DIR="{{ base_dir }}/working/service-telemetry-operator-bundle" \
       RELATED_IMAGE_PROMETHEUS_WEBHOOK_SNMP={{ prometheus_webhook_snmp_image_path | parse_image | quote }} \
       RELATED_IMAGE_PROMETHEUS_WEBHOOK_SNMP_TAG={{ prometheus_webhook_snmp_image_path | parse_tag | quote }} \
       OPERATOR_IMAGE={{ sto_image_path | parse_image | quote }} \
@@ -58,7 +58,7 @@
 
 - name: Replace namespace in STO CSV
   replace:
-    path: "{{ playbook_dir }}/working/service-telemetry-operator-bundle/manifests/service-telemetry-operator.clusterserviceversion.yaml"
+    path: "{{ base_dir }}/working/service-telemetry-operator-bundle/manifests/service-telemetry-operator.clusterserviceversion.yaml"
     regexp: 'placeholder'
     replace: '{{ namespace }}'
 


### PR DESCRIPTION
* Adding a base_dir variable to that shell scripts can be found when running remotely

* set base_dir correctly in stf-run-ci/tasks/main.yml

Co-authored-by: Emma Foley <elfiesmelfie@users.noreply.github.com>

Cherry picks changes from da1f402