### PR TITLE
Add tests/infrared/17.1

### DIFF
--- a/tests/infrared/17.1/.gitignore
+++ b/tests/infrared/17.1/.gitignore
@@ -1,0 +1,3 @@
+outputs/**
+!outputs/.KEEPIT
+

--- a/tests/infrared/17.1/enable-stf.yaml.template
+++ b/tests/infrared/17.1/enable-stf.yaml.template
@@ -48,7 +48,8 @@ custom_templates:
             - image.*
             - memory
             - memory.*
-            - network.*
+            - network.services.vpn.*
+            - network.services.firewall.*
             - perf.*
             - port
             - port.*
@@ -58,7 +59,8 @@ custom_templates:
             - volume.*
 
             # to avoid filling the memory buffers if disconnected from the message bus
-            collectd::plugin::amqp1::send_queue_limit: 50
+            # note: this may need an adjustment if there are many metrics to be sent.
+            collectd::plugin::amqp1::send_queue_limit: 5000
 
             # receive extra information about virtual memory
             collectd::plugin::vmem::verbose: true
@@ -76,3 +78,4 @@ custom_templates:
               local:
                 host: "%{hiera('fqdn_canonical')}"
                 port: 11211
+

--- a/tests/infrared/17.1/enable-stf.yaml.template
+++ b/tests/infrared/17.1/enable-stf.yaml.template
@@ -1,0 +1,78 @@
+---
+tripleo_heat_templates:
+    []
+
+custom_templates:
+    # matches the documentation for enable-stf.yaml in stable-1.3 documentation
+    parameter_defaults:
+        # only send to STF, not other publishers
+        EventPipelinePublishers: []
+        PipelinePublishers: []
+
+        # manage the polling and pipeline configuration files for Ceilometer agents
+        ManagePolling: true
+        ManagePipeline: true
+
+        # enable Ceilometer metrics and events
+        CeilometerQdrPublishMetrics: true
+        CeilometerQdrPublishEvents: true
+
+        # enable collection of API status
+        CollectdEnableSensubility: true
+        CollectdSensubilityTransport: amqp1
+
+        # enable collection of containerized service metrics
+        CollectdEnableLibpodstats: true
+
+        # set collectd overrides for higher telemetry resolution and extra plugins
+        # to load
+        CollectdConnectionType: amqp1
+        CollectdAmqpInterval: 5
+        CollectdDefaultPollingInterval: 5
+        CollectdExtraPlugins:
+        - vmem
+
+        # set standard prefixes for where metrics and events are published to QDR
+        MetricsQdrAddresses:
+        - prefix: 'collectd'
+          distribution: multicast
+        - prefix: 'anycast/ceilometer'
+          distribution: multicast
+
+        ExtraConfig:
+            ceilometer::agent::polling::polling_interval: 30
+            ceilometer::agent::polling::polling_meters:
+            - cpu
+            - disk.*
+            - ip.*
+            - image.*
+            - memory
+            - memory.*
+            - network.*
+            - perf.*
+            - port
+            - port.*
+            - switch
+            - switch.*
+            - storage.*
+            - volume.*
+
+            # to avoid filling the memory buffers if disconnected from the message bus
+            collectd::plugin::amqp1::send_queue_limit: 50
+
+            # receive extra information about virtual memory
+            collectd::plugin::vmem::verbose: true
+
+            # provide name and uuid in addition to hostname for better correlation
+            # to ceilometer data
+            collectd::plugin::virt::hostname_format: "name uuid hostname"
+
+            # provide the human-friendly name of the virtual instance
+            collectd::plugin::virt::plugin_instance_format: metadata
+
+            # set memcached collectd plugin to report its metrics by hostname
+            # rather than host IP, ensuring metrics in the dashboard remain uniform
+            collectd::plugin::memcached::instances:
+              local:
+                host: "%{hiera('fqdn_canonical')}"
+                port: 11211

--- a/tests/infrared/17.1/extra-hosts.yaml.template
+++ b/tests/infrared/17.1/extra-hosts.yaml.template
@@ -1,0 +1,9 @@
+---
+tripleo_heat_templates:
+    []
+
+custom_templates:
+    parameter_defaults:
+        ExtraHostFileEntries:
+          - '<<EXTRA_HOST_FILE_ENTRIES>>'
+

--- a/tests/infrared/17.1/gnocchi-connectors.yaml.template
+++ b/tests/infrared/17.1/gnocchi-connectors.yaml.template
@@ -1,0 +1,24 @@
+---
+tripleo_heat_templates:
+    []
+
+custom_templates:
+    resource_registry:
+        OS::TripleO::Services::GnocchiApi: /usr/share/openstack-tripleo-heat-templates/deployment/gnocchi/gnocchi-api-container-puppet.yaml
+        OS::TripleO::Services::GnocchiMetricd: /usr/share/openstack-tripleo-heat-templates/deployment/gnocchi/gnocchi-metricd-container-puppet.yaml
+        OS::TripleO::Services::GnocchiStatsd: /usr/share/openstack-tripleo-heat-templates/deployment/gnocchi/gnocchi-statsd-container-puppet.yaml
+        OS::TripleO::Services::AodhApi: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-api-container-puppet.yaml
+        OS::TripleO::Services::AodhEvaluator: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-evaluator-container-puppet.yaml
+        OS::TripleO::Services::AodhNotifier: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-notifier-container-puppet.yaml
+        OS::TripleO::Services::AodhListener: /usr/share/openstack-tripleo-heat-templates/deployment/aodh/aodh-listener-container-puppet.yaml
+
+    parameter_defaults:
+        CeilometerEnableGnocchi: true
+        CeilometerEnablePanko: false
+        GnocchiArchivePolicy: 'high'
+        GnocchiBackend: 'rbd'
+        GnocchiRbdPoolName: 'metrics'
+
+        EventPipelinePublishers: ['gnocchi://?filter_project=service']
+        PipelinePublishers: ['gnocchi://?filter_project=service']
+

--- a/tests/infrared/17.1/infrared-openstack.sh
+++ b/tests/infrared/17.1/infrared-openstack.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -e
+
+# Usage:
+#  VIRTHOST=my.big.hypervisor.net
+#  ./infrared-openstack.sh
+VIRTHOST=${VIRTHOST:-localhost}
+AMQP_HOST=${AMQP_HOST:-stf-default-interconnect-5671-service-telemetry.apps-crc.testing}
+AMQP_PORT=${AMQP_PORT:-443}
+SSH_KEY="${SSH_KEY:-${HOME}/.ssh/id_rsa}"
+NTP_SERVER="${NTP_SERVER:-clock.redhat.com,10.5.27.10,10.11.160.238}"
+CLOUD_NAME="${CLOUD_NAME:-cloud1}"
+EXTRA_HOSTS_ENTRIES="${EXTRA_HOSTS_ENTRIES:-127.0.0.1 stf-default-interconnect-5671-service-telemetry.apps-crc.testing}"
+
+VM_IMAGE_URL_PATH="${VM_IMAGE_URL_PATH:-http://download.devel.redhat.com/rhel-9/rel-eng/RHEL-9/latest-RHEL-9.2/compose/BaseOS/x86_64/images/}"
+# Recommend these default to tested immutable dentifiers where possible, pass "latest" style ids via environment if you want them
+VM_IMAGE="${VM_IMAGE:-rhel-guest-image-9.2-20230414.17.x86_64.qcow2}"
+VM_IMAGE_LOCATION="${VM_IMAGE_URL_PATH}/${VM_IMAGE}"
+
+OSP_BUILD="${OSP_BUILD:-passed_phase2}"
+OSP_VERSION="${OSP_VERSION:-17.1}"
+OSP_TOPOLOGY="${OSP_TOPOLOGY:-undercloud:1,controller:3,compute:2,ceph:3}"
+OSP_MIRROR="${OSP_MIRROR:-rdu2}"
+LIBVIRT_DISKPOOL="${LIBVIRT_DISKPOOL:-/var/lib/libvirt/images}"
+STF_ENVIRONMENT_TEMPLATE="${STF_ENVIRONMENT_TEMPLATE:-stf-connectors.yaml.template}"
+GNOCCHI_ENVIRONMENT_TEMPLATE="${GNOCCHI_ENVIRONMENT_TEMPLATE:-gnocchi-connectors.yaml.template}"
+ENABLE_STF_ENVIRONMENT_TEMPLATE="${ENABLE_STF_ENVIRONMENT_TEMPLATE:-enable-stf.yaml.template}"
+OVERCLOUD_DOMAIN="${OVERCLOUD_DOMAIN:-`hostname -s`}"
+
+UNDERCLOUD_CPU="${UNDERCLOUD_CPU:-4}"
+UNDERCLOUD_MEMORY="${UNDERCLOUD_MEMORY:-16384}"
+CONTROLLER_CPU="${CONTROLLER_CPU:-2}"
+CONTROLLER_MEMORY="${CONTROLLER_MEMORY:-12228}"
+COMPUTE_CPU="${COMPUTE_CPU:-4}"
+COMPUTE_MEMORY="${COMPUTE_MEMORY:-12228}"
+CEPH_CPU="${CEPH_CPU:-2}"
+CEPH_MEMORY="${CEPH_MEMORY:-4096}"
+
+TEMPEST_ONLY="${TEMPEST_ONLY:-false}"
+RUN_WORKLOAD="${RUN_WORKLOAD:-false}"
+CA_CERT_FILE_CONTENT="${CA_CERT_FILE_CONTENT:-}"
+ENABLE_STF_CONNECTORS="${ENABLE_STF_CONNECTORS:-true}"
+ENABLE_GNOCCHI_CONNECTORS="${ENABLE_GNOCCHI_CONNECTORS:-true}"
+
+ir_run_cleanup() {
+  infrared virsh \
+      -vv \
+      -o outputs/cleanup.yml \
+      --disk-pool "${LIBVIRT_DISKPOOL}" \
+      --host-address "${VIRTHOST}" \
+      --host-key "${SSH_KEY}" \
+      --cleanup yes
+
+  echo "*** If you just want to clean up the environment now is your chance to Ctrl+C ***"
+  sleep 10
+}
+
+ir_run_provision() {
+  infrared virsh \
+      -vvv \
+      -o outputs/provision.yml \
+      --disk-pool "${LIBVIRT_DISKPOOL}" \
+      --topology-nodes "${OSP_TOPOLOGY}" \
+      --host-address "${VIRTHOST}" \
+      --host-key "${SSH_KEY}" \
+      --image-url "${VM_IMAGE_LOCATION}" \
+      --host-memory-overcommit True \
+      --topology-network 3_nets \
+      -e override.undercloud.cpu="${UNDERCLOUD_CPU}" \
+      -e override.undercloud.memory="${UNDERCLOUD_MEMORY}" \
+      -e override.controller.cpu="${CONTROLLER_CPU}" \
+      -e override.controller.memory="${CONTROLLER_MEMORY}" \
+      -e override.compute.cpu="${COMPUTE_CPU}" \
+      -e override.compute.memory="${COMPUTE_MEMORY}" \
+      -e override.ceph.cpu="${CEPH_CPU}" \
+      -e override.ceph.memory="${CEPH_MEMORY}" \
+      --serial-files True \
+      --bootmode uefi
+}
+
+ir_create_undercloud() {
+  infrared tripleo-undercloud \
+      -vv \
+      -o outputs/undercloud-install.yml \
+      --mirror "${OSP_MIRROR}" \
+      --version "${OSP_VERSION}" \
+      --splitstack no \
+      --shade-host undercloud-0 \
+      --ssl yes \
+      --build "${OSP_BUILD}" \
+      --images-task rpm \
+      --images-update no \
+      --tls-ca https://password.corp.redhat.com/RH-IT-Root-CA.crt \
+      --overcloud-domain "${OVERCLOUD_DOMAIN}" \
+      --config-options DEFAULT.undercloud_timezone=UTC
+}
+
+stf_create_config() {
+  sed -r "s/<<AMQP_HOST>>/${AMQP_HOST}/;s/<<AMQP_PORT>>/${AMQP_PORT}/;s/<<CLOUD_NAME>>/${CLOUD_NAME}/;s/<<EXTRA_HOSTS_ENTRIES>>/${EXTRA_HOSTS_ENTRIES};s%<<CA_CERT_FILE_CONTENT>>%${CA_CERT_FILE_CONTENT//$'\n'/<@@@>}%;s/<@@@>/\n                /g" ${STF_ENVIRONMENT_TEMPLATE} > outputs/stf-connectors.yaml
+}
+
+gnocchi_create_config() {
+  cat ${GNOCCHI_ENVIRONMENT_TEMPLATE} > outputs/gnocchi-connectors.yaml
+}
+
+enable_stf_create_config() {
+  cat ${ENABLE_STF_ENVIRONMENT_TEMPLATE} > outputs/enable-stf.yaml
+}
+
+ir_create_overcloud() {
+  infrared tripleo-overcloud \
+      -vv \
+      -o outputs/overcloud-install.yml \
+      --version "${OSP_VERSION}" \
+      --deployment-files virt \
+      --overcloud-debug yes \
+      --network-backend geneve \
+      --network-protocol ipv4 \
+      --network-bgpvpn no \
+      --network-dvr no \
+      --network-l2gw no \
+      --storage-backend ceph \
+      --storage-external no \
+      --overcloud-ssl no \
+      --introspect yes \
+      --tagging yes \
+      --deploy yes \
+      --ntp-server "${NTP_SERVER}" \
+      --overcloud-templates ceilometer-write-qdr-edge-only,outputs/enable-stf.yaml,outputs/stf-connectors.yaml,outputs/gnocchi-connectors.yaml \
+      --overcloud-domain "${OVERCLOUD_DOMAIN}" \
+      --containers yes \
+      --vbmc-force False \
+      --vbmc-host undercloud \
+      --config-heat ComputeParameters.NeutronBridgeMappings='tenant:br-isolated' \
+      --extra-vars osp_version=17.0
+}
+
+ir_run_tempest() {
+  infrared tempest \
+      -vv \
+      -o outputs/test.yml \
+      --openstack-installer tripleo \
+      --openstack-version "${OSP_VERSION}" \
+      --tests smoke \
+      --setup rpm \
+      --revision=HEAD \
+      --image http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+}
+
+ir_expose_ui() {
+  infrared cloud-config --external-dhcp True \
+                        --external-shared True \
+                        --deployment-files virt \
+                        --tasks create_external_network,forward_overcloud_dashboard
+}
+
+ir_run_workload() {
+  infrared cloud-config --deployment-files virt --tasks launch_workload
+}
+
+if [ -z "${CA_CERT_FILE_CONTENT}" ]; then
+    echo "CA_CERT_FILE_CONTENT must be set and passed to the deployment, or QDR will fail to connect."
+    exit 1
+fi
+
+time if ${TEMPEST_ONLY}; then
+  echo "-- Running tempest tests"
+  ir_run_tempest
+else
+  echo "-- full cloud deployment"
+  echo ">> Cloud name: ${CLOUD_NAME}"
+  echo ">> Overcloud domain: ${OVERCLOUD_DOMAIN}"
+  echo ">> STF enabled: ${ENABLE_STF_CONNECTORS}"
+  echo ">> Gnocchi enabled: ${ENABLE_GNOCCHI_CONNECTORS}"
+  echo ">> OSP version: ${OSP_VERSION}"
+  echo ">> OSP build: ${OSP_BUILD}"
+  echo ">> OSP topology: ${OSP_TOPOLOGY}"
+
+  ir_run_cleanup
+  ir_run_provision
+  ir_create_undercloud
+  if ${ENABLE_STF_CONNECTORS}; then
+    stf_create_config
+    enable_stf_create_config
+  else
+    touch outputs/stf-connectors.yaml
+    truncate --size 0 outputs/stf-connectors.yaml
+    touch outputs/enable-stf.yaml
+    truncate --size 0 outputs/enable-stf.yaml
+  fi
+  if ${ENABLE_GNOCCHI_CONNECTORS}; then
+    gnocchi_create_config
+  else
+    touch outputs/gnocchi-connectors.yaml
+    truncate --size 0 outputs/gnocchi-connectors.yaml
+  fi
+
+  ir_create_overcloud
+  ir_expose_ui
+  if ${RUN_WORKLOAD}; then
+    ir_run_workload
+  fi
+
+  echo "-- deployment completed"
+  echo ">> Cloud name: ${CLOUD_NAME}"
+  echo ">> Overcloud domain: ${OVERCLOUD_DOMAIN}"
+  echo ">> STF enabled: ${ENABLE_STF_CONNECTORS}"
+  echo ">> Gnocchi enabled: ${ENABLE_GNOCCHI_CONNECTORS}"
+  echo ">> OSP version: ${OSP_VERSION}"
+  echo ">> OSP build: ${OSP_BUILD}"
+  echo ">> OSP topology: ${OSP_TOPOLOGY}"
+fi

--- a/tests/infrared/17.1/stf-connectors.yaml.template
+++ b/tests/infrared/17.1/stf-connectors.yaml.template
@@ -9,6 +9,9 @@ custom_templates:
 
     # set parameter defaults to match stable-1.3 documentation
     parameter_defaults:
+        ExtraConfig:
+            qdr::router_id: "%{::hostname}.<<CLOUD_NAME>>"
+
         MetricsQdrConnectors:
             - host: <<AMQP_HOST>>
               port: <<AMQP_PORT>>
@@ -45,10 +48,6 @@ custom_templates:
         CephStorageExtraConfig:
             tripleo::profile::base::metrics::collectd::amqp_host: "%{hiera('storage')}"
             tripleo::profile::base::metrics::qdr::listener_addr: "%{hiera('storage')}"
-
-        ExtraConfig:
-            ExtraHostsEntries:
-                - "<<EXTRA_HOSTS_ENTRIES>>"
 
             collectd::plugin::ceph::daemons:
                - ceph-osd.0

--- a/tests/infrared/17.1/stf-connectors.yaml.template
+++ b/tests/infrared/17.1/stf-connectors.yaml.template
@@ -1,0 +1,68 @@
+---
+tripleo_heat_templates:
+    []
+
+custom_templates:
+    # don't load collectd-write-qdr.yaml when using multi-cloud and instead load collectd service directly
+    resource_registry:
+        OS::TripleO::Services::Collectd: /usr/share/openstack-tripleo-heat-templates/deployment/metrics/collectd-container-puppet.yaml
+
+    # set parameter defaults to match stable-1.3 documentation
+    parameter_defaults:
+        MetricsQdrConnectors:
+            - host: <<AMQP_HOST>>
+              port: <<AMQP_PORT>>
+              role: edge
+              verifyHostname: false
+              sslProfile: sslProfile
+
+        MetricsQdrSSLProfiles:
+            - name: sslProfile
+              caCertFileContent: |
+                <<CA_CERT_FILE_CONTENT>>
+
+        CeilometerQdrEventsConfig:
+            driver: amqp
+            topic: <<CLOUD_NAME>>-event
+
+        CeilometerQdrMetricsConfig:
+            driver: amqp
+            topic: <<CLOUD_NAME>>-metering
+
+        CollectdAmqpInstances:
+            <<CLOUD_NAME>>-notify:
+                format: JSON
+                notify: true
+                presettle: false
+            <<CLOUD_NAME>>-telemetry:
+                format: JSON
+                presettle: false
+
+        CollectdSensubilityResultsChannel: sensubility/<<CLOUD_NAME>>-telemetry
+
+        # --- below here, extended configuration for environment beyond what is documented in stable-1.3
+        CollectdSensubilityLogLevel: DEBUG
+        CephStorageExtraConfig:
+            tripleo::profile::base::metrics::collectd::amqp_host: "%{hiera('storage')}"
+            tripleo::profile::base::metrics::qdr::listener_addr: "%{hiera('storage')}"
+
+        ExtraConfig:
+            ExtraHostsEntries:
+                - "<<EXTRA_HOSTS_ENTRIES>>"
+
+            collectd::plugin::ceph::daemons:
+               - ceph-osd.0
+               - ceph-osd.1
+               - ceph-osd.2
+               - ceph-osd.3
+               - ceph-osd.4
+               - ceph-osd.5
+               - ceph-osd.6
+               - ceph-osd.7
+               - ceph-osd.8
+               - ceph-osd.9
+               - ceph-osd.10
+               - ceph-osd.11
+               - ceph-osd.12
+               - ceph-osd.13
+               - ceph-osd.14


### PR DESCRIPTION
Add a new tests/infrared/17.1/ configuration. Add extra hosts file entry configuration to make it easier to point at an existing OpenShift deployment (primarily used with stf-verify-containers).