### PR TITLE
Create ClusterRoleBinding and Role for alertmanager

### DIFF
--- a/roles/servicetelemetry/tasks/component_alertmanager.yml
+++ b/roles/servicetelemetry/tasks/component_alertmanager.yml
@@ -66,7 +66,7 @@
         kind: Route
         name: '{{ ansible_operator_meta.name }}-alertmanager-proxy'
 
-- name: Add a service account to used by Alertmanager
+- name: Create ServiceAccount/alertmanager-stf with oauth redirect annotation
   k8s:
     definition:
       apiVersion: v1
@@ -97,6 +97,32 @@
           - subjectaccessreviews
           verbs:
           - create
+
+- name: Create ClusterRoleBinding/alertmanager-stf
+  k8s:
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: alertmanager-stf
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: alertmanager-stf
+      subjects:
+      - kind: ServiceAccount
+        name: alertmanager-stf
+        namespace: '{{ ansible_operator_meta.namespace }}'
+
+- name: Create Role/alertmanager-stf
+  k8s:
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: alertmanager-stf
+        namespace: '{{ ansible_operator_meta.namespace }}'
+      rules:
         - apiGroups:
           - security.openshift.io
           resourceNames:
@@ -106,7 +132,7 @@
           verbs:
           - use
 
-- name: Bind role
+- name: Create RoleBinding/alertmanager-stf
   k8s:
     definition:
       apiVersion: rbac.authorization.k8s.io/v1
@@ -116,7 +142,7 @@
         namespace: '{{ ansible_operator_meta.namespace }}'
       roleRef:
         apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
+        kind: Role
         name: alertmanager-stf
         namespace: '{{ ansible_operator_meta.namespace }}'
       subjects:

--- a/roles/servicetelemetry/tasks/component_alertmanager.yml
+++ b/roles/servicetelemetry/tasks/component_alertmanager.yml
@@ -98,21 +98,42 @@
           verbs:
           - create
 
-- name: Create ClusterRoleBinding/alertmanager-stf
-  k8s:
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: alertmanager-stf
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: alertmanager-stf
-      subjects:
-      - kind: ServiceAccount
-        name: alertmanager-stf
-        namespace: '{{ ansible_operator_meta.namespace }}'
+- name: Setup ClusterRoleBinding for Alertmanager
+  block:
+    - name: Define ClusterRoleBinding/alertmanager-stf
+      set_fact:
+        def_alertmanager_stf_crb: |
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: alertmanager-stf
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: alertmanager-stf
+          subjects:
+          - kind: ServiceAccount
+            name: alertmanager-stf
+            namespace: '{{ ansible_operator_meta.namespace }}'
+
+    - name: Create ClusterRoleBinding/alertmanager-stf
+      k8s:
+        definition:
+          "{{ def_alertmanager_stf_crb }}"
+  rescue:
+    - name: Remove ClusterRoleBinding/alertmanager-stf when fail to update
+      k8s:
+        state: absent
+        definition:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: alertmanager-stf
+
+    - name: Create ClusterRoleBinding/alertmanager-stf
+      k8s:
+        definition:
+          "{{ def_alertmanager_stf_crb }}"
 
 - name: Create Role/alertmanager-stf
   k8s:
@@ -132,23 +153,45 @@
           verbs:
           - use
 
-- name: Create RoleBinding/alertmanager-stf
-  k8s:
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
-      metadata:
-        name: alertmanager-stf
-        namespace: '{{ ansible_operator_meta.namespace }}'
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: alertmanager-stf
-        namespace: '{{ ansible_operator_meta.namespace }}'
-      subjects:
-      - kind: ServiceAccount
-        name: alertmanager-stf
-        namespace: '{{ ansible_operator_meta.namespace }}'
+- name: Setup RoleBinding for Alertmanager
+  block:
+    - name: Define RoleBinding/alertmanager-stf
+      set_fact:
+        def_alertmanager_stf_rb: |
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: alertmanager-stf
+            namespace: '{{ ansible_operator_meta.namespace }}'
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: alertmanager-stf
+            namespace: '{{ ansible_operator_meta.namespace }}'
+          subjects:
+          - kind: ServiceAccount
+            name: alertmanager-stf
+            namespace: '{{ ansible_operator_meta.namespace }}'
+
+    - name: Create RoleBinding/alertmanager-stf
+      k8s:
+        definition:
+          "{{ def_alertmanager_stf_rb }}"
+  rescue:
+    - name: Remove RoleBinding/alertmanager-stf when fail to update
+      k8s:
+        state: absent
+        definition:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: alertmanager-stf
+            namespace: '{{ ansible_operator_meta.namespace }}'
+
+    - name: Create RoleBinding/alertmanager-stf
+      k8s:
+        definition:
+          "{{ def_alertmanager_stf_rb }}"
 
 - name: Set default alertmanager service template
   set_fact:

