### PR TITLE
Rewrite Jenkinsfile to declarative syntax and skip CI on certain files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,12 @@ pipeline {
 	stages {
 		stage('Clone Upstream') {
 			when {
-				changeset pattern: "${tested_files}", comparator: "REGEXP"
+				anyOf {
+					changeset pattern: "${tested_files}", comparator: "REGEXP"
+					expression {
+						currentBuild.previousBuild.result != "SUCCESS" && currentBuild.previousBuild.result != null
+					}
+				}
 			}
 			steps {
 				dir('service-telemetry-operator') {
@@ -117,7 +122,12 @@ pipeline {
 				expression {
 					currentBuild.result == null
 				}
-				changeset pattern: "${tested_files}", comparator: "REGEXP"
+				anyOf {
+					changeset pattern: "${tested_files}", comparator: "REGEXP"
+					expression {
+						currentBuild.previousBuild.result != "SUCCESS" && currentBuild.previousBuild.result != null
+					}
+				}
 			}
 			steps {
 				dir('service-telemetry-operator') {
@@ -136,7 +146,12 @@ pipeline {
 				expression {
 					currentBuild.result == null
 				}
-				changeset pattern: "${tested_files}", comparator: "REGEXP"
+				anyOf {
+					changeset pattern: "${tested_files}", comparator: "REGEXP"
+					expression {
+						currentBuild.previousBuild.result != "SUCCESS" && currentBuild.previousBuild.result != null
+					}
+				}
 			}
 			steps {
 				dir('service-telemetry-operator') {
@@ -164,7 +179,12 @@ pipeline {
 				expression {
 					currentBuild.result == null
 				}
-				changeset pattern: "${tested_files}", comparator: "REGEXP"
+				anyOf {
+					changeset pattern: "${tested_files}", comparator: "REGEXP"
+					expression {
+						currentBuild.previousBuild.result != "SUCCESS" && currentBuild.previousBuild.result != null
+					}
+				}
 			}
 			steps {
 				dir('service-telemetry-operator') {
@@ -188,7 +208,12 @@ pipeline {
 				expression {
 					currentBuild.result == null
 				}
-				changeset pattern: "${tested_files}", comparator: "REGEXP"
+				anyOf {
+					changeset pattern: "${tested_files}", comparator: "REGEXP"
+					expression {
+						currentBuild.previousBuild.result != "SUCCESS" && currentBuild.previousBuild.result != null
+					}
+				}
 			}
 			steps {
 				dir('service-telemetry-operator') {
@@ -200,7 +225,12 @@ pipeline {
 		}
 		stage('Cleanup') {
 			when {
-				changeset pattern: "${tested_files}", comparator: "REGEXP"
+				anyOf {
+					changeset pattern: "${tested_files}", comparator: "REGEXP"
+					expression {
+						currentBuild.previousBuild.result != "SUCCESS" && currentBuild.previousBuild.result != null
+					}
+				}
 			}
 			steps {
 				dir('service-telemetry-operator') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 #!/usr/bin/env groovy
 
+
+def tested_files = "build/.*|deploy/.*|roles/.*|tests/smoketest/.*|Makefile|watches.yaml|Jenkinsfile"
+
 // can't just use BUILD_TAG because qdr operator limits name of resources to 60 chars
 def namespace = env.JOB_BASE_NAME + '-' + env.BUILD_NUMBER
 namespace = namespace.toLowerCase()
@@ -89,6 +92,9 @@ pipeline {
 	}
 	stages {
 		stage('Clone Upstream') {
+			when {
+				changeset pattern: "${tested_files}", comparator: "REGEXP"
+			}
 			steps {
 				dir('service-telemetry-operator') {
 					catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
@@ -111,6 +117,7 @@ pipeline {
 				expression {
 					currentBuild.result == null
 				}
+				changeset pattern: "${tested_files}", comparator: "REGEXP"
 			}
 			steps {
 				dir('service-telemetry-operator') {
@@ -129,6 +136,7 @@ pipeline {
 				expression {
 					currentBuild.result == null
 				}
+				changeset pattern: "${tested_files}", comparator: "REGEXP"
 			}
 			steps {
 				dir('service-telemetry-operator') {
@@ -156,6 +164,7 @@ pipeline {
 				expression {
 					currentBuild.result == null
 				}
+				changeset pattern: "${tested_files}", comparator: "REGEXP"
 			}
 			steps {
 				dir('service-telemetry-operator') {
@@ -179,6 +188,7 @@ pipeline {
 				expression {
 					currentBuild.result == null
 				}
+				changeset pattern: "${tested_files}", comparator: "REGEXP"
 			}
 			steps {
 				dir('service-telemetry-operator') {
@@ -189,6 +199,9 @@ pipeline {
 			}
 		}
 		stage('Cleanup') {
+			when {
+				changeset pattern: "${tested_files}", comparator: "REGEXP"
+			}
 			steps {
 				dir('service-telemetry-operator') {
 					script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,6 @@ def namespace = env.JOB_BASE_NAME + '-' + env.BUILD_NUMBER
 namespace = namespace.toLowerCase()
 namespace = namespace.replaceAll('\\.', '-')
 
-def stages_failed = false;
-
 def stf_resource = """
 apiVersion: infra.watch/v1beta1
 kind: ServiceTelemetry
@@ -82,79 +80,133 @@ spec:
 
 def working_branch = "master"
 
-node('ocp-agent') {
-    container('exec') {
-        dir('service-telemetry-operator') {
-            stage ('Clone Upstream') {
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    checkout scm
-
-                    // ansible script needs local branch to exist, not detached HEAD
-                    working_branch = sh(script: 'git ls-remote --heads origin | grep $(git rev-parse HEAD) | cut -d / -f 3', returnStdout: true).toString().trim()
-                    if (!working_branch) {
-                        // in this case, a merge with the base branch was required thus we use the second to last commit
-                        // to find the original topic branch name
-                        working_branch = sh(script: 'git ls-remote --heads origin | grep $(git rev-parse HEAD~1) | cut -d / -f 3', returnStdout: true).toString().trim()
-                    }
-
-                    sh "git checkout -b ${working_branch}"
-                }
-            }
-            stage ('Create project') {
-                if ( currentBuild.result != null ) { stages_failed = true; return; }
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    openshift.withCluster(){
-                        openshift.newProject(namespace)
-                    }
-                }
-            }
-            stage('Build STF Containers') {
-                if ( currentBuild.result != null ) { stages_failed = true; return; }
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    ansiColor('xterm') {
-                        ansiblePlaybook(
-                            // use the playbook to build the containers but don't run CI
-                            playbook: 'build/run-ci.yaml',
-                            colorized: true,
-                            extraVars: [
-                                "namespace": namespace,
-                                "__deploy_stf": "false",
-                                "__local_build_enabled": "true",
-                                "__service_telemetry_snmptraps_enabled": "true",
-                                "__service_telemetry_storage_ephemeral_enabled": "true",
-                                "working_branch":"${working_branch}"
-                            ]
-                        )
-                    }
-                }
-            }
-            stage('Deploy STF Object') {
-                if ( currentBuild.result != null ) { stages_failed = true; return; }
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    openshift.withCluster() {
-                        openshift.withProject(namespace) {
-                            timeout(time: 800, unit: 'SECONDS') {
-                                openshift.create(stf_resource)
-                                sh "OCP_PROJECT=${namespace} ./build/validate_deployment.sh"
-                            }
-                        }
-                    }
-                }
-            }
-            stage('Run Smoketest') {
-                if ( currentBuild.result != null ) { stages_failed = true; return; }
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    sh "OCP_PROJECT=${namespace} ./tests/smoketest/smoketest.sh"
-                }
-            }
-            stage('Cleanup') {
-                openshift.withCluster(){
-                    openshift.selector("project/${namespace}").delete()
-                    if ( stages_failed ) { currentBuild.result = 'FAILURE' }
-                }
-                if ( stages_failed ) { currentBuild.result = 'FAILURE' }
-            }
-        }
-    }
+pipeline {
+	agent {
+		kubernetes {
+			inheritFrom 'ocp-agent'
+			defaultContainer 'exec'
+		}
+	}
+	stages {
+		stage('Clone Upstream') {
+			steps {
+				dir('service-telemetry-operator') {
+					catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+						checkout scm
+						script {
+							working_branch = sh(script: 'git ls-remote --heads origin | grep $(git rev-parse HEAD) | cut -d / -f 3', returnStdout: true).toString().trim()
+							if (!working_branch) {
+								// in this case, a merge with the base branch was required thus we use the second to last commit
+								// to find the original topic branch name
+								working_branch = sh(script: 'git ls-remote --heads origin | grep $(git rev-parse HEAD~1) | cut -d / -f 3', returnStdout: true).toString().trim()
+							}
+						}
+						sh "git checkout -b ${working_branch}"
+					}
+				}
+			}
+		}
+		stage('Create project') {
+			when {
+				expression {
+					currentBuild.result == null
+				}
+			}
+			steps {
+				dir('service-telemetry-operator') {
+					catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+						script {
+							openshift.withCluster() {
+								openshift.newProject(namespace)
+							}
+						}
+					}
+				}
+			}
+		}
+		stage('Build STF Containers') {
+			when {
+				expression {
+					currentBuild.result == null
+				}
+			}
+			steps {
+				dir('service-telemetry-operator') {
+					catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+						ansiColor('xterm') {
+							ansiblePlaybook(
+								playbook: 'build/run-ci.yaml',
+								colorized: true,
+								extraVars: [
+									"namespace": namespace,
+									"__deploy_stf": "false",
+									"__local_build_enabled": "true",
+									"__service_telemetry_snmptraps_enabled": "true",
+									"__service_telemetry_storage_ephemeral_enabled": "true",
+									"working_branch":"${working_branch}"
+								]
+							)
+						}
+					}
+				}
+			}
+		}
+		stage('Deploy STF Object') {
+			when {
+				expression {
+					currentBuild.result == null
+				}
+			}
+			steps {
+				dir('service-telemetry-operator') {
+					catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+						script {
+							openshift.withCluster() {
+								openshift.withProject(namespace) {
+									timeout(time: 800, unit: 'SECONDS') {
+										openshift.create(stf_resource)
+										sh "OCP_PROJECT=${namespace} ./build/validate_deployment.sh"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		stage('Run Smoketest') {
+			when {
+				expression {
+					currentBuild.result == null
+				}
+			}
+			steps {
+				dir('service-telemetry-operator') {
+					catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+						sh "OCP_PROJECT=${namespace} ./tests/smoketest/smoketest.sh"
+					}
+				}
+			}
+		}
+		stage('Cleanup') {
+			steps {
+				dir('service-telemetry-operator') {
+					script {
+						openshift.withCluster(){
+							openshift.selector("project/${namespace}").delete()
+						}
+					}
+				}
+			}
+			post {
+				always {
+					script {
+						if ( currentBuild.result != null && currentBuild.result != 'SUCCESS' ) {
+							currentBuild.result = 'FAILURE'
+						}
+					}
+				}
+			}
+		}
+	}
 }
-


### PR DESCRIPTION
This PR resolves the STF-618 and STF-576 issues.

I changed the syntax from scripted to declarative, which should make adding new steps to jenkinsfile a bit easier. I still needed to use quite a few "script" tags, because for example you can't interact with openshift from declarative directly. I read in the plugin readme, that they are looking for ways to allow that.

The CI works the same as before with these small changes:

 - When switching to declarative syntax, it automatically added a new stage at the beginning: "Declarative: Checkout SCM"![pic-sel-220621-1731-55](https://user-images.githubusercontent.com/14599774/174839691-f1bb779b-2301-4b2e-8438-92f82c421846.png)

 - When a stage fails. With the old Jenkinsfile, the stages after that would get executed and they would just return right after they started. Now these stages get skipped completely (except the cleanup stage), as can be seen on the following image (I deliberately edited a few files to fail each stage).
![pic-sel-220621-1731-35](https://user-images.githubusercontent.com/14599774/174839847-ee740541-232f-40dd-a5f0-e981bf14eab1.png)

 - The naming scheme of ocp agents changed from "ocp-agent" to "{repo}-{branch}-{build number}-{some hash}" truncated to 64 character from the front. For example: "ce-telemetry-operator-jwysogla-declarative-jenkinsfile-35-lddv1". This might be useful for future debugging of the CI.

Another small change (the STF-576), I added a regex to the beginning of the Jenkinsfile. Each times the CI is started, it first checks which files changed and executes the pipeline only if one of the files matches the regex. So when we change the README for example, the CI just succeeds instantly.