### PR TITLE
[stf-run-ci] Fix check to include bool filter

### DIFF
--- a/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
+++ b/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
@@ -64,7 +64,7 @@
       data:
         cert.pem: "{{ lookup('file', 'CA.pem') | b64encode }}"
 
-- when: setup_bundle_registry_tls_ca
+- when: setup_bundle_registry_tls_ca | bool
   name: Patch the default service account to use our pull secret
   kubernetes.core.k8s_json_patch:
     kind: ServiceAccount


### PR DESCRIPTION
Update the check to use bool filter instead of a bar var. By default, ansible parses vars as strings, and without the | bool filter, this check is invalid, as it will always resolve to true, since it is a non-empty string. Other instances of the same check did this, but this one was missed.