### PR TITLE
Update to operator-sdk 1.11 on older branches

### DIFF
--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -23,7 +23,7 @@ sto_image_tag: latest
 sg_core_image_tag: latest
 sg_bridge_image_tag: latest
 prometheus_webhook_snmp_image_tag: latest
-new_operator_sdk_version: v1.5.0
+new_operator_sdk_version: v1.11.0
 namespace: service-telemetry
 pull_secret_registry:
 pull_secret_user:


### PR DESCRIPTION
I have no idea if this is okay or not, but I observed that this is different from the master branch and prevents me from using `operator-sdk run bundle` from CI automation when working from this branch. I'm opening this PR just to test the change and discuss whether it's safe or not.