### PR TITLE
Add olm.substitutesFor annotation

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -171,7 +171,7 @@ metadata:
       Service Telemetry platform for telco grade monitoring.
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.12"}]'
     olm.skipRange: '>=<<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>'
-    olm.substitutesFor: '<<OPERATOR_BUNDLE_VERSION>>'
+    olm.substitutesFor: 'service-telemetry-operator.v<<OPERATOR_BUNDLE_VERSION>>'
     operatorframework.io/suggested-namespace: service-telemetry
     operators.openshift.io/valid-subscription: '["OpenStack Platform", "Cloud Infrastructure",
       "Cloud Suite"]'

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -171,6 +171,7 @@ metadata:
       Service Telemetry platform for telco grade monitoring.
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.12"}]'
     olm.skipRange: '>=<<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>'
+    olm.substitutesFor: '<<OPERATOR_BUNDLE_VERSION>>'
     operatorframework.io/suggested-namespace: service-telemetry
     operators.openshift.io/valid-subscription: '["OpenStack Platform", "Cloud Infrastructure",
       "Cloud Suite"]'


### PR DESCRIPTION
When building the bundle, add the olm.substitutesFor annotation so that
rebuilds (via Freshmaker or otherwise) that have different build
versions appended to the end of the main version (e.g.
service-telemetry-operator-v1.5.15000000001-0.1234.p) can allow the
bundle to be upgraded without changing the skipRange, allowing for
rebuilds due to changes in the resulting base image, but no changes in
the actual operator itself can result in the latest bundle version being
deployed.

Related: RHOSOR-576
