### PR TITLE
[zuul] Use include_vars in prepare stage

### DIFF
--- a/ci/prepare.yml
+++ b/ci/prepare.yml
@@ -2,16 +2,24 @@
 - name: "Prepare the environment for running stf"
   hosts: controller
   tasks:
+    - name: "Set the sto_dir if it isn't already set"
+      ansible.builtin.set_fact:
+        sto_dir: '{{ ansible_env.HOME }}/{{ zuul.project.src_dir }}'
+      when: sto_dir | default('') | length == 0
+
+    - name: "Get vars common to all jobs"
+      ansible.builtin.include_vars:
+        file: "vars-zuul-common.yml"
+
+    - name: "Get scenario-specific vars"
+      ansible.builtin.include_vars:
+        file: "vars-{{ scenario }}.yml"
+
     - name: "Update pip"
       ansible.builtin.pip:
         name: pip
         state: latest
         extra_args: "-U"
-
-    - name: "Set the value of sto_dir, if it's not already defined"
-      ansible.builtin.set_fact:
-        sto_dir: "{{ ansible_env.HOME }}/{{ zuul.project.src_dir }}"
-      when: not (sto_dir is defined)
 
     - name: "Install pre-reqs from pip"
       ansible.builtin.pip:


### PR DESCRIPTION
Add the common and scenario vars to prepare stage so that namespace is defined before being used

This should resolve the following error:
https://review.rdoproject.org/zuul/build/78ae468be0b14079806457959b363f9a