### PR TITLE
Narrow the scope of the smoke test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ metadata:
   name: default
   namespace: ${namespace}
 spec:
-  observabilityStrategy: use_hybrid
+  observabilityStrategy: use_redhat
   alerting:
     alertmanager:
       storage:

--- a/tests/smoketest/smoketest_ceilometer_entrypoint.sh
+++ b/tests/smoketest/smoketest_ceilometer_entrypoint.sh
@@ -32,38 +32,42 @@ echo "[DEBUG] Query returned"
 metrics_result=$?
 echo "[DEBUG] Set metrics_result to $metrics_result"
 
-echo "*** [INFO] Get documents for this test from ElasticSearch..."
-DOCUMENT_HITS=$(curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "${ELASTICSEARCH}/_search" -H 'Content-Type: application/json' -d'{
-  "query": {
-    "bool": {
-      "filter": [
-        { "term" : { "labels.instance" : { "value" : "'${CLOUDNAME}'", "boost" : 1.0 } } },
-        { "range" : { "startsAt" : { "gte" : "now-1m", "lt" : "now" } } }
-      ]
+if [ "$OBSERVABILITY_STRATEGY" != "use_redhat" ]; then
+  echo "*** [INFO] Get documents for this test from ElasticSearch..."
+  DOCUMENT_HITS=$(curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "${ELASTICSEARCH}/_search" -H 'Content-Type: application/json' -d'{
+    "query": {
+      "bool": {
+        "filter": [
+          { "term" : { "labels.instance" : { "value" : "'${CLOUDNAME}'", "boost" : 1.0 } } },
+          { "range" : { "startsAt" : { "gte" : "now-1m", "lt" : "now" } } }
+        ]
+      }
     }
-  }
-}' | python3 -c "import sys, json; parsed = json.load(sys.stdin); print(parsed['hits']['total']['value'])")
+  }' | python3 -c "import sys, json; parsed = json.load(sys.stdin); print(parsed['hits']['total']['value'])")
 
 
-echo "*** [INFO] List of indices for debugging..."
-curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "${ELASTICSEARCH}/_cat/indices/ceilometer_*?s=index"
-echo
+  echo "*** [INFO] List of indices for debugging..."
+  curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "${ELASTICSEARCH}/_cat/indices/ceilometer_*?s=index"
+  echo
 
-echo "*** [INFO] Get documents for this test from ElasticSearch..."
-ES_INDEX=ceilometer_image
-DOCUMENT_HITS=$(curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "${ELASTICSEARCH}/${ES_INDEX}/_search" -H 'Content-Type: application/json' -d'{
-  "query": {
-    "match_all": {}
-  }
-}'| python3 -c "import sys, json; parsed = json.load(sys.stdin); print(parsed['hits']['total']['value'])")
+  echo "*** [INFO] Get documents for this test from ElasticSearch..."
+  ES_INDEX=ceilometer_image
+  DOCUMENT_HITS=$(curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "${ELASTICSEARCH}/${ES_INDEX}/_search" -H 'Content-Type: application/json' -d'{
+    "query": {
+      "match_all": {}
+    }
+  }'| python3 -c "import sys, json; parsed = json.load(sys.stdin); print(parsed['hits']['total']['value'])")
 
-echo "*** [INFO] Found ${DOCUMENT_HITS} documents"
-echo; echo
+  echo "*** [INFO] Found ${DOCUMENT_HITS} documents"
+  echo; echo
 
-# check if we got documents back for this test
-events_result=1
-if [ "$DOCUMENT_HITS" -gt "0" ]; then
-    events_result=0
+  # check if we got documents back for this test
+  events_result=1
+  if [ "$DOCUMENT_HITS" -gt "0" ]; then
+      events_result=0
+  fi
+else
+  events_result=0
 fi
 
 echo "[INFO] Verification exit codes (0 is passing, non-zero is a failure): events=${events_result} metrics=${metrics_result}"

--- a/tests/smoketest/smoketest_collectd_entrypoint.sh
+++ b/tests/smoketest/smoketest_collectd_entrypoint.sh
@@ -62,25 +62,29 @@ grep -E '"result":\[{"metric":{"__name__":"sensubility_container_health_status",
 metrics_result=$((metrics_result || $?))
 echo; echo
 
-echo "*** [INFO] Get documents for this test from ElasticSearch..."
-DOCUMENT_HITS=$(curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "${ELASTICSEARCH}/_search" -H 'Content-Type: application/json' -d'{
-  "query": {
-    "bool": {
-      "filter": [
-        { "term" : { "labels.instance" : { "value" : "'${CLOUDNAME}'", "boost" : 1.0 } } },
-        { "range" : { "generated" : { "gte" : "now-1m", "lt" : "now" } } }
-      ]
+if [ "$OBSERVABILITY_STRATEGY" != "use_redhat" ]; then
+  echo "*** [INFO] Get documents for this test from ElasticSearch..."
+  DOCUMENT_HITS=$(curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "${ELASTICSEARCH}/_search" -H 'Content-Type: application/json' -d'{
+    "query": {
+      "bool": {
+        "filter": [
+          { "term" : { "labels.instance" : { "value" : "'${CLOUDNAME}'", "boost" : 1.0 } } },
+          { "range" : { "generated" : { "gte" : "now-1m", "lt" : "now" } } }
+        ]
+      }
     }
-  }
-}' | python3 -c "import sys, json; parsed = json.load(sys.stdin); print(parsed['hits']['total']['value'])")
+  }' | python3 -c "import sys, json; parsed = json.load(sys.stdin); print(parsed['hits']['total']['value'])")
 
-echo "*** [INFO] Found ${DOCUMENT_HITS} documents"
-echo; echo
+  echo "*** [INFO] Found ${DOCUMENT_HITS} documents"
+  echo; echo
 
-# check if we got documents back for this test
-events_result=1
-if [ "$DOCUMENT_HITS" -gt "0" ]; then
-    events_result=0
+  # check if we got documents back for this test
+  events_result=1
+  if [ "$DOCUMENT_HITS" -gt "0" ]; then
+      events_result=0
+  fi
+else
+  events_result=0
 fi
 
 echo "[INFO] Verification exit codes (0 is passing, non-zero is a failure): events=${events_result} metrics=${metrics_result}"

--- a/tests/smoketest/smoketest_job.yaml.template
+++ b/tests/smoketest/smoketest_job.yaml.template
@@ -24,6 +24,8 @@ spec:
           value: "<<ELASTICSEARCH_AUTH_PASS>>"
         - name: PROMETHEUS_AUTH_PASS
           value: "<<PROMETHEUS_AUTH_PASS>>"
+        - name: OBSERVABILITY_STRATEGY
+          value: "<<OBSERVABILITY_STRATEGY>>"
         volumeMounts:
         - name: collectd-config
           mountPath: /etc/minimal-collectd.conf.template
@@ -51,6 +53,8 @@ spec:
           value: "<<ELASTICSEARCH_AUTH_PASS>>"
         - name: PROMETHEUS_AUTH_PASS
           value: "<<PROMETHEUS_AUTH_PASS>>"
+        - name: OBSERVABILITY_STRATEGY
+          value: "<<OBSERVABILITY_STRATEGY>>"
         volumeMounts:
         - name: ceilometer-publisher
           mountPath: /ceilometer_publish.py


### PR DESCRIPTION
The intention of this change is to limit CI smoke testing to only our supported components (ie. no ElasticSearch)

I didn't want to remove the code because we intend to support writing to an external ES soon, and we might as well use all the same code for that validation. When we get to that stage, we can just remove these conditionals.

In the meantime, this aligns our CI testing with the new default observability_strategy so we're testing it the same way it would deploy.