### PR TITLE
Migrate to dependencies.yaml

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -203,12 +203,6 @@ spec:
         name: servicemonitors.monitoring.coreos.com
         version: v1
       version: v1beta1
-    required:
-    - description: Creation of Smart Gateways
-      displayName: Smart Gateway
-      kind: SmartGateway
-      name: smartgateways.smartgateway.infra.watch
-      version: v2
   description: Service Telemetry Operator for monitoring clouds
   displayName: Service Telemetry Operator
   icon:

--- a/deploy/olm-catalog/service-telemetry-operator/metadata/dependencies.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/dependencies.yaml
@@ -1,0 +1,7 @@
+---
+dependencies:
+  - type: olm.gvk
+    value:
+      group: smartgateways.smartgateway.infra.watch
+      kind: SmartGateway
+      version: v2


### PR DESCRIPTION
Migrate the requires list out of the CSV and into
metadata/dependencies.yaml. Primarily this is for product release
reasons and dependency resolution with OSBS when performing builds for
product release. These changes are the result of following through the
documentation written at
https://olm.operatorframework.io/docs/concepts/olm-architecture/dependency-resolution/#declaring-dependencies
and
https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md
