### PR TITLE
Cluster Observability Operator dependency

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -39,3 +39,6 @@ properties:
           - package:
               packageName: observability-operator
               versionRange: '>=0.0.1'
+          - package:
+              packageName: cluster-observability-operator
+              versionRange: '>=0.0.1'


### PR DESCRIPTION
Add cluster observability operator as the preferred dependency (bottom
of list is highest priority) when installing Service Telemetry Operator.
The cluster-observability-operator is the name of the downstream
(product) bundle in the Red Hat Operators CatalogSource.

If installing for upstream, preferred operator will be
observability-operator (when the Red Hat Operators CatalogSource is not
available or enabled). And then as a fall-back method when neither
Observability Operator or Cluster Observability Operator is not
available, allow for Prometheus Operator from the Community Operators to
satisfy for the Prometheus storage backend.
