### PR TITLE
[stf-run-ci] Use {{ base_dir }} instead of relative paths

### DIFF
--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -8,14 +8,14 @@
     - name: Try cloning same-named branch or override branch from SGO repository
       ansible.builtin.git:
         repo: "{{ sgo_repository }}"
-        dest: working/smart-gateway-operator
+        dest: "{{ base_dir }}/working/smart-gateway-operator"
         version: "{{ sgo_branch | default(branch, true) }}"
         force: true
   rescue:
     - name: "Get {{ version_branches.sgo }} upstream branch because specified branch or repository doesn't exist"
       ansible.builtin.git:
         repo: https://github.com/infrawatch/smart-gateway-operator
-        dest: working/smart-gateway-operator
+        dest: "{{ base_dir }}/working/smart-gateway-operator"
         version: "{{ version_branches.sgo }}"
 
 - name: Get sg-core
@@ -23,13 +23,13 @@
     - name: Try cloning same-named branch or override branch from sg-core repository
       ansible.builtin.git:
         repo: "{{ sg_core_repository }}"
-        dest: working/sg-core
+        dest: "{{ base_dir }}/working/sg-core"
         version: "{{ sg_core_branch | default(branch, true) }}"
   rescue:
     - name: "Get {{ version_branches.sg_core }} upstream branch because specified branch or repository doesn't exist"
       ansible.builtin.git:
         repo: https://github.com/infrawatch/sg-core
-        dest: working/sg-core
+        dest: "{{ base_dir }}/working/sg-core"
         version: "{{ version_branches.sg_core }}"
 
 - name: Get sg-bridge
@@ -37,13 +37,13 @@
     - name: Try cloning same-named branch or override branch from sg-bridge repository
       ansible.builtin.git:
         repo: "{{ sg_bridge_repository }}"
-        dest: working/sg-bridge
+        dest: "{{ base_dir }}/working/sg-bridge"
         version: "{{ sg_bridge_branch | default(branch, true) }}"
   rescue:
     - name: "Get {{ version_branches.sg_bridge }} upstream branch because specified branch or repository doesn't exist"
       ansible.builtin.git:
         repo: https://github.com/infrawatch/sg-bridge
-        dest: working/sg-bridge
+        dest: "{{ base_dir }}/working/sg-bridge"
         version: "{{ version_branches.sg_bridge }}"
 
 - name: Get prometheus-webhook-snmp
@@ -51,12 +51,12 @@
     - name: Try cloning same-named branch or override branch from prometheus-webhook-snmp repository
       ansible.builtin.git:
         repo: "{{ prometheus_webhook_snmp_repository }}"
-        dest: working/prometheus-webhook-snmp
+        dest: "{{ base_dir }}/working/prometheus-webhook-snmp"
         version: "{{ prometheus_webhook_snmp_branch | default(branch, true) }}"
   rescue:
     - name: "Get {{ version_branches.prometheus_webhook_snmp }} upstream branch because specified branch or repository doesn't exist"
       ansible.builtin.git:
         repo: https://github.com/infrawatch/prometheus-webhook-snmp
-        dest: working/prometheus-webhook-snmp
+        dest: "{{ base_dir }}/working/prometheus-webhook-snmp"
         version: "{{ version_branches.prometheus_webhook_snmp }}"
 

--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create service-telemetry-framework-index working directory
   ansible.builtin.file:
-    path: working/service-telemetry-framework-index
+    path: "{{ base_dir }}/working/service-telemetry-framework-index"
     state: directory
     mode: '0755'
 
@@ -39,10 +39,10 @@
       variable_start_string: "<<"
       variable_end_string: ">>"
       src: config-json.j2
-      dest: working/service-telemetry-framework-index/config.json
+      dest: "{{ base_dir }}/working/service-telemetry-framework-index/config.json"
 
   - name: Create a Secret for the dockercfg
-    ansible.builtin.command: oc create secret generic -n {{ namespace }} service-telemetry-framework-index-dockercfg --from-file=.dockerconfigjson=working/service-telemetry-framework-index/config.json --type=kubernetes.io/dockerconfigjson
+    ansible.builtin.command: oc create secret generic -n {{ namespace }} service-telemetry-framework-index-dockercfg --from-file=.dockerconfigjson={{ base_dir }}/working/service-telemetry-framework-index/config.json --type=kubernetes.io/dockerconfigjson
 
 - name: Create ImageStream for ose-operator-registry
   ansible.builtin.command: oc import-image -n {{ namespace }} ose-operator-registry:{{ default_operator_registry_image_tag }} --from={{ default_operator_registry_image_base }}:{{ default_operator_registry_image_tag }} --confirm
