### PR TITLE
Remove OperatorHub.io as a CatalogSource (#394)

### DIFF
--- a/build/stf-run-ci/tasks/pre-clean.yml
+++ b/build/stf-run-ci/tasks/pre-clean.yml
@@ -29,3 +29,22 @@
     kind: clusterroles
     label_selectors:
       - "olm.owner.namespace = {{ namespace }}"
+
+# Clean the environment if it has OperatorHub.io CatalogSource still enabled as
+# environment is using community-operators CatalogSource when use_community has
+# been enabled. This avoids installing an additional CatalogSource which is no
+# longer required.
+- name: Remove OperatorHub.io CatalogSource if it installed
+  k8s:
+    state: absent
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        name: operatorhubio-operators
+        namespace: openshift-marketplace
+      spec:
+        sourceType: grpc
+        image: quay.io/operatorhubio/catalog:latest
+        displayName: OperatorHub.io Operators
+        publisher: OperatorHub.io


### PR DESCRIPTION
Remove the OperatorHub.io CatalogSource and instead use the
community-operators CatalogSource which is available with an OCP
installation. Ideally this will avoid some of the conflicts we've been
seeing in our CI environment. This is a short term fix as future
development will likely make use of Observability Operator to provide
the metrics data store and alert delivery mechanism.

(cherry-picked from commit e50f0573295847d238df547d07dab8a6e460892d)

Backporting this change in order to help with environment cleanup in
testing to avoid some timeouts we're seeing related to this
CatalogSource.
