### PR TITLE
Use stable-v1 cert-manager in CI for OCP >= 4.13

### DIFF
--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -57,3 +57,5 @@ sg_bridge_repository: https://github.com/infrawatch/sg-bridge
 prometheus_webhook_snmp_repository: https://github.com/infrawatch/prometheus-webhook-snmp
 
 base_dir: ''
+
+cert_manager_channel: stable-v1

--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -50,6 +50,15 @@
           namespace: openshift-cert-manager-operator
         spec: {}
 
+  - name: Get OCP version
+    shell: oc version -o yaml | grep openshiftVersion | awk '{print $2}'
+    register: ocp_ver
+
+  - name: Use tech-preview channge for cert_manager in older OCP versions
+    set_fact:
+      cert_manager_channel: tech-preview
+    when: ocp_ver.stdout is version('4.13', '<')
+
   - name: Subscribe to Cert Manager for OpenShift Operator
     k8s:
       definition:
@@ -59,7 +68,7 @@
           name: openshift-cert-manager-operator
           namespace: openshift-cert-manager-operator
         spec:
-          channel: tech-preview
+          channel: "{{ cert_manager_channel }}"
           installPlanApproval: Automatic
           name: openshift-cert-manager-operator
           source: redhat-operators


### PR DESCRIPTION
- cert-manager goes GA in 4.13 and the stable-v1 channel is available
- Older versions must still use the tech-preview channel