### PR TITLE
Increase sensubility smart-gateway ring buffer

### DIFF
--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -73,7 +73,7 @@ spec:
             subscriptionAddress: sensubility/cloud1-telemetry
             debugEnabled: false
             bridge:
-              ringBufferSize: 16384
+              ringBufferSize: 65535
               ringBufferCount: 15000
               verbose: false
       events:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -126,7 +126,7 @@ metadata:
                     {
                       "bridge": {
                         "ringBufferCount": 15000,
-                        "ringBufferSize": 16384,
+                        "ringBufferSize": 65535,
                         "verbose": false
                       },
                       "collectorType": "sensubility",

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -115,7 +115,7 @@ servicetelemetry_defaults:
             subscription_address: sensubility/cloud1-telemetry
             debug_enabled: false
             bridge:
-              ring_buffer_size: 16384
+              ring_buffer_size: 65535
               ring_buffer_count: 15000
               verbose: false
       events:


### PR DESCRIPTION
Increase the ring buffer size of the sensubility Smart Gateway as
messages often exceed the default of 16384 bytes, resulting in no API
healt check data from controllers arriving.

Closes: rhbz#2241033
