### PR TITLE
[zuul] use 'service-telemetry' as namespace

### DIFF
--- a/ci/vars-zuul-common.yml
+++ b/ci/vars-zuul-common.yml
@@ -1,5 +1,5 @@
 ---
-namespace: "service-telemetry-PR#{{ zuul.change }}-{{ zuul.build }}"
+namespace: "service-telemetry"
 setup_bundle_registry_tls_ca: false
 setup_bundle_registry_auth: false
 base_dir: "{{ sto_dir }}/build"


### PR DESCRIPTION
The format was incorrect, and cannot include '#' or capital letters.

https://review.rdoproject.org/zuul/build/7b4f5f48368a41d2be73044bbd00abed