### PR TITLE
Fix casc template

### DIFF
--- a/.jenkins/deploy/casc-configmap.yaml
+++ b/.jenkins/deploy/casc-configmap.yaml
@@ -124,7 +124,7 @@ data:
             def commentTriggerPhrase = '^test$|^retest$|^recheck$'
             configure { node ->
               node / strategy(class: 'jenkins.branch.DefaultBranchPropertyStrategy') {
-                properties(class: 'java.util.Arrays$ArrayList') {
+                properties(class: 'java.util.Arrays$${ESCAPEDOLLAR}ArrayList') {
                   def s = a(class: 'jenkins.branch.BranchProperty-array')
                   s / 'jenkins.branch.NoTriggerBranchProperty' {}
                   s / 'com.adobe.jenkins.github__pr__comment__build.TriggerPRCommentBranchProperty'(plugin: 'github-pr-comment-build@2.3') {


### PR DESCRIPTION
Repos were not scanning when deploying from this template because the `$` in `java.util.Arrays$ArrayList` was triggering an empty expansion of `$ArrayList`. This uses the `$$` sequence and a non-existent envvar to escape the `$`  (https://stackoverflow.com/a/61259844)