### PR TITLE
Reduce the Ceilometer pollsters in helper script

### DIFF
--- a/tests/infrared/17.1/enable-stf.yaml.template
+++ b/tests/infrared/17.1/enable-stf.yaml.template
@@ -41,20 +41,7 @@ custom_templates:
             ceilometer::agent::polling::polling_interval: 30
             ceilometer::agent::polling::polling_meters:
             - cpu
-            - disk.*
-            - ip.*
-            - image.*
-            - memory
-            - memory.*
-            - network.services.vpn.*
-            - network.services.firewall.*
-            - perf.*
-            - port
-            - port.*
-            - switch
-            - switch.*
-            - storage.*
-            - volume.*
+            - memory.usage
 
             # to avoid filling the memory buffers if disconnected from the message bus
             # note: this may need an adjustment if there are many metrics to be sent.


### PR DESCRIPTION
Update the ceilometer pollsters used by the 17.1 deployment helper script.

Related: rhbz#2239390