### PR TITLE
Force SGO checkout during build

### DIFF
--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -10,6 +10,7 @@
         repo: "{{ sgo_repository }}"
         dest: working/smart-gateway-operator
         version: "{{ sgo_branch | default(branch, true) }}"
+        force: yes
   rescue:
     - name: "Get {{ version_branches.sgo }} upstream branch because specified branch or repository doesn't exist"
       git:


### PR DESCRIPTION
* Replacing the placeholder namespace during the build results in a "there are local changes" error on next build
* This forces the checkout to discard that (and other!?) local changes
* Quicker dev/test loop