### PR TITLE
Add gitleaks.toml for rh-gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+[allowlist]
+  description = "Global Allowlist"
+
+  # Ignore based on any subset of the file path
+  paths = [
+    # Ignore all example certs
+    '''roles\/servicetelemetry\/vars\/dummy_user_certs\.yml'''
+  ]


### PR DESCRIPTION
Add a .gitleaks.toml file to avoid the false positive leak for the
example certificate when deploying for Elasticsearch.
