### PR TITLE
Revert cert-manager channel to "tech-preview"

### DIFF
--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -64,5 +64,3 @@ sg_bridge_repository: https://github.com/infrawatch/sg-bridge
 prometheus_webhook_snmp_repository: https://github.com/infrawatch/prometheus-webhook-snmp
 
 base_dir: ''
-
-cert_manager_channel: stable-v1

--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -51,11 +51,6 @@
             namespace: openshift-cert-manager-operator
           spec: {}
 
-    - name: Use tech-preview channel for cert_manager in older OCP versions
-      set_fact:
-        cert_manager_channel: tech-preview
-      when: ocp_ver.stdout is version('4.12', '<')
-
     - name: Subscribe to Cert Manager for OpenShift Operator
       k8s:
         definition:
@@ -65,7 +60,7 @@
             name: openshift-cert-manager-operator
             namespace: openshift-cert-manager-operator
           spec:
-            channel: "{{ cert_manager_channel }}"
+            channel: "tech-preview"
             installPlanApproval: Automatic
             name: openshift-cert-manager-operator
             source: redhat-operators


### PR DESCRIPTION
We recently changed the channel being used to retrieve cert-manager from "tech-preview" to "stable-v1"

Since we only support tech-preview for up to STF 1.5.2, we should stick to test using that version