@@ -124,10 +124,10 @@
   - name: Create index.yaml base for index image
     ansible.builtin.template:
       src: index-yaml.j2
-      dest: working/service-telemetry-framework-index/index.yaml
+      dest: "{{ base_dir }}/working/service-telemetry-framework-index/index.yaml"
 
   - name: Build service-telemetry-framework-index
-    ansible.builtin.command: oc start-build -n "{{ namespace }}" service-telemetry-framework-index --wait --from-dir working/service-telemetry-framework-index
+    ansible.builtin.command: oc start-build -n "{{ namespace }}" service-telemetry-framework-index --wait --from-dir {{ base_dir }}/working/service-telemetry-framework-index
 
 - name: Create CloudOps CatalogSource
   kubernetes.core.k8s:

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -72,12 +72,14 @@
   ansible.builtin.command:
     cmd: "./get_operator_sdk.sh {{ operator_sdk_v0 }}"
     creates: "{{ base_dir }}/working/operator-sdk-{{ operator_sdk_v0 }}"
+    chdir: "{{ base_dir }}"
 
 - name: Get operator_sdk_v1 (deploy from bundles)
   when: __local_build_enabled | bool or __deploy_from_bundles_enabled | bool or __deploy_from_index_enabled | bool
   ansible.builtin.command:
     cmd: "{{ base_dir }}/get_operator_sdk.sh {{ operator_sdk_v1 }}"
     creates: "{{ base_dir }}/working/operator-sdk-{{ operator_sdk_v1 }}"
+    chdir: "{{ base_dir }}"
 
 - name: Set logfile_dir
   when: not (logfile_dir is defined)

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -92,11 +92,11 @@
   - name: Create base build list
     ansible.builtin.set_fact:
       build_list:
-        - { name: service-telemetry-operator, dockerfile_path: build/Dockerfile, image_reference_name: sto_image_path, working_build_dir: ../ }
-        - { name: smart-gateway-operator, dockerfile_path: build/Dockerfile, image_reference_name: sgo_image_path, working_build_dir: ./working/smart-gateway-operator }
-        - { name: sg-core, dockerfile_path: build/Dockerfile, image_reference_name: sg_core_image_path, working_build_dir: ./working/sg-core }
-        - { name: sg-bridge, dockerfile_path: build/Dockerfile, image_reference_name: sg_bridge_image_path, working_build_dir: ./working/sg-bridge }
-        - { name: prometheus-webhook-snmp, dockerfile_path: Dockerfile, image_reference_name: prometheus_webhook_snmp_image_path, working_build_dir: ./working/prometheus-webhook-snmp }
+        - {name: service-telemetry-operator, dockerfile_path: build/Dockerfile, image_reference_name: sto_image_path, working_build_dir: "{{ base_dir }}/../"}
+        - {name: smart-gateway-operator, dockerfile_path: build/Dockerfile, image_reference_name: sgo_image_path, working_build_dir: "{{ base_dir }}/working/smart-gateway-operator"}
+        - {name: sg-core, dockerfile_path: build/Dockerfile, image_reference_name: sg_core_image_path, working_build_dir: "{{ base_dir }}/working/sg-core"}
+        - {name: sg-bridge, dockerfile_path: build/Dockerfile, image_reference_name: sg_bridge_image_path, working_build_dir: "{{ base_dir }}/working/sg-bridge"}
+        - {name: prometheus-webhook-snmp, dockerfile_path: Dockerfile, image_reference_name: prometheus_webhook_snmp_image_path, working_build_dir: "{{ base_dir }}/working/prometheus-webhook-snmp"}
 
   - ansible.builtin.debug:
       var: build_list
@@ -121,8 +121,8 @@
     - name: Create base build list
       ansible.builtin.set_fact:
         bundle_build_list:
