### PR TITLE
Manage Operator dependencies with properties.yaml

### DIFF
--- a/build/generate_bundle.sh
+++ b/build/generate_bundle.sh
@@ -6,36 +6,27 @@ REL=$(dirname "$0")
 . "${REL}/metadata.sh"
 
 generate_version() {
-    echo "-- Generating operator version"
     UNIXDATE=$(date '+%s')
     OPERATOR_BUNDLE_VERSION=${OPERATOR_CSV_MAJOR_VERSION}.${UNIXDATE}
-    echo "---- Operator Version: ${OPERATOR_BUNDLE_VERSION}"
 }
 
 create_working_dir() {
-    echo "-- Create working directory"
     WORKING_DIR=${WORKING_DIR:-"/tmp/${OPERATOR_NAME}-bundle-${OPERATOR_BUNDLE_VERSION}"}
     mkdir -p "${WORKING_DIR}"
-    echo "---- Created working directory: ${WORKING_DIR}"
 }
 
 generate_dockerfile() {
-    echo "-- Generate Dockerfile for bundle"
     sed -E "s#<<OPERATOR_BUNDLE_VERSION>>#${OPERATOR_BUNDLE_VERSION}#g;s#<<BUNDLE_CHANNELS>>#${BUNDLE_CHANNELS}#g;s#<<BUNDLE_DEFAULT_CHANNEL>>#${BUNDLE_DEFAULT_CHANNEL}#g" "${REL}/../${BUNDLE_PATH}/Dockerfile.in" > "${WORKING_DIR}/Dockerfile"
-    echo "---- Generated Dockerfile complete"
 }
 
 generate_bundle() {
-    echo "-- Generate bundle"
     REPLACE_REGEX="s#<<CREATED_DATE>>#${CREATED_DATE}#g;s#<<OPERATOR_IMAGE>>#${OPERATOR_IMAGE}#g;s#<<OPERATOR_TAG>>#${OPERATOR_TAG}#g;s#<<RELATED_IMAGE_PROMETHEUS_WEBHOOK_SNMP>>#${RELATED_IMAGE_PROMETHEUS_WEBHOOK_SNMP}#g;s#<<RELATED_IMAGE_PROMETHEUS_WEBHOOK_SNMP_TAG>>#${RELATED_IMAGE_PROMETHEUS_WEBHOOK_SNMP_TAG}#g;s#<<RELATED_IMAGE_OAUTH_PROXY>>#${RELATED_IMAGE_OAUTH_PROXY}#g;s#<<RELATED_IMAGE_OAUTH_PROXY_TAG>>#${RELATED_IMAGE_OAUTH_PROXY_TAG}#g;s#<<OPERATOR_BUNDLE_VERSION>>#${OPERATOR_BUNDLE_VERSION}#g;s#1.99.0#${OPERATOR_BUNDLE_VERSION}#g;s#<<OPERATOR_DOCUMENTATION_URL>>#${OPERATOR_DOCUMENTATION_URL}#g;s#<<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>>#${BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND}#g"
 
-    pushd "${REL}/../"
-    ${OPERATOR_SDK} generate bundle --channels ${BUNDLE_CHANNELS} --default-channel ${BUNDLE_DEFAULT_CHANNEL} --manifests --metadata --version "${OPERATOR_BUNDLE_VERSION}" --output-dir "${WORKING_DIR}"
-    popd
+    pushd "${REL}/../" > /dev/null 2>&1
+    ${OPERATOR_SDK} generate bundle --channels ${BUNDLE_CHANNELS} --default-channel ${BUNDLE_DEFAULT_CHANNEL} --manifests --metadata --version "${OPERATOR_BUNDLE_VERSION}" --output-dir "${WORKING_DIR}" > /dev/null 2>&1
+    popd > /dev/null 2>&1
 
-    echo "---- Replacing variables in generated manifest"
     sed -i -E "${REPLACE_REGEX}" "${WORKING_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"
-    echo "---- Generated bundle complete at ${WORKING_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"
 }
 
 copy_extra_metadata() {
@@ -44,8 +35,7 @@ copy_extra_metadata() {
     # purposes) does, and newer versions of opm (as used in both downstream and
     # upstream index image builds) also understands these files. Just copy them
     # into the bundle directory during building.
-    echo "-- Copy extra metadata in"
-    pushd "${REL}/../"
+    pushd "${REL}/../" > /dev/null 2>&1
     cp -r ./deploy/olm-catalog/service-telemetry-operator/tests/ "${WORKING_DIR}"
     cp ./deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml "${WORKING_DIR}/metadata/"
 }
@@ -58,11 +48,14 @@ build_bundle_instructions() {
 
 
 # generate templates
-echo "## Begin bundle creation"
+#echo "## Begin bundle creation"
 generate_version
 create_working_dir
 generate_dockerfile
 generate_bundle
 copy_extra_metadata
-build_bundle_instructions
-echo "## End Bundle creation"
+#build_bundle_instructions
+#echo "## End Bundle creation"
+
+JSON_OUTPUT='{"operator_bundle_image":"%s","operator_bundle_version":"%s","operator_image":"%s","bundle_channels":"%s","bundle_default_channel":"%s","operator_tag":"%s","working_dir":"%s"}'
+printf "$JSON_OUTPUT" "$OPERATOR_BUNDLE_IMAGE" "$OPERATOR_BUNDLE_VERSION" "$OPERATOR_IMAGE" "$BUNDLE_CHANNELS" "$BUNDLE_DEFAULT_CHANNEL" "$OPERATOR_TAG" "$WORKING_DIR"

--- a/build/stf-run-ci/README.md
+++ b/build/stf-run-ci/README.md
@@ -1,70 +1,67 @@
-stf-run-ci
-==========
+# stf-run-ci
 
 Run the Service Telemetry Framework CI system. This role is intended to be
 called from a playbook running locally on a preconfigured test system.
 Primarily this means a running CodeReady Container system has been provided.
 
-Requirements
-------------
+## Requirements
 
 - CodeReady Containers
 - Ansible 2.9 (tested)
 - `oc` command line tool
 
-Variables
----------
+## Variables
 
 Not all variables are listed here, but these are the most common ones you might
 choose to override:
 
-| Parameter name                                         | Values                   | Default                                               | Description                                                                                                         |
-| ------------------------------                         | ------------             | ---------                                             | ------------------------------------                                                                                |
-| `__deploy_stf`                                         | {true,false}             | true                                                  | Whether to deploy an instance of STF                                                                                |
-| `__local_build_enabled`                                | {true,false}             | true                                                  | Whether to deploy STF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch`              |
-| `__deploy_from_bundles_enabled`                        | {true,false}             | false                                                 | Whether to deploy STF from OLM bundles (TODO: compat with `__local_build_enabled`)                                  |
-| `__service_telemetry_bundle_image_path`                | <image_path>             | <none>                                                | Image path to Service Telemetry Operator bundle                                                                     |
-| `__smart_gateway_bundle_image_path`                    | <image_path>             | <none>                                                | Image path to Smart Gateway Operator bundle                                                                         |
-| `prometheus_webhook_snmp_branch`                       | <git_branch>             | master                                                | Which Prometheus Webhook SNMP git branch to checkout                                                                |
-| `sgo_branch`                                           | <git_branch>             | master                                                | Which Smart Gateway Operator git branch to checkout                                                                 |
-| `sg_core_branch`                                       | <git_branch>             | master                                                | Which Smart Gateway Core git branch to checkout                                                                     |
-| `sg_bridge_branch`                                     | <git_branch>             | master                                                | Which Smart Gateway Bridge git branch to checkout                                                                   |
-| `prometheus_webhook_snmp_branch`                       | <git_branch>             | master                                                | Which Prometheus webhook snmp branch to checkout                                                                    |
-| `sgo_repository`                                       | <git_repository>         | https://github.com/infrawatch/smart-gateway-operator  | Which Smart Gateway Operator git repository to clone                                                                |
-| `sg_core_repository`                                   | <git_repository>         | https://github.com/infrawatch/sg-core                 | Which Smart Gateway Core git repository to clone                                                                    |
-| `sg_bridge_repository`                                 | <git_repository>         | https://github.com/infrawatch/sg-bridge               | Which Smart Gateway Bridge git repository to clone                                                                  |
-| `prometheus_webhook_snmp_repository`                   | <git_repository>         | https://github.com/infrawatch/prometheus-webhook-snmp | Which Prometheus webhook snmp git repository to clone                                                               |
-| `loki_operator_repository`                             | <git_repository>         | https://github.com/viaq/loki-operator                 | Which Loki-operator git repository to clone                                                                         |
-| `__service_telemetry_events_certificates_endpoint_cert_duration`    | [ParseDuration](https://golang.org/pkg/time/#ParseDuration) | 2160h | Lifetime of the ElasticSearch endpoint certificate (minimum duration is 1h)                                         |
-| `__service_telemetry_events_certificates_ca_cert_duration`          | [ParseDuration](https://golang.org/pkg/time/#ParseDuration) | 70080h | Lifetime of the ElasticSearch CA certificate (minimum duration is 1h)                                              |
-| `__service_telemetry_events_enabled`                   | {true,false}             | true                                                  | Whether to enable events support in ServiceTelemetry                                                                |
-| `__service_telemetry_high_availability_enabled`        | {true,false}             | false                                                 | Whether to enable high availability support in ServiceTelemetry                                                     |
-| `__service_telemetry_metrics_enabled`                  | {true,false}             | true                                                  | Whether to enable metrics support in ServiceTelemetry                                                               |
-| `__service_telemetry_storage_ephemeral_enabled`        | {true,false}             | false                                                 | Whether to enable ephemeral storage support in ServiceTelemetry                                                     |
-| `__service_telemetry_storage_persistent_storage_class` | <storage_class>          | <undefined>                                           | Set a custom storageClass to override the default provided by OpenShift platform                                    |
-| `__service_telemetry_snmptraps_enabled`                | {true,false}             | true                                                  | Whether to enable snmptraps delivery via Alertmanager receiver (prometheus-webhook-snmp)                            |
-| `__service_telemetry_snmptraps_community`              | <snmptrap_community>     | `public`                                              | Set the SNMP community to send traps to. Defaults to public                                                         |
-| `__service_telemetry_snmptraps_target`                 | <snmptrap_target>        | `192.168.24.254`                                      | Set the SNMP target to send traps to. Defaults to 192.168.24.254                                                    |
-| `__service_telemetry_snmptraps_retries`                | <snmptrap_retry_count>   | 5                                                     | Set the SNMP retry count for traps. Defaults to 5                                                                   |
-| `__service_telemetry_snmptraps_port`                   | <snmptrap_port>          | 162                                                   | Set the SNMP target port for traps. Defaults to 162                                                                 |
-| `__service_telemetry_snmptraps_timeout`                | <snmptrap_timeout>       | 1                                                     | Set the SNMP retry timeout (in seconds). Defaults to 1                                                              |
-| `__service_telemetry_alert_oid_label`                  | <alert_label>            | oid                                                   | The alert label name to look for oid value. Default to oid.                                                         |
-| `__service_telemetry_trap_oid_prefix`                  | <oid_prefix>             | 1.3.6.1.4.1.50495.15                                  | The OID prefix for trap variable bindings.                                                                          |
-| `__service_telemetry_trap_default_oid`                 | <default_oid>            | 1.3.6.1.4.1.50495.15.1.2.1                            | The trap OID if none is found in the Prometheus alert labels.                                                       |
-| `__service_telemetry_trap_default_severity`            | <default_severity>       | <undefined>                                           | The trap severity if none is found in the Prometheus alert labels.                                                  |
-| `__service_telemetry_logs_enabled`                     | {true,false}             | false                                                 | Whether to enable logs support in ServiceTelemetry                                                                  |
-| `__service_telemetry_observability_strategy`           | <observability_strategy> | `use_hybrid`                                          | Which observability strategy to use for deployment. Default is 'use_hybrid'. Also supported are 'use_redhat', 'use_community', and 'none' |
-| `__service_telemetry_transports_certificates_endpoint_cert_duration`| [ParseDuration](https://golang.org/pkg/time/#ParseDuration) | 2160h | Lifetime of the QDR endpoint certificate (minimum duration is 1h)                                                   |
-| `__service_telemetry_transports_certificates_ca_cert_duration`      | [ParseDuration](https://golang.org/pkg/time/#ParseDuration) | 70080h | Lifetime of the QDR CA certificate (minimum duration is 1h)                                                        |
-| `__internal_registry_path`                             | <registry_path>          | image-registry.openshift-image-registry.svc:5000      | Path to internal registry for image path                                                                            |
-| `__deploy_loki_enabled`                                | {true,false}             | false                                                 | Whether to deploy loki-operator and other systems for logging development purposes                                  |
-| `__golang_image_path`                                  | <image_path>             | quay.io/infrawatch/golang:1.16                        | Golang image path for building the loki-operator image                                                              |
-| `__loki_image_path`                                    | <image_path>             | quay.io/infrawatch/loki:2.2.1                         | Loki image path for Loki microservices                                                                              |
+| Parameter name                                                       | Values                                                      | Default                                               | Description                                                                                                                               |
+| ------------------------------                                       | ------------                                                | ---------                                             | ------------------------------------                                                                                                      |
+| `__deploy_stf`                                                       | {true,false}                                                | true                                                  | Whether to deploy an instance of STF                                                                                                      |
+| `__local_build_enabled`                                              | {true,false}                                                | true                                                  | Whether to deploy STF from local built artifacts. Also see `working_branch`, `sg_branch`, `sgo_branch`                                    |
+| `__deploy_from_bundles_enabled`                                      | {true,false}                                                | false                                                 | Whether to deploy STF from OLM bundles (TODO: compat with `__local_build_enabled`)                                                        |
+| `__deploy_from_index_enabled`                                        | {true,false}                                                | false                                                 | Whether to deploy STF from locally built bundles and index image.                                                                         |
+| `__service_telemetry_bundle_image_path`                              | <image_path>                                                | <none>                                                | Image path to Service Telemetry Operator bundle                                                                                           |
+| `__smart_gateway_bundle_image_path`                                  | <image_path>                                                | <none>                                                | Image path to Smart Gateway Operator bundle                                                                                               |
+| `prometheus_webhook_snmp_branch`                                     | <git_branch>                                                | master                                                | Which Prometheus Webhook SNMP git branch to checkout                                                                                      |
+| `sgo_branch`                                                         | <git_branch>                                                | master                                                | Which Smart Gateway Operator git branch to checkout                                                                                       |
+| `sg_core_branch`                                                     | <git_branch>                                                | master                                                | Which Smart Gateway Core git branch to checkout                                                                                           |
+| `sg_bridge_branch`                                                   | <git_branch>                                                | master                                                | Which Smart Gateway Bridge git branch to checkout                                                                                         |
+| `prometheus_webhook_snmp_branch`                                     | <git_branch>                                                | master                                                | Which Prometheus webhook snmp branch to checkout                                                                                          |
+| `sgo_repository`                                                     | <git_repository>                                            | https://github.com/infrawatch/smart-gateway-operator  | Which Smart Gateway Operator git repository to clone                                                                                      |
+| `sg_core_repository`                                                 | <git_repository>                                            | https://github.com/infrawatch/sg-core                 | Which Smart Gateway Core git repository to clone                                                                                          |
+| `sg_bridge_repository`                                               | <git_repository>                                            | https://github.com/infrawatch/sg-bridge               | Which Smart Gateway Bridge git repository to clone                                                                                        |
+| `prometheus_webhook_snmp_repository`                                 | <git_repository>                                            | https://github.com/infrawatch/prometheus-webhook-snmp | Which Prometheus webhook snmp git repository to clone                                                                                     |
+| `loki_operator_repository`                                           | <git_repository>                                            | https://github.com/viaq/loki-operator                 | Which Loki-operator git repository to clone                                                                                               |
+| `__service_telemetry_events_certificates_endpoint_cert_duration`     | [ParseDuration](https://golang.org/pkg/time/#ParseDuration) | 2160h                                                 | Lifetime of the ElasticSearch endpoint certificate (minimum duration is 1h)                                                               |
+| `__service_telemetry_events_certificates_ca_cert_duration`           | [ParseDuration](https://golang.org/pkg/time/#ParseDuration) | 70080h                                                | Lifetime of the ElasticSearch CA certificate (minimum duration is 1h)                                                                     |
+| `__service_telemetry_events_enabled`                                 | {true,false}                                                | true                                                  | Whether to enable events support in ServiceTelemetry                                                                                      |
+| `__service_telemetry_high_availability_enabled`                      | {true,false}                                                | false                                                 | Whether to enable high availability support in ServiceTelemetry                                                                           |
+| `__service_telemetry_metrics_enabled`                                | {true,false}                                                | true                                                  | Whether to enable metrics support in ServiceTelemetry                                                                                     |
+| `__service_telemetry_storage_ephemeral_enabled`                      | {true,false}                                                | false                                                 | Whether to enable ephemeral storage support in ServiceTelemetry                                                                           |
+| `__service_telemetry_storage_persistent_storage_class`               | <storage_class>                                             | <undefined>                                           | Set a custom storageClass to override the default provided by OpenShift platform                                                          |
+| `__service_telemetry_snmptraps_enabled`                              | {true,false}                                                | true                                                  | Whether to enable snmptraps delivery via Alertmanager receiver (prometheus-webhook-snmp)                                                  |
+| `__service_telemetry_snmptraps_community`                            | <snmptrap_community>                                        | `public`                                              | Set the SNMP community to send traps to. Defaults to public                                                                               |
+| `__service_telemetry_snmptraps_target`                               | <snmptrap_target>                                           | `192.168.24.254`                                      | Set the SNMP target to send traps to. Defaults to 192.168.24.254                                                                          |
+| `__service_telemetry_snmptraps_retries`                              | <snmptrap_retry_count>                                      | 5                                                     | Set the SNMP retry count for traps. Defaults to 5                                                                                         |
+| `__service_telemetry_snmptraps_port`                                 | <snmptrap_port>                                             | 162                                                   | Set the SNMP target port for traps. Defaults to 162                                                                                       |
+| `__service_telemetry_snmptraps_timeout`                              | <snmptrap_timeout>                                          | 1                                                     | Set the SNMP retry timeout (in seconds). Defaults to 1                                                                                    |
+| `__service_telemetry_alert_oid_label`                                | <alert_label>                                               | oid                                                   | The alert label name to look for oid value. Default to oid.                                                                               |
+| `__service_telemetry_trap_oid_prefix`                                | <oid_prefix>                                                | 1.3.6.1.4.1.50495.15                                  | The OID prefix for trap variable bindings.                                                                                                |
+| `__service_telemetry_trap_default_oid`                               | <default_oid>                                               | 1.3.6.1.4.1.50495.15.1.2.1                            | The trap OID if none is found in the Prometheus alert labels.                                                                             |
+| `__service_telemetry_trap_default_severity`                          | <default_severity>                                          | <undefined>                                           | The trap severity if none is found in the Prometheus alert labels.                                                                        |
+| `__service_telemetry_logs_enabled`                                   | {true,false}                                                | false                                                 | Whether to enable logs support in ServiceTelemetry                                                                                        |
+| `__service_telemetry_observability_strategy`                         | <observability_strategy>                                    | `use_hybrid`                                          | Which observability strategy to use for deployment. Default is 'use_hybrid'. Also supported are 'use_redhat', 'use_community', and 'none' |
+| `__service_telemetry_transports_certificates_endpoint_cert_duration` | [ParseDuration](https://golang.org/pkg/time/#ParseDuration) | 2160h                                                 | Lifetime of the QDR endpoint certificate (minimum duration is 1h)                                                                         |
+| `__service_telemetry_transports_certificates_ca_cert_duration`       | [ParseDuration](https://golang.org/pkg/time/#ParseDuration) | 70080h                                                | Lifetime of the QDR CA certificate (minimum duration is 1h)                                                                               |
+| `__internal_registry_path`                                           | <registry_path>                                             | image-registry.openshift-image-registry.svc:5000      | Path to internal registry for image path                                                                                                  |
+| `__deploy_loki_enabled`                                              | {true,false}                                                | false                                                 | Whether to deploy loki-operator and other systems for logging development purposes                                                        |
+| `__golang_image_path`                                                | <image_path>                                                | quay.io/infrawatch/golang:1.16                        | Golang image path for building the loki-operator image                                                                                    |
+| `__loki_image_path`                                                  | <image_path>                                                | quay.io/infrawatch/loki:2.2.1                         | Loki image path for Loki microservices                                                                                                    |
 
 
 
-Example Playbook
-----------------
+# Example Playbook
 
 ```yaml
 ---
@@ -77,32 +74,39 @@ Example Playbook
         name: stf-run-ci
 ```
 
-Usage
------
+# Usage
 
 You can deploy Service Telemetry Framework using this role in a few
 configuration methods:
 
 * local build artifacts from Git repository cloned locally
+* local build artifacts, local bundle artifacts, and Subscription via OLM using locally built index image
 * standard deployment using Subscription and OLM
 * supporting components but no instance of Service Telemetry Operator
+
+## Basic deployment
 
 You can deploy using the sample `run-ci.yaml` from the _Example Playbook_
 section:
 
-```
+```sh
 ansible-playbook run-ci.yaml
 ```
+
+## Standard deloyment with existing artifacts
 
 If you want to do a standard deployment (existing remote artifacts) you can use
 the following command:
 
-```
+```sh
 ansible-playbook --extra-vars __local_build_enabled=false run-ci.yaml
 ```
 
+## Deployment with pre-build bundles
+
 You can deploy directly from pre-built bundles like this:
-```
+
+```sh
 ansible-playbook -e __local_build_enabled=false -e __deploy_from_bundles_enabled=true \
   -e __service_telemetry_bundle_image_path=<registry>/<namespace>/stf-service-telemetry-operator-bundle:<tag> \
   -e __smart_gateway_bundle_image_path=<registry>/<namespace>/stf-smart-gateway-operator-bundle:<tag> \
@@ -117,12 +121,18 @@ the registry already in place in the build directory, if required. If this is
 not required, add `--skip-tags bundle_registry_tls_ca`. If no login is required
 to your bundle image registry, add `--skip-tags bundle_registry_auth`
 
-License
--------
+## Deployment from local artifacts, bundles, and index
+
+You can perform a deployment using OLM and a Subscription from locally built artifacts, bundles, and index image like this:
+
+```sh
+ansible-playbook -e __local_build_enabled=true -e __deploy_from_index_enabled=true run-ci.yaml
+```
+
+# License
 
 Apache v2.0
 
-Author Information
-------------------
+# Author Information
 
-Leif Madsen
+Red Hat (CloudOps DFG)

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -7,6 +7,7 @@ list_of_stf_objects:
 
 __local_build_enabled: true
 __deploy_from_bundles_enabled: false
+__deploy_from_index_enabled: false
 __deploy_stf: true
 
 __service_telemetry_events_certificates_endpoint_cert_duration: 70080h
@@ -33,11 +34,17 @@ __internal_registry_path: image-registry.openshift-image-registry.svc:5000
 __service_telemetry_bundle_image_path:
 __smart_gateway_bundle_image_path:
 
+default_operator_registry_image_base: registry.redhat.io/openshift4/ose-operator-registry
+default_operator_registry_image_tag: v4.12
+
 sgo_image_tag: latest
 sto_image_tag: latest
 sg_core_image_tag: latest
 sg_bridge_image_tag: latest
 prometheus_webhook_snmp_image_tag: latest
+sgo_bundle_image_tag: latest
+sto_bundle_image_tag: latest
+stf_index_image_tag: latest
 new_operator_sdk_version: v1.11.0
 namespace: service-telemetry
 pull_secret_registry:

--- a/build/stf-run-ci/tasks/create_builds.yml
+++ b/build/stf-run-ci/tasks/create_builds.yml
@@ -1,47 +1,51 @@
 ---
-- name: Create BuildConfig and ImageStream
-  shell: oc new-build -n "{{ namespace }}" --name {{ artifact.name }} --dockerfile - < {{ artifact.working_build_dir }}/{{ artifact.dockerfile_path }}
+- name: Get current BuildConfig for artifact to check if it exists
+  k8s_info:
+    api_version: build.openshift.io/v1
+    kind: BuildConfig
+    namespace: "{{ namespace }}"
+    name: "{{ artifact.name }}"
+  register: build_config_lookup
 
-- name: Kill first build since it will always fail (triggered on BuildConfig creation)
-  shell: sleep 10 ; oc delete build {{ artifact.name }}-1 -n "{{ namespace }}"
-
-- name: Kick off build
-  block:
-    - name: Start local image build
-      command: oc start-build {{ artifact.name }} -n "{{ namespace }}" --wait --from-dir "{{ artifact.working_build_dir }}"
-      register: build_name
-  always:
-    - name: Describe local image build (results)
-      command: oc describe build {{ artifact.name }} -n "{{ namespace }}"
-      register: build_describe
-
-    - debug:
-        var: build_describe.stdout_lines
-
-- debug:
-    var: build_name
-
-- name: Set current build name
-  set_fact:
-    this_build_name: "{{ build_name['stdout'].split(' ')[0].split('/')[1] }}"
-
-- debug:
-    var: this_build_name
-
-- name: Get artifact path
+- name: Get current Builds for artifact to check if it exists
   k8s_info:
     api_version: build.openshift.io/v1
     kind: Build
-    name: "{{ this_build_name }}"
     namespace: "{{ namespace }}"
-  register: image_reference
+    label_selectors:
+      - "build={{ artifact.name }}"
+  register: build_lookup
+
+- when: build_config_lookup.resources | length == 0
+  block:
+  - name: Create BuildConfig and ImageStream
+    shell: oc new-build -n "{{ namespace }}" --name {{ artifact.name }} --dockerfile - < {{ artifact.working_build_dir }}/{{ artifact.dockerfile_path }}
+
+  - name: Kill first build since it will always fail (triggered on BuildConfig creation)
+    shell: sleep 10 ; oc delete build {{ artifact.name }}-1 -n "{{ namespace }}"
+
+- name: Start local image build
+  command: oc start-build {{ artifact.name }} -n "{{ namespace }}" --wait --from-dir "{{ artifact.working_build_dir }}"
+  register: build_results
+  when: build_lookup.resources | length == 0
+
+- name: Get latest build information for artifact
+  command: oc get build --selector build={{ artifact.name }} -n "{{ namespace }}" -ojsonpath='{.items[-1:]}'
+  register: build_describe_results
+
+- name: Set build_describe from json results
+  set_fact:
+    build_describe: "{{ build_describe_results.stdout | from_json }}"
 
 - debug:
-    var: image_reference.resources[0].status.outputDockerImageReference
+    var: build_describe
+
+- debug:
+    var: build_describe.status.outputDockerImageReference
 
 - name: Set unique image reference for this artifact
   set_fact:
-    "{{ artifact.image_reference_name }}": "{{ image_reference.resources[0].status.outputDockerImageReference }}"
+    "{{ artifact.image_reference_name }}": "{{ build_describe.status.outputDockerImageReference }}"
 
 - debug:
     var: "{{ artifact.image_reference_name }}"

--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -1,0 +1,145 @@
+---
+- name: Create service-telemetry-framework-index working directory
+  file:
+    path: working/service-telemetry-framework-index
+    state: directory
+    mode: '0755'
+
+- name: Create info variables from bundle generation output
+  set_fact:
+    sto_bundle_info: "{{ generate_bundle_sto.stdout }}"
+    sgo_bundle_info: "{{ generate_bundle_sgo.stdout }}"
+
+- name: Get the builder-dockercfg Secret name
+  command: oc get secret -n {{ namespace }} --field-selector='type==kubernetes.io/dockercfg' -ojsonpath='{.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="builder")].metadata.name}'
+  register: secret_builder_dockercfg_name
+
+- name: Get contents of builder Secret
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ secret_builder_dockercfg_name.stdout }}"
+    namespace: "{{ namespace }}"
+  register: secret_builder_dockercfg_results
+
+- name: Get builder-dockercfg authentication contents
+  set_fact:
+    builder_dockercfg_auth_results: "{{ secret_builder_dockercfg_results.resources[0].data['.dockercfg'] | b64decode }}"
+
+- name: Set internal registry authentication
+  set_fact:
+    internal_registry: "{{ builder_dockercfg_auth_results['image-registry.openshift-image-registry.svc:5000'] | to_json }}"
+
+- when: query('kubernetes.core.k8s', api_version='v1', kind='Secret', resource_name='service-telemetry-framework-index-dockercfg', namespace=namespace) | length == 0
+  block:
+  - name: Create config.json to import as Secret
+    template:
+      variable_start_string: "<<"
+      variable_end_string: ">>"
+      src: config-json.j2
+      dest: working/service-telemetry-framework-index/config.json
+
+  - name: Create a Secret for the dockercfg
+    command: oc create secret generic -n {{ namespace }} service-telemetry-framework-index-dockercfg --from-file=.dockerconfigjson=working/service-telemetry-framework-index/config.json --type=kubernetes.io/dockerconfigjson
+
+- name: Create ImageStream for ose-operator-registry
+  command: oc import-image -n {{ namespace }} ose-operator-registry:{{ default_operator_registry_image_tag }} --from={{ default_operator_registry_image_base }}:{{ default_operator_registry_image_tag }} --confirm
+  when: query('kubernetes.core.k8s', api_version='v1', kind='ImageStream', resource_name='ose-operator-registry', namespace=namespace) | length == 0
+
+- name: Create ImageStream for service-telemetry-framework-index
+  command: oc create imagestream -n {{ namespace }} service-telemetry-framework-index
+  when: query('kubernetes.core.k8s', api_version='v1', kind='ImageStream', resource_name='service-telemetry-framework-index', namespace=namespace) | length == 0
+
+- name: Create BuildConfig for service-telemetry-framework-index
+  k8s:
+    definition:
+      apiVersion: build.openshift.io/v1
+      kind: BuildConfig
+      metadata:
+        annotations:
+          openshift.io/generated-by: stf-run-ci
+        labels:
+          build: service-telemetry-framework-index
+        name: service-telemetry-framework-index
+        namespace: "{{ namespace }}"
+      spec:
+        failedBuildsHistoryLimit: 5
+        nodeSelector: null
+        output:
+          to:
+            kind: ImageStreamTag
+            name: service-telemetry-framework-index:latest
+        postCommit: {}
+        resources: {}
+        runPolicy: Serial
+        source:
+          dockerfile: |
+            # The base image is expected to contain
+            # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+            FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12
+
+            COPY --chmod=666 index.yaml /configs/
+
+            RUN mkdir /tmp/auth/
+            # we need the contents of the mounted build volume from secret placed into config.json
+            RUN cp /opt/app-root/auth/.dockerconfigjson /tmp/auth/config.json
+            RUN DOCKER_CONFIG=/tmp/auth /bin/opm --skip-tls-verify render {{ sto_bundle_image_path }} {{ sgo_bundle_image_path }} --output=yaml >> /configs/index.yaml
+
+            ENTRYPOINT ["/bin/opm"]
+            CMD ["serve", "/configs"]
+            # Set DC-specific label for the location of the DC root directory
+            # in the image
+            LABEL operators.operatorframework.io.index.configs.v1=/configs
+          type: Dockerfile
+        strategy:
+          dockerStrategy:
+            from:
+              kind: ImageStreamTag
+              name: ose-operator-registry:v4.12
+            volumes:
+            - mounts:
+              - destinationPath: /opt/app-root/auth
+              name: pull-secret
+              source:
+                secret:
+                  defaultMode: 420
+                  secretName: service-telemetry-framework-index-dockercfg
+                type: Secret
+          type: Docker
+        successfulBuildsHistoryLimit: 5
+
+- name: Get builds of service-telemetry-framework-index
+  k8s_info:
+    api_version: build.openshift.io/v1
+    kind: Build
+    namespace: "{{ namespace }}"
+    label_selectors:
+      - "build=service-telemetry-framework-index"
+  register: index_builds
+
+- when: index_builds.resources | length == 0
+  block:
+  - name: Create index.yaml base for index image
+    template:
+      src: index-yaml.j2
+      dest: working/service-telemetry-framework-index/index.yaml
+
+  - name: Build service-telemetry-framework-index
+    command: oc start-build -n "{{ namespace }}" service-telemetry-framework-index --wait --from-dir working/service-telemetry-framework-index
+
+- name: Create CloudOps CatalogSource
+  k8s:
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        name: service-telemetry-framework-operators
+        namespace: "{{ namespace }}"
+      spec:
+        displayName: CloudOps Operators
+        image: "{{ stf_index_image_path }}"
+        publisher: CloudOps
+        sourceType: grpc
+        updateStrategy:
+          registryPoll:
+            interval: 1m

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 # tasks file for stf-run-ci
+
+# -- initial setup
 - name: Setup default values
   set_fact:
     branch: "{{ working_branch | default('master') }}"
@@ -13,22 +15,45 @@
     sg_bridge_image_path: "{{ __internal_registry_path }}/{{ namespace }}/sg-bridge:{{ sg_bridge_image_tag }}"
     prometheus_webhook_snmp_image_path: "{{ __internal_registry_path }}/{{ namespace }}/prometheus-webhook-snmp:{{ prometheus_webhook_snmp_image_tag }}"
 
+- name: Set default image paths for bundle and index builds
+  set_fact:
+    sgo_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/smart-gateway-operator-bundle:{{ sgo_bundle_image_tag }}"
+    sto_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-operator-bundle:{{ sto_bundle_image_tag }}"
+    stf_index_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-framework-index:{{ stf_index_image_tag }}"
+
 - name: Fail on mutually exclusive flags
   fail:
     msg: __deploy_from_bundles_enabled not currently supported with __local_build_enabled (but should be)
   when: __local_build_enabled | bool and __deploy_from_bundles_enabled | bool
+
+- name: Fail when deploying from index image and local build disabled
+  fail:
+    msg: __deploy_from_index_enabled must also have __local_build_enabled
+  when: __deploy_from_index_enabled | bool and not __local_build_enabled | bool
+
+- name: Fail when deploying from index images and deployment from bundles also requested (mutually exclusive methods)
+  fail:
+    msg: __deploy_from_index_enabled can not be used with __deploy_from_bundles_enabled
+  when: __deploy_from_index_enabled | bool and __deploy_from_bundles_enabled | bool
 
 - name: Get the list of nodes
   k8s_info:
     kind: Node
   register: node_info
 
+- name: Get OCP version
+  shell: oc version -o yaml | grep openshiftVersion | awk '{print $2}'
+  register: ocp_ver
+
 - name: Find out if we are using crc by looking at the node hostnames
   set_fact:
     is_crc: "{{ True if 'crc' in node_info.resources[0].metadata.labels[\"kubernetes.io/hostname\"] else False }}"
 
+# -- prepare environment and cleanup
 - name: Clean up any existing global artifacts
   include_tasks: pre-clean.yml
+  tags:
+    - pre-clean
 
 - name: Setup supporting Operator subscriptions
   include_tasks: setup_base.yml
@@ -41,10 +66,13 @@
   when: base_dir | length == 0
 
 - name: Get new operator sdk
-  when: __local_build_enabled | bool or __deploy_from_bundles_enabled | bool
+  when: __local_build_enabled | bool or __deploy_from_bundles_enabled | bool or __deploy_from_index_enabled | bool
   command: "{{ base_dir }}/get_new_operator_sdk.sh {{ new_operator_sdk_version }}"
 
+# -- create artifacts
 - when: __local_build_enabled | bool
+  tags:
+    - create_builds
   block:
   - name: Setup supporting repositories
     include_tasks: clone_repos.yml
@@ -76,7 +104,33 @@
     tags:
       - deploy
 
-- block:
+- when: __deploy_from_index_enabled | bool
+  tags:
+    - create_bundles
+  block:
+    - name: Create base build list
+      set_fact:
+        bundle_build_list:
+          - { name: service-telemetry-operator-bundle, dockerfile_path: Dockerfile, image_reference_name: sto_bundle_image_path, working_build_dir: ./working/service-telemetry-operator-bundle }
+          - { name: smart-gateway-operator-bundle, dockerfile_path: Dockerfile, image_reference_name: sgo_bundle_image_path, working_build_dir: ./working/smart-gateway-operator-bundle }
+
+    - debug:
+        var: bundle_build_list
+
+    - name: Create bundle builds and artifacts
+      include_tasks: create_builds.yml
+      loop: "{{ bundle_build_list }}"
+      loop_control:
+        loop_var: artifact
+      tags:
+        - build
+
+    - name: Create file-based catalog
+      include_tasks: create_catalog.yml
+
+# -- deploy
+- when: not __local_build_enabled | bool
+  block:
   - name: Setup Service Telemetry Framework from supplied bundle URLs
     include_tasks: setup_stf_from_bundles.yml
     when: __deploy_from_bundles_enabled | bool
@@ -85,12 +139,31 @@
     include_tasks: setup_stf.yml
     when: not __deploy_from_bundles_enabled | bool
 
-  when: not __local_build_enabled | bool
+- when: __deploy_from_index_enabled | bool
+  name: Subscribe to locally built Service Telemetry Operator
+  k8s:
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        labels:
+          operators.coreos.com/service-telemetry-operator.service-telemetry: ""
+        name: service-telemetry-operator
+        namespace: "{{ namespace }}"
+      spec:
+        channel: unstable
+        installPlanApproval: Automatic
+        name: service-telemetry-operator
+        source: service-telemetry-framework-operators
+        sourceNamespace: "{{ namespace }}"
 
+# -- check if we're ready to instantiate
 - name: Pre-flight checks
   include_tasks: preflight_checks.yml
 
-- block:
+# -- create a ServiceTelemetry object to stand up the STF instance
+- when: __deploy_stf | bool
+  block:
   - name: Deploy an instance of STF
     include_tasks: deploy_stf.yml
 
@@ -103,5 +176,3 @@
 
   - debug:
       var: validate_deployment.stdout_lines
-
-  when: __deploy_stf | bool

--- a/build/stf-run-ci/tasks/pre-clean.yml
+++ b/build/stf-run-ci/tasks/pre-clean.yml
@@ -48,6 +48,47 @@
         displayName: OperatorHub.io Operators
         publisher: OperatorHub.io
 
+- name: Remove CloudOps CatalogSource if it is installed
+  k8s:
+    state: absent
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        name: service-telemetry-framework-operators
+        namespace: "{{ namespace }}"
+      spec:
+        displayName: CloudOps Operators
+        publisher: CloudOps
+        sourceType: grpc
+
+- name: Remove Service Telemetry Operator bundle build
+  k8s:
+    state: absent
+    api_version: build.openshift.io/v1
+    kind: Build
+    namespace: "{{ namespace }}"
+    label_selectors:
+      - "build=service-telemetry-operator-bundle"
+
+- name: Remove Smart Gateway Operator bundle build
+  k8s:
+    state: absent
+    api_version: build.openshift.io/v1
+    kind: Build
+    namespace: "{{ namespace }}"
+    label_selectors:
+      - "build=smart-gateway-operator-bundle"
+
+- name: Remove Service Telemetry Framework index build
+  k8s:
+    state: absent
+    api_version: build.openshift.io/v1
+    kind: Build
+    namespace: "{{ namespace }}"
+    label_selectors:
+      - "build=service-telemetry-framework-index"
+
 - name: Remove service-telemetry-operator-bundle CatalogSource (bundle deploy)
   k8s:
     state: absent

--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -28,51 +28,80 @@
         targetNamespaces:
         - "{{ namespace }}"
 
-- block:
-  - name: Create openshift-cert-manager-operator namespace
-    k8s:
-      definition:
-        apiVersion: project.openshift.io/v1
-        kind: Project
-        metadata:
-          name: openshift-cert-manager-operator
-        spec:
-          finalizers:
-          - kubernetes
+- when: not __deploy_from_index_enabled | bool
+  block:
+    - name: Create openshift-cert-manager-operator namespace
+      k8s:
+        definition:
+          apiVersion: project.openshift.io/v1
+          kind: Project
+          metadata:
+            name: openshift-cert-manager-operator
+          spec:
+            finalizers:
+            - kubernetes
 
-  - name: Create openshift-cert-manager-operator OperatorGroup
-    k8s:
-      definition:
-        apiVersion: operators.coreos.com/v1
-        kind: OperatorGroup
-        metadata:
-          name: openshift-cert-manager-operator
-          namespace: openshift-cert-manager-operator
-        spec: {}
+    - name: Create openshift-cert-manager-operator OperatorGroup
+      k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1
+          kind: OperatorGroup
+          metadata:
+            name: openshift-cert-manager-operator
+            namespace: openshift-cert-manager-operator
+          spec: {}
 
-  - name: Get OCP version
-    shell: oc version -o yaml | grep openshiftVersion | awk '{print $2}'
-    register: ocp_ver
+    - name: Use tech-preview channel for cert_manager in older OCP versions
+      set_fact:
+        cert_manager_channel: tech-preview
+      when: ocp_ver.stdout is version('4.12', '<')
 
-  - name: Use tech-preview channel for cert_manager in older OCP versions
-    set_fact:
-      cert_manager_channel: tech-preview
-    when: ocp_ver.stdout is version('4.12', '<')
+    - name: Subscribe to Cert Manager for OpenShift Operator
+      k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: openshift-cert-manager-operator
+            namespace: openshift-cert-manager-operator
+          spec:
+            channel: "{{ cert_manager_channel }}"
+            installPlanApproval: Automatic
+            name: openshift-cert-manager-operator
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
 
-  - name: Subscribe to Cert Manager for OpenShift Operator
-    k8s:
-      definition:
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: Subscription
-        metadata:
-          name: openshift-cert-manager-operator
-          namespace: openshift-cert-manager-operator
-        spec:
-          channel: "{{ cert_manager_channel }}"
-          installPlanApproval: Automatic
-          name: openshift-cert-manager-operator
-          source: redhat-operators
-          sourceNamespace: openshift-marketplace
+    - name: Subscribe to AMQ Interconnect Operator
+      k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: amq7-interconnect-operator
+            namespace: "{{ namespace }}"
+          spec:
+            channel: 1.10.x
+            installPlanApproval: Automatic
+            name: amq7-interconnect-operator
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
+
+    - name: Subscribe to Prometheus Operator
+      k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: prometheus
+            namespace: "{{ namespace }}"
+          spec:
+            channel: beta
+            installPlanApproval: Automatic
+            name: prometheus
+            source: community-operators
+            sourceNamespace: openshift-marketplace
+      when:
+        - __service_telemetry_observability_strategy == "use_community"
 
 - name: Subscribe to Elastic Cloud on Kubernetes Operator
   k8s:
@@ -90,38 +119,6 @@
         sourceNamespace: openshift-marketplace
   when:
     - __service_telemetry_observability_strategy in ['use_community', 'use_hybrid']
-
-- name: Subscribe to AMQ Interconnect Operator
-  k8s:
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: amq7-interconnect-operator
-        namespace: "{{ namespace }}"
-      spec:
-        channel: 1.10.x
-        installPlanApproval: Automatic
-        name: amq7-interconnect-operator
-        source: redhat-operators
-        sourceNamespace: openshift-marketplace
-
-- name: Subscribe to Prometheus Operator
-  k8s:
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: prometheus
-        namespace: "{{ namespace }}"
-      spec:
-        channel: beta
-        installPlanApproval: Automatic
-        name: prometheus
-        source: community-operators
-        sourceNamespace: openshift-marketplace
-  when:
-    - __service_telemetry_observability_strategy == "use_community"
 
 - block:
   # Upstream Source + Sub from https://github.com/rhobs/observability-operator/tree/main/hack/olm

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -1,5 +1,7 @@
 ---
-# NOTE: the split filter cuts the image path (quay.io:443/infrawatch/container_image:tag_name) on the colon. Field :-1 (everything but the final field) is the image path, field -1 (final field) is the image tag
+# WARNING: generation of bundles is not idempotent from the point of being able
+# to use the generate_bundle_<name> content for use in other places
+
 # --- Smart Gateway Operator ---
 - name: Generate Smart Gateway Operator CSV
   shell:
@@ -15,9 +17,9 @@
       ./generate_bundle.sh
   register: generate_bundle_sgo
 
-- name: Results of bundle generation
+- name: Results of SGO bundle generation
   debug:
-    var: generate_bundle_sgo.stdout_lines
+    var: generate_bundle_sgo.stdout
 
 - name: Replace namespace in SGO role binding
   replace:
@@ -25,22 +27,24 @@
     regexp: 'placeholder'
     replace: '{{ namespace }}'
 
-- name: Load Smart Gateway Operator RBAC
-  command: oc apply -f working/smart-gateway-operator/deploy/{{ item }} -n "{{ namespace }}"
-  loop:
-    - service_account.yaml
-    - role.yaml
-    - role_binding.yaml
-    - olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
-
 - name: Replace namespace in SGO CSV
   replace:
     path: "{{ base_dir }}/working/smart-gateway-operator-bundle/manifests/smart-gateway-operator.clusterserviceversion.yaml"
     regexp: 'placeholder'
     replace: '{{ namespace }}'
 
-- name: Load Smart Gateway Operator CSV
-  shell: oc apply -f working/smart-gateway-operator-bundle/manifests/smart-gateway-operator.clusterserviceversion.yaml -n "{{ namespace }}"
+- when: not __deploy_from_index_enabled | bool
+  block:
+  - name: Load Smart Gateway Operator RBAC
+    command: oc apply -f working/smart-gateway-operator/deploy/{{ item }} -n "{{ namespace }}"
+    loop:
+      - service_account.yaml
+      - role.yaml
+      - role_binding.yaml
+      - olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
+
+  - name: Load Smart Gateway Operator CSV
+    shell: oc apply -f working/smart-gateway-operator-bundle/manifests/smart-gateway-operator.clusterserviceversion.yaml -n "{{ namespace }}"
 
 # --- Service Telemetry Operator ---
 - name: Generate Service Telemetry Operator CSV
@@ -53,6 +57,11 @@
       OPERATOR_IMAGE={{ sto_image_path | parse_image | quote }} \
       OPERATOR_TAG={{ sto_image_path | parse_tag | quote }} \
       ./generate_bundle.sh
+  register: generate_bundle_sto
+
+- name: Results of STO bundle generation
+  debug:
+    var: generate_bundle_sto.stdout
 
 - name: Replace namespace in STO role binding
   replace:
@@ -60,7 +69,14 @@
     regexp: 'placeholder'
     replace: '{{ namespace }}'
 
-- block:
+- name: Replace namespace in STO CSV
+  replace:
+    path: "{{ base_dir }}/working/service-telemetry-operator-bundle/manifests/service-telemetry-operator.clusterserviceversion.yaml"
+    regexp: 'placeholder'
+    replace: '{{ namespace }}'
+
+- when: not __deploy_from_index_enabled | bool
+  block:
   - name: Load Service Telemetry Operator RBAC
     command: oc apply -f ../deploy/{{ item }} -n "{{ namespace }}"
     loop:
@@ -69,15 +85,9 @@
       - role_binding.yaml
       - olm-catalog/service-telemetry-operator/manifests/infra.watch_servicetelemetrys_crd.yaml
 
-  - name: Revert local change to role_binding.yaml
-    shell: git checkout -- "{{ base_dir }}/../deploy/role_binding.yaml"
+  - name: Load Service Telemetry Operator CSV
+    shell: oc apply -f working/service-telemetry-operator-bundle/manifests/service-telemetry-operator.clusterserviceversion.yaml -n "{{ namespace }}"
 
-- name: Replace namespace in STO CSV
-  replace:
-    path: "{{ base_dir }}/working/service-telemetry-operator-bundle/manifests/service-telemetry-operator.clusterserviceversion.yaml"
-    regexp: 'placeholder'
-    replace: '{{ namespace }}'
-
-- name: Load Service Telemetry Operator CSV
-  shell: oc apply -f working/service-telemetry-operator-bundle/manifests/service-telemetry-operator.clusterserviceversion.yaml -n "{{ namespace }}"
-
+# cleanup
+- name: Revert local change to role_binding.yaml
+  shell: git checkout -- "{{ base_dir }}/../deploy/role_binding.yaml"

--- a/build/stf-run-ci/templates/config-json.j2
+++ b/build/stf-run-ci/templates/config-json.j2
@@ -1,0 +1,1 @@
+{"auths":{"image-registry.openshift-image-registry.svc:5000":<< internal_registry >>}}

--- a/build/stf-run-ci/templates/index-yaml.j2
+++ b/build/stf-run-ci/templates/index-yaml.j2
@@ -1,0 +1,20 @@
+---
+defaultChannel: {{ sto_bundle_info.bundle_default_channel }}
+name: service-telemetry-operator
+schema: olm.package
+---
+schema: olm.channel
+package: service-telemetry-operator
+name: {{ sto_bundle_info.bundle_channels }}
+entries:
+  - name: service-telemetry-operator.v{{ sto_bundle_info.operator_bundle_version }}
+---
+defaultChannel: {{ sgo_bundle_info.bundle_default_channel }}
+name: smart-gateway-operator
+schema: olm.package
+---
+schema: olm.channel
+package: smart-gateway-operator
+name: {{ sgo_bundle_info.bundle_channels }}
+entries:
+  - name: smart-gateway-operator.v{{ sgo_bundle_info.operator_bundle_version }}

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -218,12 +218,6 @@ spec:
         name: servicemonitors.monitoring.coreos.com
         version: v1
       version: v1beta1
-    required:
-    - description: Creation of Smart Gateways
-      displayName: Smart Gateway
-      kind: SmartGateway
-      name: smartgateways.smartgateway.infra.watch
-      version: v2
   description: Service Telemetry Operator for monitoring clouds
   displayName: Service Telemetry Operator
   icon:

--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -35,7 +35,7 @@ properties:
         constraints:
           - package:
               packageName: prometheus
-              versionRange: '>= 0.56.0'
+              versionRange: '>=0.56.0'
           - package:
               packageName: rhods-prometheus-operator
               versionRange: '>=4.10.0'

--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -37,8 +37,5 @@ properties:
               packageName: prometheus
               versionRange: '>=0.56.0'
           - package:
-              packageName: rhods-prometheus-operator
-              versionRange: '>=4.10.0'
-          - package:
               packageName: observability-operator
               versionRange: '>=0.0.1'

--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -1,3 +1,35 @@
 properties:
   - type: olm.maxOpenShiftVersion
     value: "4.12"
+  - type: olm.constraint
+    value:
+      failureMessage: Require data transport for Service Telemetry Framework
+      all:
+        constraints:
+          - failureMessage: Package amq7-interconnect-operator is needed for data transport with STF
+            package:
+              packageName: amq7-interconnect-operator
+              versionRange: '>=1.10.0'
+  - type: olm.constraint
+    value:
+      failureMessage: Require certificate management for Service Telemetry Framework
+      all:
+        constraints:
+          - failureMessage: Package openshift-cert-manager-operator is needed for AMQ Interconnect setup
+            package:
+              packageName: openshift-cert-manager-operator
+              versionRange: '>=1.10.0'
+  - type: olm.constraint
+    value:
+      failureMessage: Require Prometheus backend for data storage of metrics for Service Telemetry Framework
+      any:
+        constraints:
+          - package:
+              packageName: prometheus
+              versionRange: '>= 0.56.0'
+          - package:
+              packageName: rhods-prometheus-operator
+              versionRange: '>=4.10.0'
+          - package:
+              packageName: observability-operator
+              versionRange: '>=0.0.1'

--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -3,6 +3,15 @@ properties:
     value: "4.12"
   - type: olm.constraint
     value:
+      failureMessage: Require Smart Gateway for Service Telemetry Framework
+      all:
+        constraints:
+          - failureMessage: Package smart-gateway-operator is needed for Service Telemetry Framework
+            package:
+              packageName: smart-gateway-operator
+              versionRange: '>=5.0.0'
+  - type: olm.constraint
+    value:
       failureMessage: Require data transport for Service Telemetry Framework
       all:
         constraints:


### PR DESCRIPTION
Use the properties.yaml to manage the packages we require when deploying
Service Telemetry Operator. Allows us to reference the Operator name
(which you can find via 'oc get packagemanifests' and reviewing the
packageName value of the packagemanifest (which should just match the
name listed in the oc get packagemanifests output).

Constraints allow the use of versions as well, setting a target of >=
the current version(ish).

Per
https://olm.operatorframework.io/docs/concepts/olm-architecture/dependency-resolution/#nested-compound-constraints:

> A nested compound constraint, one that contains at least one child
compound constraint along with zero or more simple constraints, is
evaluated from the bottom up following the procedures described for each
above.

For Prometheus, we set our ordered list from bottom to top, with a
preference for Observability Operator, followed by RHODS Prometheus
Operator, and finally Prometheus Operator from the Community Catalog.

Closes: STF-1356
