### PR TITLE
Adjust QDR authentication password generation

### DIFF
--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -172,7 +172,7 @@
             labels:
               stf_one_time_upgrade: "{{ lookup('pipe', 'date +%s') }}"
           stringData:
-            guest: "{{ lookup('password', '/dev/null') }}"
+            guest: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
       when:
         - _qdr_basicauth_object.resources[0] is defined and _qdr_basicauth_object.resources[0].metadata.labels.stf_one_time_upgrade is not defined
 


### PR DESCRIPTION
Adjust the passwords being generated for QDR authentication since
certain characters (such as colon) will cause a failure in the parsing
routine within qpid-dispatch. Updates the lookup function to only use
ascii_letters and digits and increases the length to 32 characters.
