### PR TITLE
Allow Grafana management in all observability modes

### DIFF
--- a/roles/servicetelemetry/tasks/main.yml
+++ b/roles/servicetelemetry/tasks/main.yml
@@ -102,7 +102,6 @@
 
 - when:
     - has_integreatly_api | bool
-    - observability_strategy in ['use_community', 'use_hybrid']
   name: Start graphing component plays
   include_tasks: component_grafana.yml
 


### PR DESCRIPTION
Allow management of Grafana in all observability modes. Grafana
continues to be installed from community operators, but can continue to
be used even when deploying STF in the default observability strategy of
use_redhat.

Closes STF-1500

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
