### PR TITLE
Disable event pipeline management

### DIFF
--- a/tests/infrared/17.1/enable-stf.yaml.template
+++ b/tests/infrared/17.1/enable-stf.yaml.template
@@ -11,6 +11,7 @@ custom_templates:
         # manage the polling and pipeline configuration files for Ceilometer agents
         ManagePolling: true
         ManagePipeline: true
+        ManageEventPipeline: false
 
         # enable Ceilometer metrics
         CeilometerQdrPublishMetrics: true


### PR DESCRIPTION
Disable the event pipeline management in the enable-stf.yaml file for the RHOSP 17.1 helper script to align to STF 1.5.3 disabling eventing by default, matching our documentation changes.

Related STF-1498