### PR TITLE
Fix bug with supplied user.crt/key not persisting

### DIFF
--- a/roles/servicetelemetry/tasks/component_clouds.yml
+++ b/roles/servicetelemetry/tasks/component_clouds.yml
@@ -57,7 +57,7 @@
         name: '{{ servicetelemetry_vars.backends.events.elasticsearch.forwarding.tls_secret_name }}'
       register: es_certs
 
-    - when: es_certs[0].data[user.key] is not defined or es_certs[0].data[user.crt] is not defined
+    - when: es_certs.resources[0].data[user.key] is not defined or es_certs.resources[0].data[user.crt] is not defined
       block:
         - name: Load dummy certs
           include_vars:

--- a/roles/servicetelemetry/tasks/component_clouds.yml
+++ b/roles/servicetelemetry/tasks/component_clouds.yml
@@ -57,7 +57,7 @@
         name: '{{ servicetelemetry_vars.backends.events.elasticsearch.forwarding.tls_secret_name }}'
       register: es_certs
 
-    - when: es_certs.resources[0].data[user.key] is not defined or es_certs.resources[0].data[user.crt] is not defined
+    - when: es_certs.resources[0].data["user.key"] is not defined or es_certs.resources[0].data["user.crt"] is not defined
       block:
         - name: Load dummy certs
           include_vars:


### PR DESCRIPTION
I haven't tested this yet, just spotted it while working on related code and want to make sure I don't forget.  I suspect the existing code will overwrite a supplied user.key/.crt with dummy data in all cases.