### PR TITLE
Move the metrics_result retrieve

### DIFF
--- a/tests/smoketest/smoketest_ceilometer_entrypoint.sh
+++ b/tests/smoketest/smoketest_ceilometer_entrypoint.sh
@@ -29,7 +29,6 @@ echo "*** [INFO] Checking for recent image metrics..."
 echo "[DEBUG] Running the curl command to return a query"
 curl -k -u "internal:${PROMETHEUS_AUTH_PASS}" -g "${PROMETHEUS}/api/v1/query?" --data-urlencode 'query=ceilometer_image_size' 2>&1 | grep '"result":\[{"metric":{"__name__":"ceilometer_image_size"'
 metrics_result=$?
-echo "[DEBUG] Query returned"
 echo "[DEBUG] Set metrics_result to $metrics_result"
 
 if [ "$OBSERVABILITY_STRATEGY" != "use_redhat" ]; then

--- a/tests/smoketest/smoketest_ceilometer_entrypoint.sh
+++ b/tests/smoketest/smoketest_ceilometer_entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set +e
 
 # Executes inside the test harness container to start collectd and look for resulting metrics in prometheus
 PROMETHEUS=${PROMETHEUS:-"https://default-prometheus-proxy:9092"}
@@ -28,8 +28,8 @@ echo "*** [INFO] Checking for recent image metrics..."
 
 echo "[DEBUG] Running the curl command to return a query"
 curl -k -u "internal:${PROMETHEUS_AUTH_PASS}" -g "${PROMETHEUS}/api/v1/query?" --data-urlencode 'query=ceilometer_image_size' 2>&1 | grep '"result":\[{"metric":{"__name__":"ceilometer_image_size"'
-echo "[DEBUG] Query returned"
 metrics_result=$?
+echo "[DEBUG] Query returned"
 echo "[DEBUG] Set metrics_result to $metrics_result"
 
 if [ "$OBSERVABILITY_STRATEGY" != "use_redhat" ]; then

--- a/tests/smoketest/smoketest_collectd_entrypoint.sh
+++ b/tests/smoketest/smoketest_collectd_entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set +e
 
 # Executes inside the test harness container to start collectd and look for resulting metrics in prometheus
 PROMETHEUS=${PROMETHEUS:-"https://default-prometheus-proxy:9092"}


### PR DESCRIPTION
Move the metrics_result value retrieval to above an echo command so that
the result is of the curl command and not the echo command. Also change
the scripts to set +e so that the scripts don't exist right away since
there are checks at the end that set an appropriate exit code (and gives
more information since the script will complete vs exit immediately).

Reported by Chris in Slack
