### PR TITLE
Bump compatibility from 4.10-4.12 to 4.10-4.14

### DIFF
--- a/.jenkins/README.md
+++ b/.jenkins/README.md
@@ -40,7 +40,7 @@ export SMEE_CHANNEL=<YOUR_SMEE_CHANNEL>  #(just the slug, not the whole URL)
 export GH_ORG=<YOUR_GITHUB_ORGANIZATION>
 export JENKINS_URL=$(oc get route jenkins -ojsonpath='{.spec.host}')
 # This is for labelling the status that is returned to github
-export OCP_VERSION=<ocp version>  # e.g. 4.12
+export OCP_VERSION=<ocp version>  # e.g. 4.14
 
 for f in deploy/*; do
   envsubst < "${f}" | oc apply -f -

--- a/.jenkins/agent/Dockerfile
+++ b/.jenkins/agent/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-jenkins-agent-base:latest
 
 # pass --build-arg OC_CLIENT_VERSION=<version> to build stage to change client version
-ARG OC_CLIENT_VERSION="4.12"
+ARG OC_CLIENT_VERSION="4.13"
 
 RUN curl -LO "https://github.com/operator-framework/operator-sdk/releases/download/v0.19.4/operator-sdk-v0.19.4-x86_64-linux-gnu" && \
     chmod +x operator-sdk-v0.19.4-x86_64-linux-gnu && mv operator-sdk-v0.19.4-x86_64-linux-gnu /usr/local/bin/operator-sdk

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -35,7 +35,7 @@ __service_telemetry_bundle_image_path: "quay.io/infrawatch-operators/service-tel
 __smart_gateway_bundle_image_path: "quay.io/infrawatch-operators/smart-gateway-operator-bundle:nightly-head"
 
 default_operator_registry_image_base: registry.redhat.io/openshift4/ose-operator-registry
-default_operator_registry_image_tag: v4.12
+default_operator_registry_image_tag: v4.13
 
 elasticsearch_version: 7.16.1
 

--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -76,7 +76,7 @@
           dockerfile: |
             # The base image is expected to contain
             # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-            FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12
+            FROM registry.redhat.io/openshift4/ose-operator-registry:v4.13
 
             COPY --chmod=666 index.yaml /configs/
 
@@ -95,7 +95,7 @@
           dockerStrategy:
             from:
               kind: ImageStreamTag
-              name: ose-operator-registry:v4.12
+              name: ose-operator-registry:v4.13
             volumes:
             - mounts:
               - destinationPath: /opt/app-root/auth

--- a/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
+++ b/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.10-v4.12"
+LABEL com.redhat.openshift.versions="v4.10-v4.14"
 LABEL com.redhat.delivery.backport=false
 
 LABEL com.redhat.component="service-telemetry-operator-bundle-container" \

--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -1,6 +1,6 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: "4.12"
+    value: "4.14"
   - type: olm.constraint
     value:
       failureMessage: Require Smart Gateway for Service Telemetry Framework


### PR DESCRIPTION
I have relaxed the version constraint to encompass 4.14, but since it is not yet released, the active parts have been updated to 4.13 only, which is the version I am currently testing on anyways.