### PR TITLE
[stf-collect-logs] Move describe build|pod from ci/ to the role

### DIFF
--- a/build/stf-collect-logs/tasks/main.yml
+++ b/build/stf-collect-logs/tasks/main.yml
@@ -54,8 +54,28 @@
   ansible.builtin.command:
     cmd: |
       oc -n {{ namespace }} get pods > {{ logfile_dir }}/post_oc_get_pods.log 2>&1
-      echo "Additional information" >> {{ logfile_dir }}/post_oc_get_pods.log
-      oc -n {{ namespace }} describe pods >> {{ logfile_dir }}/post_oc_get_pods.log 2>&1
+  ignore_errors: true
+  retries: 3
+  delay: 10
+
+- name: "Describe non-completed, non-running pods"
+  ansible.builtin.shell:
+    cmd: |
+      for pod in $(oc get pods | grep -v NAME | grep -v Running | awk '{ print $1 }');
+      do
+        oc -n {{ namespace }} describe pod $pod > {{ logfile_dir }}/post_oc_describe_pod_${pod}.log 2>&1
+      done
+  ignore_errors: true
+  retries: 3
+  delay: 10
+
+- name: "Describe builds"
+  ansible.builtin.shell:
+    cmd: |
+      for build in $(oc -n {{ namespace }} get builds -o json | jq -r '.items[].metadata.name');
+      do
+        oc -n {{ namespace }} describe build $build > {{ logfile_dir }}/post_oc_describe_build_${build}.log 2>&1
+      done
   ignore_errors: true
   retries: 3
   delay: 10

--- a/ci/post-collect_logs.yml
+++ b/ci/post-collect_logs.yml
@@ -42,25 +42,6 @@
       ansible.builtin.import_role:
         name: '../build/stf-collect-logs'
 
-    - name: "Get pods and describe non-completed, non-running pods"
-      ansible.builtin.shell:
-        cmd: |
-          echo "*** oc get pods ***" > {{ logfile_dir }}/oc_get_pods.log 2>&1
-          oc -n {{ namespace }} get pods >> {{ logfile_dir }}/oc_get_pods.log 2>&1
-
-          for pod in $(oc get pods | grep -v NAME | grep -v Running | awk '{ print $1 }');
-          do
-            oc -n {{ namespace }} describe pod $pod > {{ logfile_dir }}/post_oc_describe_pod_${pod}.log 2>&1
-          done
-      ignore_errors: true
-      retries: 3
-      delay: 10
-
-    - name: "Get build details"
-      ansible.builtin.shell:
-        cmd: |
-          for build in $(oc -n {{ namespace }} get builds  -o json| jq -r '.items[].metadata.name'); do oc -n {{ namespace }} describe build $build > {{ logfile_dir }}/post_oc_describe_build_${build}.log 2>&1; done
-
     - name: "Copy generated logs"
       ansible.builtin.shell: |
         cp {{ ansible_env.HOME }}/*.log .


### PR DESCRIPTION
Move the additional log creation tasks that were added between adding the stf-collect-logs role and merging the PR.