### PR TITLE
Refactor smoketest script

### DIFF
--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -80,6 +80,7 @@ fi
 # create the alert using startsAt which in theory may cause trigger to be faster
 echo "*** [INFO] Create alert"
 oc delete pod -l run=curl ; oc run curl --wait --restart='Never' --image=quay.io/infrawatch/busyboxplus:curl -- sh -c "curl -v -k -H \"Content-Type: application/json\" -H \"Authorization: Bearer ${PROMETHEUS_K8S_TOKEN}\" -d '[{\"status\":\"firing\",\"labels\":{\"alertname\":\"smoketest\",\"severity\":\"warning\"},\"startsAt\":\"$(date --rfc-3339=seconds | sed 's/ /T/')\"}]' https://default-alertmanager-proxy:9095/api/v1/alerts"
+oc logs curl
 
 echo "*** [INFO] Waiting to see SNMP trap message in webhook pod"
 SNMP_WEBHOOK_POD=$(oc get pod -l "app=default-snmp-webhook" -ojsonpath='{.items[0].metadata.name}')

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -28,6 +28,7 @@ if [ "${OC_CLIENT_VERSION_Y}" -lt "${OC_CLIENT_VERSION_Y_REQUIRED}" ] || [ "${OC
 fi
 
 CLEANUP=${CLEANUP:-true}
+SMOKETEST_VERBOSE=${SMOKETEST_VERBOSE:-true}
 
 for ((i=1; i<=NUMCLOUDS; i++)); do
   NAME="smoke${i}"
@@ -76,28 +77,11 @@ else
     PROMETHEUS_K8S_TOKEN=$(oc create token prometheus-stf)
 fi
 
-oc run curl --restart='Never' --image=quay.io/infrawatch/busyboxplus:curl -- sh -c "curl -k -H \"Content-Type: application/json\" -H \"Authorization: Bearer ${PROMETHEUS_K8S_TOKEN}\" -d '[{\"labels\":{\"alertname\":\"Testalert1\"}}]' https://default-alertmanager-proxy:9095/api/v1/alerts"
-# it takes some time to get the alert delivered, continuing with other tests
-
-
-# Trying to find a less brittle test than a timeout
-JOB_TIMEOUT=300s
-for NAME in "${CLOUDNAMES[@]}"; do
-    echo "*** [INFO] Waiting on job/stf-smoketest-${NAME}..."
-    oc wait --for=condition=complete --timeout=${JOB_TIMEOUT} "job/stf-smoketest-${NAME}"
-    RET=$((RET || $?)) # Accumulate exit codes
-done
-
-echo "*** [INFO] Checking that the qdr certificate has a long expiry"
-EXPIRETIME=$(oc get secret default-interconnect-openstack-ca -o json | grep \"tls.crt\"\: | awk -F '": "' '{print $2}' | rev | cut -c3- | rev | base64 -d | openssl x509 -in - -text | grep "Not After" | awk -F " : " '{print $2}')
-EXPIRETIME_UNIX=$(date -d "${EXPIRETIME}" "+%s")
-TARGET_UNIX=$(date -d "now + 7 years" "+%s")
-if [ ${EXPIRETIME_UNIX} -lt ${TARGET_UNIX} ]; then
-    echo "[FAILURE] Certificate expire time (${EXPIRETIME}) less than 7 years from now"
-fi
+# create the alert using startsAt which in theory may cause trigger to be faster
+echo "*** [INFO] Create alert"
+oc delete pod -l run=curl ; oc run curl --wait --restart='Never' --image=quay.io/infrawatch/busyboxplus:curl -- sh -c "curl -v -k -H \"Content-Type: application/json\" -H \"Authorization: Bearer ${PROMETHEUS_K8S_TOKEN}\" -d '[{\"status\":\"firing\",\"labels\":{\"alertname\":\"smoketest\",\"severity\":\"warning\"},\"startsAt\":\"$(date --rfc-3339=seconds | sed 's/ /T/')\"}]' https://default-alertmanager-proxy:9095/api/v1/alerts"
 
 echo "*** [INFO] Waiting to see SNMP trap message in webhook pod"
-oc delete pod curl
 SNMP_WEBHOOK_POD=$(oc get pod -l "app=default-snmp-webhook" -ojsonpath='{.items[0].metadata.name}')
 SNMP_WEBHOOK_CHECK_MAX_TRIES=5
 SNMP_WEBHOOK_CHECK_TIMEOUT=30
@@ -112,70 +96,85 @@ while [ $SNMP_WEBHOOK_CHECK_COUNT -lt $SNMP_WEBHOOK_CHECK_MAX_TRIES ]; do
     sleep $SNMP_WEBHOOK_CHECK_TIMEOUT
 done
 
+# Trying to find a less brittle test than a timeout
+JOB_TIMEOUT=300s
+for NAME in "${CLOUDNAMES[@]}"; do
+    echo "*** [INFO] Waiting on job/stf-smoketest-${NAME}..."
+    oc wait --for=condition=complete --timeout=${JOB_TIMEOUT} "job/stf-smoketest-${NAME}"
+    RET=$((RET || $?)) # Accumulate exit codes
+done
+
+echo "*** [INFO] Checking that the qdr certificate has a long expiry"
+EXPIRETIME=$(oc get secret default-interconnect-openstack-ca -o json | grep \"tls.crt\"\: | awk -F '": "' '{print $2}' | rev | cut -c3- | rev | base64 -d | openssl x509 -text | grep "Not After" | awk -F " : " '{print $2}')
+EXPIRETIME_UNIX=$(date -d "${EXPIRETIME}" "+%s")
+TARGET_UNIX=$(date -d "now + 7 years" "+%s")
+if [ ${EXPIRETIME_UNIX} -lt ${TARGET_UNIX} ]; then
+    echo "[FAILURE] Certificate expire time (${EXPIRETIME}) less than 7 years from now"
+fi
+
 echo "*** [INFO] Showing oc get all..."
 oc get all
 echo
 
 echo "*** [INFO] Showing servicemonitors..."
-oc get servicemonitor -o yaml
+oc get servicemonitors.monitoring.rhobs -o yaml
 echo
 
-echo "*** [INFO] Logs from smoketest containers..."
-for NAME in "${CLOUDNAMES[@]}"; do
-    oc logs "$(oc get pod -l "job-name=stf-smoketest-${NAME}" -o jsonpath='{.items[0].metadata.name}')" -c smoketest-collectd
-    oc logs "$(oc get pod -l "job-name=stf-smoketest-${NAME}" -o jsonpath='{.items[0].metadata.name}')" -c smoketest-ceilometer
-done
-echo
+if [ "$SMOKETEST_VERBOSE" = "true" ]; then
+    echo "*** [INFO] Logs from smoketest containers..."
+        for NAME in "${CLOUDNAMES[@]}"; do
+            oc logs "$(oc get pod -l "job-name=stf-smoketest-${NAME}" -o jsonpath='{.items[0].metadata.name}')" -c smoketest-collectd
+            oc logs "$(oc get pod -l "job-name=stf-smoketest-${NAME}" -o jsonpath='{.items[0].metadata.name}')" -c smoketest-ceilometer
+        done
+    echo
 
-echo "*** [INFO] Logs from qdr..."
-oc logs "$(oc get pod -l application=default-interconnect -o jsonpath='{.items[0].metadata.name}')"
-echo
+    echo "*** [INFO] Logs from qdr..."
+    oc logs "$(oc get pod -l application=default-interconnect -o jsonpath='{.items[0].metadata.name}')"
+    echo
 
-echo "*** [INFO] Logs from smart gateways..."
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-meter" -o jsonpath='{.items[0].metadata.name}')" -c bridge
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-meter" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-event" -o jsonpath='{.items[0].metadata.name}')" -c bridge
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-event" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-meter" -o jsonpath='{.items[0].metadata.name}')" -c bridge
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-meter" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-event" -o jsonpath='{.items[0].metadata.name}')" -c bridge
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-event" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-sens-meter" -o jsonpath='{.items[0].metadata.name}')" -c bridge
-oc logs "$(oc get pod -l "smart-gateway=default-cloud1-sens-meter" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
-echo
+    echo "*** [INFO] Logs from smart gateways..."
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-meter" -o jsonpath='{.items[0].metadata.name}')" -c bridge
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-meter" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-event" -o jsonpath='{.items[0].metadata.name}')" -c bridge
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-coll-event" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-meter" -o jsonpath='{.items[0].metadata.name}')" -c bridge
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-meter" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-event" -o jsonpath='{.items[0].metadata.name}')" -c bridge
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-ceil-event" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-sens-meter" -o jsonpath='{.items[0].metadata.name}')" -c bridge
+    oc logs "$(oc get pod -l "smart-gateway=default-cloud1-sens-meter" -o jsonpath='{.items[0].metadata.name}')" -c sg-core
+    echo
 
