### PR TITLE
[zuul] Add STO to required repos

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -12,6 +12,7 @@
     required-projects:
       - name: openstack-k8s-operators/ci-framework
         override-checkout: main
+      - name: github.com/infrawatch/service-telemetry-operator
       - name: github.com/infrawatch/smart-gateway-operator
       - name: github.com/infrawatch/sg-bridge
       - name: github.com/infrawatch/sg-core


### PR DESCRIPTION
It appears that STO is not included explictly when running jobs from SGO [1]. This will be the case in all the other repos. This change explicitly add it, in case it's not already included by zuul.

[1] https://review.rdoproject.org/zuul/build/edd8f17bfdac4360a94186b46c4cea3f