### PR TITLE
Update oc to 4.11 in jenkins agent

### DIFF
--- a/.jenkins/agent/Dockerfile
+++ b/.jenkins/agent/Dockerfile
@@ -6,5 +6,5 @@ RUN dnf install -y ansible golang python38 && \
     alternatives --set python /usr/bin/python3.8 && \
     python -m pip install openshift kubernetes "ansible-core~=2.12" && \
     ansible-galaxy collection install -f 'kubernetes.core:>=2.2.0' community.general
-RUN curl -LO "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.10/openshift-client-linux.tar.gz" && \
+RUN curl -LO "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.11/openshift-client-linux.tar.gz" && \
     tar -xv -C /usr/local/bin -f openshift-client-linux.tar.gz

--- a/.jenkins/agent/Dockerfile
+++ b/.jenkins/agent/Dockerfile
@@ -6,3 +6,5 @@ RUN dnf install -y ansible golang python38 && \
     alternatives --set python /usr/bin/python3.8 && \
     python -m pip install openshift kubernetes "ansible-core~=2.12" && \
     ansible-galaxy collection install -f 'kubernetes.core:>=2.2.0' community.general
+RUN curl -LO "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.10/openshift-client-linux.tar.gz" && \
+    tar -xv -C /usr/local/bin -f openshift-client-linux.tar.gz


### PR DESCRIPTION
Got this during CI:
```
+ OCP_PROJECT=pr-388-4
+ ./tests/smoketest/smoketest.sh
*** Please install 'oc' client version 4.10 or later ***
```

Let's see...
```
$ oc run -it testagent --image=image-registry.openshift-image-registry.svc:5000/ci/jenkins-agent --command -- /bin/sh
If you don't see a command prompt, try pressing enter.
sh-4.4# oc version
Client Version: v4.2.0-alpha.0-1560-g142cb44
```

Woah, yikes. 4.2??

Patch the Dockerfile...
```
$ oc start-build jenkins-agent --from-file ./Dockerfile --follow=true
[...]
$ oc run -it testagent --image=image-registry.openshift-image-registry.svc:5000/ci/jenkins-agent --command -- /bin/sh
If you don't see a command prompt, try pressing enter.
sh-4.4# oc version
Client Version: 4.10.41
```