### PR TITLE
Add requires infrastructure annotations

### DIFF
--- a/build/generate_bundle.sh
+++ b/build/generate_bundle.sh
@@ -36,18 +36,6 @@ generate_bundle() {
     popd > /dev/null 2>&1
 
     sed -i -E "${REPLACE_REGEX}" "${WORKING_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"
-    cat >> "${WORKING_DIR}/metadata/annotations.yaml" << EOF
-  features.operators.openshift.io/disconnected: "false"
-  features.operators.openshift.io/fips-compliant: "false"
-  features.operators.openshift.io/proxy-aware: "false"
-  features.operators.openshift.io/cnf: "false"
-  features.operators.openshift.io/cni: "false"
-  features.operators.openshift.io/csi: "false"
-  features.operators.openshift.io/tls-profiles: "false"
-  features.operators.openshift.io/token-auth-aws: "false"
-  features.operators.openshift.io/token-auth-azure: "false"
-  features.operators.openshift.io/token-auth-gcp: "false"
-EOF
 }
 
 copy_extra_metadata() {

--- a/build/generate_bundle.sh
+++ b/build/generate_bundle.sh
@@ -36,6 +36,18 @@ generate_bundle() {
     popd > /dev/null 2>&1
 
     sed -i -E "${REPLACE_REGEX}" "${WORKING_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"
+    cat >> "${WORKING_DIR}/metadata/annotations.yaml" << EOF
+  features.operators.openshift.io/disconnected: "false"
+  features.operators.openshift.io/fips-compliant: "false"
+  features.operators.openshift.io/proxy-aware: "false"
+  features.operators.openshift.io/cnf: "false"
+  features.operators.openshift.io/cni: "false"
+  features.operators.openshift.io/csi: "false"
+  features.operators.openshift.io/tls-profiles: "false"
+  features.operators.openshift.io/token-auth-aws: "false"
+  features.operators.openshift.io/token-auth-azure: "false"
+  features.operators.openshift.io/token-auth-gcp: "false"
+EOF
 }
 
 copy_extra_metadata() {

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -181,6 +181,16 @@ metadata:
       "Cloud Suite"]'
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     repository: https://github.com/infrawatch/service-telemetry-operator
     support: Red Hat
   name: service-telemetry-operator.v1.99.0

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -175,22 +175,22 @@ metadata:
     description: Service Telemetry Framework. Umbrella Operator for instantiating
       the required dependencies and configuration of various components to build a
       Service Telemetry platform for telco grade monitoring.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=<<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>'
     operatorframework.io/suggested-namespace: service-telemetry
     operators.openshift.io/valid-subscription: '["OpenStack Platform", "Cloud Infrastructure",
       "Cloud Suite"]'
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible
-    features.operators.openshift.io/disconnected: "false"
-    features.operators.openshift.io/fips-compliant: "false"
-    features.operators.openshift.io/proxy-aware: "false"
-    features.operators.openshift.io/cnf: "false"
-    features.operators.openshift.io/cni: "false"
-    features.operators.openshift.io/csi: "false"
-    features.operators.openshift.io/tls-profiles: "false"
-    features.operators.openshift.io/token-auth-aws: "false"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
     repository: https://github.com/infrawatch/service-telemetry-operator
     support: Red Hat
   name: service-telemetry-operator.v1.99.0


### PR DESCRIPTION
Add required infrastructure annotations for the bundle. Implementation
is done in generate_bundle.sh because the annotations.yaml file in the
deploy/olm-catalog/ directory is not read by operator-sdk-0.19.4. Append
required additional feature annotations to the generated
annotations.yaml by operator-sdk generate bundle.

Related STF-1530
