### PR TITLE
Implement changes for operator-sdk-1.26.0 testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,15 +20,9 @@ jobs:
 
       - name: Lint Ansible roles/servicetelemetry/ directory
         run: ${HOME}/.local/bin/ansible-lint roles/servicetelemetry
-# TODO: requires a bunch of work on our bash scripts, or finesse
-#      - name: Run Super-Linter
-#        uses: github/super-linter@v3
-#        env:
-#          DEFAULT_BRANCH: master
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  build-check:
-    name: Build check
+  build-operator-check:
+    name: Build Operator check
     runs-on: ubuntu-20.04
 
     steps:
@@ -38,15 +32,15 @@ jobs:
       - name: Verify image builds
         run: docker build --tag infrawatch/service-telemetry-operator:latest --file build/Dockerfile .
 
-  bundle-check:
-    name: Bundle check
+  build-bundle-check:
+    name: Build bundle check
     runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Get operator-sdk image
+      - name: Get operator-sdk image 0.19.4
         run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk-$RELEASE_VERSION-x86_64-linux-gnu
         env:
           RELEASE_VERSION: v0.19.4
@@ -63,5 +57,63 @@ jobs:
       - name: Generate bundle
         run: WORKING_DIR=/tmp/bundle ./build/generate_bundle.sh
 
+      - name: Verify image builds
+        run: docker build --tag infrawatch/service-telemetry-operator:latest --file build/Dockerfile .
+
+  check-bundle-validation-scorecard:
+    name: Validate the generated bundle and perform scorecard checks
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # prepare environment to buld the bundle
+      - name: Get operator-sdk image 0.19.4
+        run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk-$RELEASE_VERSION-x86_64-linux-gnu
+        env:
+          RELEASE_VERSION: v0.19.4
+
+      - name: Make operator-sdk executable
+        run: chmod +x operator-sdk
+
+      - name: Move operator-sdk binary
+        run: sudo mv operator-sdk /usr/local/bin
+
+      - name: Create working directory
+        run: mkdir /tmp/bundle
+
+      # generate the bundle using operator-sdk-0.19.4
+      - name: Generate bundle
+        run: WORKING_DIR=/tmp/bundle ./build/generate_bundle.sh
+
+      # prepare the environment to run bundle validation and bundle scorecard checks
+      - name: Get operator-sdk image 1.26.0
+        run: curl --output operator-sdk-$RELEASE_VERSION -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk_linux_amd64
+        env:
+          RELEASE_VERSION: v1.26.0
+
+      - name: Make operator-sdk executable
+        run: chmod +x operator-sdk-$RELEASE_VERSION
+        env:
+          RELEASE_VERSION: v1.26.0
+
+      - name: Move operator-sdk binary
+        run: sudo mv operator-sdk-$RELEASE_VERSION /usr/local/bin
+        env:
+          RELEASE_VERSION: v1.26.0
+
+      # perform bundle validation
       - name: Check bundle validation
-        run: operator-sdk bundle validate --verbose /tmp/bundle
+        run: operator-sdk-$RELEASE_VERSION bundle validate --verbose /tmp/bundle
+        env:
+          RELEASE_VERSION: v1.26.0
+
+      - name: Create KinD cluster to execute scorecard tests
+        uses: helm/kind-action@v1.4.0
+
+      # perform scorecard checks against a KinD cluster
+      - name: Check scorecord validation
+        run: operator-sdk-$RELEASE_VERSION scorecard --verbose /tmp/bundle
+        env:
+          RELEASE_VERSION: v1.26.0

--- a/build/generate_bundle.sh
+++ b/build/generate_bundle.sh
@@ -38,6 +38,13 @@ generate_bundle() {
     echo "---- Generated bundle complete at ${WORKING_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"
 }
 
+copy_extra_metadata() {
+    echo "-- Copy extra metadata in"
+    pushd "${REL}/../"
+    cp -r ./deploy/olm-catalog/service-telemetry-operator/tests/ "${WORKING_DIR}"
+    cp ./deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml "${WORKING_DIR}/metadata/"
+}
+
 build_bundle_instructions() {
     echo "-- Commands to create a bundle build"
     echo docker build -t "${OPERATOR_BUNDLE_IMAGE}:${OPERATOR_BUNDLE_VERSION}" -f "${WORKING_DIR}/Dockerfile" "${WORKING_DIR}"
@@ -51,5 +58,6 @@ generate_version
 create_working_dir
 generate_dockerfile
 generate_bundle
+copy_extra_metadata
 build_bundle_instructions
 echo "## End Bundle creation"

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -169,7 +169,6 @@ metadata:
     description: Service Telemetry Framework. Umbrella Operator for instantiating
       the required dependencies and configuration of various components to build a
       Service Telemetry platform for telco grade monitoring.
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.12"}]'
     olm.skipRange: '>=<<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>'
     operatorframework.io/suggested-namespace: service-telemetry
     operators.openshift.io/valid-subscription: '["OpenStack Platform", "Cloud Infrastructure",

--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -1,0 +1,4 @@
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.10"}]'
+properties:
+  - type: olm.maxOpenShiftVersion
+    value: "4.10"

--- a/deploy/olm-catalog/service-telemetry-operator/tests/scorecard/config.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/tests/scorecard/config.yaml
@@ -1,0 +1,21 @@
+kind: Configuration
+apiversion: scorecard.operatorframework.io/v1alpha3
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - image: quay.io/operator-framework/scorecard-test:latest
+    entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+  - image: quay.io/operator-framework/scorecard-test:latest
+    entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test


### PR DESCRIPTION
Implement changes that allow testing validation via operator-sdk-1.26.0
without bumping the entire bundle generation process from
operator-sdk-0.19.4 to post-operator-sdk-1.x.

These are the same tests run for validation during product pipeline
verification.

* Adds test to verify building of the bundle image works.
* Adds KinD deployment to allow executing scorecard checks.

Related: STF-1252
