### PR TITLE
Install ObO during index-based deployments

### DIFF
--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -121,24 +121,24 @@
       when:
         - __service_telemetry_observability_strategy == "use_community"
 
-    - name: Subscribe to Red Hat Obervability Operator
-      kubernetes.core.k8s:
-        definition:
-          apiVersion: operators.coreos.com/v1alpha1
-          kind: Subscription
-          metadata:
-            labels:
-              operators.coreos.com/observability-operator.openshift-operators: ""
-            name: observability-operator
-            namespace: openshift-operators
-          spec:
-            channel: stable
-            installPlanApproval: Automatic
-            name: observability-operator
-            source: community-operators
-            sourceNamespace: openshift-marketplace
-      when:
-        - __service_telemetry_observability_strategy in ['use_redhat', 'use_hybrid']
+- name: Subscribe to Red Hat Obervability Operator
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        labels:
+          operators.coreos.com/observability-operator.openshift-operators: ""
+        name: observability-operator
+        namespace: openshift-operators
+      spec:
+        channel: stable
+        installPlanApproval: Automatic
+        name: observability-operator
+        source: community-operators
+        sourceNamespace: openshift-marketplace
+  when:
+    - __service_telemetry_observability_strategy in ['use_redhat', 'use_hybrid']
 
 - name: Subscribe to Elastic Cloud on Kubernetes Operator
   kubernetes.core.k8s:


### PR DESCRIPTION
Because Observability Operator (ObO) is a cluster-scoped Operator, the OLM dependency management can't resolve the dependency for us. Update setup_base to pre-install ObO when observabilityStrategy is use_redhat or use_hybrid, even when when index-based deployment is enabled.

Resolves: STF-1483