-echo "*** [INFO] Logs from smart gateway operator..."
-oc logs "$(oc get pod -l app=smart-gateway-operator -o jsonpath='{.items[0].metadata.name}')"
-echo
+    echo "*** [INFO] Logs from smart gateway operator..."
+    oc logs "$(oc get pod -l app=smart-gateway-operator -o jsonpath='{.items[0].metadata.name}')"
+    echo
 
-echo "*** [INFO] Logs from prometheus..."
-oc logs "$(oc get pod -l prometheus=default -o jsonpath='{.items[0].metadata.name}')" -c prometheus
-echo
+    echo "*** [INFO] Logs from prometheus..."
+    oc logs "$(oc get pod -l prometheus=default -o jsonpath='{.items[0].metadata.name}')" -c prometheus
+    echo
 
-echo "*** [INFO] Logs from elasticsearch..."
-oc logs "$(oc get pod -l common.k8s.elastic.co/type=elasticsearch -o jsonpath='{.items[0].metadata.name}')"
-echo
+    echo "*** [INFO] Logs from elasticsearch..."
+    oc logs "$(oc get pod -l common.k8s.elastic.co/type=elasticsearch -o jsonpath='{.items[0].metadata.name}')"
+    echo
 
-echo "*** [INFO] Logs from snmp webhook..."
-oc logs "$(oc get pod -l app=default-snmp-webhook -o jsonpath='{.items[0].metadata.name}')"
-echo
+    echo "*** [INFO] Logs from snmp webhook..."
+    oc logs "$(oc get pod -l app=default-snmp-webhook -o jsonpath='{.items[0].metadata.name}')"
+    echo
 
