### PR TITLE
Expand support for OCP 4.11 (#391)

### DIFF
--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -13,6 +13,8 @@
           name: certified-operators
         - disabled: false
           name: redhat-operators
+        - disabled: "{{ false if __service_telemetry_observability_strategy == 'use_community' else true }}"
+          name: community-operators
 
 - name: Create OperatorGroup
   k8s:
@@ -63,22 +65,6 @@
           source: redhat-operators
           sourceNamespace: openshift-marketplace
 
-- name: Enable OperatorHub.io for Elastic Cloud on Kubernetes
-  k8s:
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: CatalogSource
-      metadata:
-        name: operatorhubio-operators
-        namespace: openshift-marketplace
-      spec:
-        sourceType: grpc
-        image: quay.io/operatorhubio/catalog:latest
-        displayName: OperatorHub.io Operators
-        publisher: OperatorHub.io
-  when:
-    - __service_telemetry_observability_strategy == "use_community"
-
 - name: Subscribe to Elastic Cloud on Kubernetes Operator
   k8s:
     definition:
@@ -123,7 +109,7 @@
         channel: beta
         installPlanApproval: Automatic
         name: prometheus
-        source: operatorhubio-operators
+        source: community-operators
         sourceNamespace: openshift-marketplace
   when:
     - __service_telemetry_observability_strategy == "use_community"

--- a/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
+++ b/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="=v4.10"
+LABEL com.redhat.openshift.versions="v4.10-v4.11"
 LABEL com.redhat.delivery.backport=false
 
 LABEL com.redhat.component="service-telemetry-operator-bundle-container" \

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     description: Service Telemetry Framework. Umbrella Operator for instantiating
       the required dependencies and configuration of various components to build a
       Service Telemetry platform for telco grade monitoring.
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.10"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.11"}]'
     olm.skipRange: '>=<<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>'
     operatorframework.io/suggested-namespace: service-telemetry
     operators.openshift.io/valid-subscription: '["OpenStack Platform", "Cloud Infrastructure",

--- a/tests/smoketest/smoketest_job.yaml.template
+++ b/tests/smoketest/smoketest_job.yaml.template
@@ -21,9 +21,9 @@ spec:
         - name: CLOUDNAME
           value: <<CLOUDNAME>>
         - name: ELASTICSEARCH_AUTH_PASS
-          value: <<ELASTICSEARCH_AUTH_PASS>>
+          value: "<<ELASTICSEARCH_AUTH_PASS>>"
         - name: PROMETHEUS_AUTH_PASS
-          value: <<PROMETHEUS_AUTH_PASS>>
+          value: "<<PROMETHEUS_AUTH_PASS>>"
         volumeMounts:
         - name: collectd-config
           mountPath: /etc/minimal-collectd.conf.template
@@ -48,9 +48,9 @@ spec:
         - name: CLOUDNAME
           value: <<CLOUDNAME>>
         - name: ELASTICSEARCH_AUTH_PASS
-          value: <<ELASTICSEARCH_AUTH_PASS>>
+          value: "<<ELASTICSEARCH_AUTH_PASS>>"
         - name: PROMETHEUS_AUTH_PASS
-          value: <<PROMETHEUS_AUTH_PASS>>
+          value: "<<PROMETHEUS_AUTH_PASS>>"
         volumeMounts:
         - name: ceilometer-publisher
           mountPath: /ceilometer_publish.py


### PR DESCRIPTION
* Expand support for OCP 4.11

Allow installation to be done on OCP 4.11 while updating the smoketest
jobs to support later versions of the client. Also migrate to using
community-operators CatalogSource instead of OperatorHub.io. Only enable
community-operators when the use_community strategy is enabled.

Update the token request syntax when requesting a service account token.
Add checks to look for oc client version and fail if we're using a
version that's too old.

* Make passwords safer in smoketest job template

Encapsulate the password values with double quotes to help make them
safer for consumption in the template. I had an odd situation where the
password contained a bunch of extended characters and caused the
smoketest to report an error on the template having an issue with yaml
to json.

The password contained several characters such as . and : which confused
the template. Wrapping the contents in the double quotes allowed the
smoketest to apply the job.batch template and result in a working
smoketest run.

(cherry picked from commit 729f8411663d840d21a697bb965dcaf9eddb7c18)
