### PR TITLE
Don't deploy events SGs by default

### DIFF
--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -76,22 +76,6 @@ spec:
               ringBufferSize: 65535
               ringBufferCount: 15000
               verbose: false
-      events:
-        collectors:
-          - collectorType: collectd
-            subscriptionAddress: collectd/cloud1-notify
-            debugEnabled: false
-            bridge:
-              ringBufferSize: 16384
-              ringBufferCount: 15000
-              verbose: false
-          - collectorType: ceilometer
-            subscriptionAddress: anycast/ceilometer/cloud1-event.sample
-            debugEnabled: false
-            bridge:
-              ringBufferSize: 16384
-              ringBufferCount: 15000
-              verbose: false
   graphing:
     enabled: false
     grafana:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -77,30 +77,6 @@ metadata:
             },
             "clouds": [
               {
-                "events": {
-                  "collectors": [
-                    {
-                      "bridge": {
-                        "ringBufferCount": 15000,
-                        "ringBufferSize": 16384,
-                        "verbose": false
-                      },
-                      "collectorType": "collectd",
-                      "debugEnabled": false,
-                      "subscriptionAddress": "collectd/cloud1-notify"
-                    },
-                    {
-                      "bridge": {
-                        "ringBufferCount": 15000,
-                        "ringBufferSize": 16384,
-                        "verbose": false
-                      },
-                      "collectorType": "ceilometer",
-                      "debugEnabled": false,
-                      "subscriptionAddress": "anycast/ceilometer/cloud1-event.sample"
-                    }
-                  ]
-                },
                 "metrics": {
                   "collectors": [
                     {


### PR DESCRIPTION
When deploying from the UI, don't populate the events SGs by default as
they are no longer used in a default configuration in RHOSP.
