### PR TITLE
Update 17.1 helper scripts README

### DIFF
--- a/tests/infrared/17.1/README.md
+++ b/tests/infrared/17.1/README.md
@@ -3,9 +3,9 @@
 ## Basic deployment
 
 ```bash
-CA_CERT_FILE_CONTENT="$(oc get secret/default-interconnect-selfsigned -o jsonpath='{.data.ca\.crt}' | base64 -d)" \
 OCP_ROUTE_IP="10.0.100.50" \
-AMQP_HOST="default-interconnect-5671-service-telemetry.apps.stf15.localhost" \
+CA_CERT_FILE_CONTENT="$(oc get secret/default-interconnect-selfsigned -o jsonpath='{.data.ca\.crt}' | base64 -d)" \
+AMQP_HOST="$(oc get route default-interconnect-5671 -ojsonpath='{.spec.host}')" \
 ENABLE_STF_CONNECTORS=true \
 ENABLE_GNOCCHI_CONNECTORS=false \
 CONTROLLER_MEMORY="24000" \


### PR DESCRIPTION
Update the README to move the OCP_ROUTE_IP to the top making it easier to not include it when copying the command (since it needs to be populated manually). Update the default path contents with an oc command to fill that in automatically.