--- a/roles/servicetelemetry/tasks/component_prometheus.yml
+++ b/roles/servicetelemetry/tasks/component_prometheus.yml
@@ -49,21 +49,42 @@
         verbs:
         - get
 
-- name: Create ClusterRoleBinding/prometheus-stf
-  k8s:
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: prometheus-stf
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: prometheus-stf
-      subjects:
-      - kind: ServiceAccount
-        name: prometheus-stf
-        namespace: '{{ ansible_operator_meta.namespace }}'
+- name: Setup ClusterRoleBinding for Prometheus
+  block:
+    - name: Define ClusterRoleBinding/prometheus-stf
+      set_fact:
+        def_prometheus_stf_crb: |
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: prometheus-stf
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: prometheus-stf
+          subjects:
+          - kind: ServiceAccount
+            name: prometheus-stf
+            namespace: '{{ ansible_operator_meta.namespace }}'
+
+    - name: Create ClusterRoleBinding/prometheus-stf
+      k8s:
+        definition:
+          "{{ def_prometheus_stf_crb }}"
+  rescue:
+    - name: Remove ClusterRoleBinding/prometheus-stf when fail to update
+      k8s:
+        state: absent
+        definition:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: prometheus-stf
+
+    - name: Create ClusterRoleBinding/prometheus-stf
+      k8s:
+        definition:
+          "{{ def_prometheus_stf_crb }}"
 
 - name: Create Role/prometheus-stf for Prometheus operations
   k8s:
@@ -103,22 +124,44 @@
         verbs:
         - use
 
-- name: Create RoleBinding/prometheus-stf
-  k8s:
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
-      metadata:
-        name: prometheus-stf
-        namespace: '{{ ansible_operator_meta.namespace }}'
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: prometheus-stf
-      subjects:
-      - kind: ServiceAccount
-        name: prometheus-stf
-        namespace: '{{ ansible_operator_meta.namespace }}'
+- name: Setup RoleBinding for Prometheus
+  block:
+    - name: Define RoleBinding/prometheus-stf
+      set_fact:
+        def_prometheus_stf_rb: |
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: prometheus-stf
+            namespace: '{{ ansible_operator_meta.namespace }}'
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: prometheus-stf
+          subjects:
+          - kind: ServiceAccount
+            name: prometheus-stf
+            namespace: '{{ ansible_operator_meta.namespace }}'
+
+    - name: Create RoleBinding/prometheus-stf
+      k8s:
+        definition:
+          "{{ def_prometheus_stf_rb }}"
+  rescue:
+  - name: Remove RoleBinding/prometheus-stf on failure to update
+    k8s:
+      state: absent
+      definition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: prometheus-stf
+          namespace: '{{ ansible_operator_meta.namespace }}'
+
+  - name: Create RoleBinding/prometheus-stf
+    k8s:
+      definition:
+        "{{ def_prometheus_stf_rb }}"
 
 - name: Remove old ClusterRoleBinding for prometheus-k8s using CMO roleRef
   k8s:

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -80,6 +80,7 @@ fi
 # create the alert using startsAt which in theory may cause trigger to be faster
 echo "*** [INFO] Create alert"
 oc delete pod -l run=curl ; oc run curl --wait --restart='Never' --image=quay.io/infrawatch/busyboxplus:curl -- sh -c "curl -v -k -H \"Content-Type: application/json\" -H \"Authorization: Bearer ${PROMETHEUS_K8S_TOKEN}\" -d '[{\"status\":\"firing\",\"labels\":{\"alertname\":\"smoketest\",\"severity\":\"warning\"},\"startsAt\":\"$(date --rfc-3339=seconds | sed 's/ /T/')\"}]' https://default-alertmanager-proxy:9095/api/v1/alerts"
+oc wait --for=jsonpath='{.status.phase}'=Succeeded pod/curl
 oc logs curl
 
 echo "*** [INFO] Waiting to see SNMP trap message in webhook pod"
@@ -177,9 +178,8 @@ echo
 
 if [ $RET -eq 0 ] && [ $SNMP_WEBHOOK_STATUS -eq 0 ]; then
     echo "*** [SUCCESS] Smoke test job completed successfully"
+    exit 0
 else
     echo "*** [FAILURE] Smoke test job still not succeeded after ${JOB_TIMEOUT}"
+    exit 1
 fi
-echo
-
-exit $RET


### PR DESCRIPTION
Create appropriate ClusterRoleBinding and Role for alertmanager-stf,
breaking out SCC into a Role vs ClusterRole to keep things in alignment
to prometheus-stf RBAC setup.
