### PR TITLE
Fix ci for stable-x.y branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 // can't just use BUILD_TAG because qdr operator limits name of resources to 60 chars
 def namespace = env.JOB_BASE_NAME + '-' + env.BUILD_NUMBER
 namespace = namespace.toLowerCase()
+namespace = namespace.replaceAll('\\.', '-')
 
 def stages_failed = false;
 


### PR DESCRIPTION
Replace "." for "-" in ci namespaces. Fixes STF-1023