### PR TITLE
Fix qdr auth one_time_upgrade label check

### DIFF
--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -172,7 +172,7 @@
             labels:
               stf_one_time_upgrade: "{{ lookup('pipe', 'date +%s') }}"
           stringData:
-            guest: "{{ lookup('password', '/dev/null') }}"
+            guest: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
       when:
         - _qdr_basicauth_object.resources[0] is defined and _qdr_basicauth_object.resources[0].metadata.labels.stf_one_time_upgrade is not defined
 

--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -154,9 +154,9 @@
   block:
     - name: Get QDR BasicAuth secret
       k8s_info:
-        api_version: interconnectedcloud.github.io/v1alpha1
-        kind: Interconnect
-        name: "{{ ansible_operator_meta.name }}-interconnect"
+        api_version: v1
+        kind: Secret
+        name: "{{ ansible_operator_meta.name }}-interconnect-users"
         namespace: "{{ ansible_operator_meta.namespace }}"
       register: _qdr_basicauth_object
 

--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -174,7 +174,7 @@
           stringData:
             guest: "{{ lookup('password', '/dev/null') }}"
       when:
-        - _qdr_basicauth_object.resources[0] is defined and _qdr_basicauth_object[0].metadata.labels.stf_one_time_upgrade is not defined
+        - _qdr_basicauth_object.resources[0] is defined and _qdr_basicauth_object.resources[0].metadata.labels.stf_one_time_upgrade is not defined
 
 - name: Set default Interconnect manifest
   set_fact:


### PR DESCRIPTION
Bug is here: https://github.com/infrawatch/service-telemetry-operator/blob/master/roles/servicetelemetry/tasks/component_qdr.yml#L152

We need to upgrade the default password that is generated by the Interconnect Operator because it is extremely weak. The logic on L177 is supposed to pair with the label on L173 to make this a "one time" operation. However, you can see on L158 it's querying and registering the Interconnect object itself to _qdr_basicauth_object, not the Secret, so `_qdr_basicauth_object[0].metadata.labels.stf_one_time_upgrade` will never be defined (also it should be `_qdr_basicauth_object.resources[0]`, so a double-bug)