-echo "*** [INFO] Logs from alertmanager..."
-oc logs "$(oc get pod -l app.kubernetes.io/name=alertmanager -o jsonpath='{.items[0].metadata.name}')" -c alertmanager
-echo
+    echo "*** [INFO] Logs from alertmanager..."
+    oc logs "$(oc get pod -l app.kubernetes.io/name=alertmanager -o jsonpath='{.items[0].metadata.name}')" -c alertmanager
+    echo
+fi
 
 echo "*** [INFO] Cleanup resources..."
 if $CLEANUP; then
     oc delete "job/stf-smoketest-${NAME}"
+    # resolve the alert to clean up the system, otherwise this expires in 5 minutes
+    oc delete pod -l run=curl ; oc run curl --restart='Never' --image=quay.io/infrawatch/busyboxplus:curl -- sh -c "curl -v -k -H \"Content-Type: application/json\" -H \"Authorization: Bearer ${PROMETHEUS_K8S_TOKEN}\" -d '[{\"status\":\"firing\",\"labels\":{\"alertname\":\"smoketest\",\"severity\":\"warning\"},\"startsAt\":\"$(date --rfc-3339=seconds | sed 's/ /T/')\",\"endsAt\":\"$(date --rfc-3339=seconds | sed 's/ /T/')\"}]' https://default-alertmanager-proxy:9095/api/v1/alerts"
 fi
 echo
 
-if [ $SNMP_WEBHOOK_STATUS -ne 0 ]; then
-    echo "*** [FAILURE] SNMP Webhook failed"
-    exit 1
-fi
-
-if [ $RET -eq 0 ]; then
+if [ $RET -eq 0 ] && [ $SNMP_WEBHOOK_STATUS -eq 0 ]; then
     echo "*** [SUCCESS] Smoke test job completed successfully"
 else
     echo "*** [FAILURE] Smoke test job still not succeeded after ${JOB_TIMEOUT}"


### PR DESCRIPTION
Perform a bit of smoketest refactoring and fix up a few bugs.

* Update alert trigger to use startsAt in order to potentially speed up
  delivery of the alerts. Failures in the SNMP_WEBHOOK_STATUS seems to
  be primarily to delayed alert notification through
  prometheus-snmp-webhook.
* Add an alert clean up task as part of the clean up logic at the end.
* Update openssl x509 to not use the -in flag which seems unnecessary
  and on some systems causes a failure.
* Add new SMOKETEST_VERBOSE boolean so local testing can skip massive
  amounts of information dumped to stdout.
* Remove curl pod using label selector for slightly cleaner output.
* Update failure check to combine RET and SNMP_WEBHOOK_STATUS since
  testing seems to show changes are slightly more reliable.
