### PR TITLE
[jenkins] Add custom context labels for github build status notification

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -10,6 +10,7 @@ RUN jenkins-plugin-cli -p ant:latest \
   email-ext:latest \
   git:latest \
   github-branch-source:latest \
+  github-scm-trait-notification-context:latest \
   gradle:latest \
   ldap:latest \
   mailer:latest \

--- a/.jenkins/deploy/casc-configmap.yaml
+++ b/.jenkins/deploy/casc-configmap.yaml
@@ -94,6 +94,11 @@ data:
                     // 1 : Forks in the same account
                     // 2 : Nobody
                 }
+                // Custom Github Notification Context; https://github.com/jenkinsci/github-scm-trait-notification-context-plugin
+                traits << 'org.jenkinsci.plugins.githubScmTraitNotificationContext.NotificationContextTrait' {
+                   contextLabel("continuous-integration/jenkins/ocp-4.12")
+                   typeSuffix(true)
+                }
             }
 
               // "Project Recognizers"


### PR DESCRIPTION
Multiple jenkins deployment can now be run and report their build status separately instead of both reporting to the same ``continuous-integration/jenkins/pr-merge`` and overriding each other.

There is now ``continuous-integration/jenkins/ocp-<OCP_VERSION>/pr-merge`` NOTE: the OCP_VERSION is hardcoded at the moment

https://github.com/jenkinsci/github-scm-trait-notification-context-plugin