### PR TITLE
Adjust the default scrape interval

### DIFF
--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -40,7 +40,7 @@ servicetelemetry_defaults:
       prometheus:
         enabled: true
         deployment_size: 1
-        scrape_interval: 15s
+        scrape_interval: 30s
         storage:
           strategy: persistent
           retention: 24h

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -40,7 +40,7 @@ servicetelemetry_defaults:
       prometheus:
         enabled: true
         deployment_size: 1
-        scrape_interval: 10s
+        scrape_interval: 15s
         storage:
           strategy: persistent
           retention: 24h

--- a/tests/infrared/17.1/enable-stf.yaml.template
+++ b/tests/infrared/17.1/enable-stf.yaml.template
@@ -6,16 +6,14 @@ custom_templates:
     # matches the documentation for enable-stf.yaml in stable-1.3 documentation
     parameter_defaults:
         # only send to STF, not other publishers
-        EventPipelinePublishers: []
         PipelinePublishers: []
 
         # manage the polling and pipeline configuration files for Ceilometer agents
         ManagePolling: true
         ManagePipeline: true
 
-        # enable Ceilometer metrics and events
+        # enable Ceilometer metrics
         CeilometerQdrPublishMetrics: true
-        CeilometerQdrPublishEvents: true
 
         # enable collection of API status
         CollectdEnableSensubility: true
@@ -27,12 +25,12 @@ custom_templates:
         # set collectd overrides for higher telemetry resolution and extra plugins
         # to load
         CollectdConnectionType: amqp1
-        CollectdAmqpInterval: 5
-        CollectdDefaultPollingInterval: 5
+        CollectdAmqpInterval: 30
+        CollectdDefaultPollingInterval: 30
         CollectdExtraPlugins:
         - vmem
 
-        # set standard prefixes for where metrics and events are published to QDR
+        # set standard prefixes for where metrics are published to QDR
         MetricsQdrAddresses:
         - prefix: 'collectd'
           distribution: multicast
@@ -78,4 +76,4 @@ custom_templates:
               local:
                 host: "%{hiera('fqdn_canonical')}"
                 port: 11211
-
+# vim: ft=yaml

--- a/tests/infrared/17.1/enable-stf.yaml.template
+++ b/tests/infrared/17.1/enable-stf.yaml.template
@@ -76,4 +76,3 @@ custom_templates:
               local:
                 host: "%{hiera('fqdn_canonical')}"
                 port: 11211
-# vim: ft=yaml

--- a/tests/infrared/17.1/stf-connectors.yaml.template
+++ b/tests/infrared/17.1/stf-connectors.yaml.template
@@ -3,11 +3,9 @@ tripleo_heat_templates:
     []
 
 custom_templates:
-    # don't load collectd-write-qdr.yaml when using multi-cloud and instead load collectd service directly
     resource_registry:
         OS::TripleO::Services::Collectd: /usr/share/openstack-tripleo-heat-templates/deployment/metrics/collectd-container-puppet.yaml
 
-    # set parameter defaults to match stable-1.3 documentation
     parameter_defaults:
         ExtraConfig:
             qdr::router_id: "%{::hostname}.<<CLOUD_NAME>>"
@@ -24,19 +22,11 @@ custom_templates:
               caCertFileContent: |
                 <<CA_CERT_FILE_CONTENT>>
 
-        CeilometerQdrEventsConfig:
-            driver: amqp
-            topic: <<CLOUD_NAME>>-event
-
         CeilometerQdrMetricsConfig:
             driver: amqp
             topic: <<CLOUD_NAME>>-metering
 
         CollectdAmqpInstances:
-            <<CLOUD_NAME>>-notify:
-                format: JSON
-                notify: true
-                presettle: false
             <<CLOUD_NAME>>-telemetry:
                 format: JSON
                 presettle: false
@@ -45,23 +35,3 @@ custom_templates:
 
         # --- below here, extended configuration for environment beyond what is documented in stable-1.3
         CollectdSensubilityLogLevel: DEBUG
-        CephStorageExtraConfig:
-            tripleo::profile::base::metrics::collectd::amqp_host: "%{hiera('storage')}"
-            tripleo::profile::base::metrics::qdr::listener_addr: "%{hiera('storage')}"
-
-            collectd::plugin::ceph::daemons:
-               - ceph-osd.0
-               - ceph-osd.1
-               - ceph-osd.2
-               - ceph-osd.3
-               - ceph-osd.4
-               - ceph-osd.5
-               - ceph-osd.6
-               - ceph-osd.7
-               - ceph-osd.8
-               - ceph-osd.9
-               - ceph-osd.10
-               - ceph-osd.11
-               - ceph-osd.12
-               - ceph-osd.13
-               - ceph-osd.14


### PR DESCRIPTION
Adjust the default scrape interval to be 15s in alignment with default
configuration changes setting the polling rate in RHOSP to 30 seconds.

Related STF-1512
