### PR TITLE
Allow forward slashes in working branch names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,11 +103,11 @@ pipeline {
 					catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
 						checkout scm
 						script {
-							working_branch = sh(script: 'git ls-remote --heads origin | grep $(git rev-parse HEAD) | cut -d / -f 3', returnStdout: true).toString().trim()
+							working_branch = sh(script: 'git ls-remote --heads origin | grep $(git rev-parse HEAD) | cut -d / -f 3-', returnStdout: true).toString().trim()
 							if (!working_branch) {
 								// in this case, a merge with the base branch was required thus we use the second to last commit
 								// to find the original topic branch name
-								working_branch = sh(script: 'git ls-remote --heads origin | grep $(git rev-parse HEAD~1) | cut -d / -f 3', returnStdout: true).toString().trim()
+								working_branch = sh(script: 'git ls-remote --heads origin | grep $(git rev-parse HEAD~1) | cut -d / -f 3-', returnStdout: true).toString().trim()
 							}
 						}
 						sh "git checkout -b ${working_branch}"


### PR DESCRIPTION
When a branch is named something like 'enhance/stf-1234' the 'working_branch' value will be invalid as only the first field delimited by a forward-slash will be used. This change increases the range of fields from 3 and onward.