### PR TITLE
Use the proper parameter for SNMP timeout

### DIFF
--- a/roles/servicetelemetry/templates/manifest_snmp_traps.j2
+++ b/roles/servicetelemetry/templates/manifest_snmp_traps.j2
@@ -28,7 +28,7 @@ spec:
             - name: SNMP_PORT
               value: "{{ servicetelemetry_vars.alerting.alertmanager.receivers.snmp_traps.port }}"
             - name: SNMP_TIMEOUT
-              value: "{{ servicetelemetry_vars.alerting.alertmanager.receivers.snmp_traps.port }}"
+              value: "{{ servicetelemetry_vars.alerting.alertmanager.receivers.snmp_traps.timeout }}"
             - name: ALERT_OID_LABEL
               value: "{{ servicetelemetry_vars.alerting.alertmanager.receivers.snmp_traps.alert_oid_label }}"
             - name: TRAP_OID_PREFIX


### PR DESCRIPTION
The SNMP_TIMEOUT environment variable in the manifest_snmp_traps.j2
template for Service Telemetry Operator uses the wrong parameter,
passing port instead of timeout value to the template.

This change updates the template to use the appropriate parameter as
input.

Closes: rhbz#2213016