-          - { name: service-telemetry-operator-bundle, dockerfile_path: Dockerfile, image_reference_name: sto_bundle_image_path, working_build_dir: ./working/service-telemetry-operator-bundle }
-          - { name: smart-gateway-operator-bundle, dockerfile_path: Dockerfile, image_reference_name: sgo_bundle_image_path, working_build_dir: ./working/smart-gateway-operator-bundle }
+          - { name: service-telemetry-operator-bundle, dockerfile_path: Dockerfile, image_reference_name: sto_bundle_image_path, working_build_dir: "{{ base_dir }}/working/service-telemetry-operator-bundle" }
+          - { name: smart-gateway-operator-bundle, dockerfile_path: Dockerfile, image_reference_name: sgo_bundle_image_path, working_build_dir: "{{ base_dir }}/working/smart-gateway-operator-bundle" }
 
     - ansible.builtin.debug:
         var: bundle_build_list

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -5,7 +5,7 @@
 # --- Smart Gateway Operator ---
 - name: Generate Smart Gateway Operator CSV
   ansible.builtin.shell:
-    chdir: working/smart-gateway-operator/build
+    chdir: "{{ base_dir }}/working/smart-gateway-operator/build"
     cmd: |
       LOGFILE="{{ ansible_env.HOME }}/sgo_gen_bundle.log" \
       OPERATOR_SDK="{{ base_dir }}/working/operator-sdk-{{ operator_sdk_v0 }}" \
@@ -39,7 +39,7 @@
   block:
   - name: Load Smart Gateway Operator RBAC
     ansible.builtin.command:
-      cmd: oc apply -f working/smart-gateway-operator/deploy/{{ item }} -n "{{ namespace }}"
+      cmd: oc apply -f {{ base_dir }}/working/smart-gateway-operator/deploy/{{ item }} -n "{{ namespace }}"
     loop:
       - service_account.yaml
       - role.yaml
@@ -48,7 +48,7 @@
 
   - name: Load Smart Gateway Operator CSV
     ansible.builtin.shell:
-      cmd: oc apply -f working/smart-gateway-operator-bundle/manifests/smart-gateway-operator.clusterserviceversion.yaml -n "{{ namespace }}"
+      cmd: oc apply -f {{ base_dir }}/working/smart-gateway-operator-bundle/manifests/smart-gateway-operator.clusterserviceversion.yaml -n "{{ namespace }}"
 
 # --- Service Telemetry Operator ---
 - name: Generate Service Telemetry Operator CSV
@@ -93,7 +93,7 @@
 
   - name: Load Service Telemetry Operator CSV
     ansible.builtin.shell:
-      cmd: oc apply -f working/service-telemetry-operator-bundle/manifests/service-telemetry-operator.clusterserviceversion.yaml -n "{{ namespace }}"
+      cmd: oc apply -f {{ base_dir }}/working/service-telemetry-operator-bundle/manifests/service-telemetry-operator.clusterserviceversion.yaml -n "{{ namespace }}"
 
 # cleanup
 - name: Revert local change to role_binding.yaml

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -55,7 +55,6 @@
   ansible.builtin.shell:
     chdir: "{{ base_dir }}"
     cmd: |
-      LOGFILE="{{ ansible_env.HOME }}/sto_gen_bundle.log" \
       OPERATOR_SDK="{{ base_dir }}/working/operator-sdk-{{ operator_sdk_v0 }}" \
       WORKING_DIR="{{ base_dir }}/working/service-telemetry-operator-bundle" \
       RELATED_IMAGE_PROMETHEUS_WEBHOOK_SNMP={{ prometheus_webhook_snmp_image_path | parse_image | quote }} \

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -103,3 +103,4 @@
 - name: Revert local change to role_binding.yaml
   ansible.builtin.shell:
     cmd: git checkout -- "{{ base_dir }}/../deploy/role_binding.yaml"
+    chdir: "{{ base_dir }}"


### PR DESCRIPTION
* Add base_dir for script imports in stf-run-ci
* Update destination in stf-run-ci/{clone_repos,setup_stf_local_build}
* Use base_dir instead of relative paths
* main: build_list
* create_stf_local_build: use base_dir for logfile in generate bundle

get_operator_sdk.sh: Use readlink to use absolute dir

[use_base_dir][stf-run-ci] Update chdir for getting operator-sdk

Add base_dir so that operator-sdk is in the expected location