### PR TITLE
QDR Auth in smoketest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ spec:
           strategy: ephemeral
   transports:
     qdr:
-      auth: none
+      auth: basic
       enabled: true
       deploymentSize: 1
       web:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,6 @@ spec:
           strategy: ephemeral
   transports:
     qdr:
-      auth: basic
       enabled: true
       deploymentSize: 1
       web:

--- a/tests/smoketest/collectd-sensubility.conf
+++ b/tests/smoketest/collectd-sensubility.conf
@@ -10,7 +10,7 @@ worker_count=2
 checks={"check-container-health":{"command":"cat /healthcheck.log","handlers":[],"interval":3,"occurrences":3,"refresh":90,"standalone":true}}
 
 [amqp1]
-connection=amqp://default-interconnect.<<NAMESPACE>>.svc:5671
+connection=amqp://qdr-test:5672
 results_channel=sensubility/cloud1-telemetry
 client_name=smoketest.redhat.com
 results_format=smartgateway

--- a/tests/smoketest/minimal-collectd.conf.template
+++ b/tests/smoketest/minimal-collectd.conf.template
@@ -11,8 +11,8 @@ LoadPlugin cpu
 LoadPlugin amqp1
 <Plugin "amqp1">
   <Transport "name">
-    Host "default-interconnect"
-    Port "5671"
+    Host "qdr-test"
+    Port "5672"
     Address "collectd"
     <Instance "cloud1-telemetry">
         Format JSON

--- a/tests/smoketest/qdr-test.conf.yaml.template
+++ b/tests/smoketest/qdr-test.conf.yaml.template
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: qdr-test-config
+data:
+    qdrouterd.conf: |
+        router {
+            mode: edge
+            id: qdr-test.smoketest
+            workerThreads: 2
+            saslConfigDir: /etc/sasl2
+            saslConfigName: qdrouterd
+        }
+
+        sslProfile {
+            name: sslProfile
+            caCertFile: /etc/pki/tls/certs/ca.crt
+        }
+
+        listener {
+            host: 0.0.0.0
+            port: 5672
+            authenticatePeer: false
+            saslMechanisms: ANONYMOUS
+        }
+
+        connector {
+            host: default-interconnect
+            port: 5671
+            role: edge
+            saslPassword: pass:<<AMQP_PASS>>
+            saslUsername: guest@default-interconnect
+            sslProfile: sslProfile
+            verifyHostname: false
+        }
+
+        address {
+            prefix: unicast
+            distribution: closest
+        }
+
+        address {
+            prefix: exclusive
+            distribution: closest
+        }
+
+        address {
+            prefix: broadcast
+            distribution: multicast
+        }
+
+        address {
+            distribution: multicast
+            prefix: collectd
+        }
+
+        address {
+            distribution: multicast
+            prefix: anycast/ceilometer
+        }
+
+        log {
+            module: DEFAULT
+            enable: info+
+            includeTimestamp: true
+        }

--- a/tests/smoketest/qdr-test.yaml
+++ b/tests/smoketest/qdr-test.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: restricted-v2
+  name: qdr-test
+  labels:
+    qdr: qdr-test
+spec:
+  containers:
+    - name: qdr
+      image: quay.io/tripleowallabycentos9/openstack-qdrouterd:current-tripleo
+      imagePullPolicy: IfNotPresent
+      command: ['/usr/sbin/qdrouterd','-c','/etc/qpid-dispatch/qdrouterd.conf']
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+      ports:
+      - containerPort: 5672
+        name: amqp
+        protocol: TCP
+      volumeMounts:
+      - mountPath: /etc/pki/tls/certs/
+        name: default-interconnect-selfsigned-cert
+      - mountPath: /etc/qpid-dispatch/
+        name: qdr-test-config
+      resources: {}
+  volumes:
+  - name: default-interconnect-selfsigned-cert
+    secret:
+      defaultMode: 420
+      secretName: default-interconnect-selfsigned
+  - name: qdr-test-config
+    configMap:
+      defaultMode: 420
+      name: qdr-test-config
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: qdr-test
+spec:
+  ports:
+  - name: amqp
+    port: 5672
+    targetPort: amqp
+  selector:
+    qdr: qdr-test

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -27,13 +27,6 @@ if [ "${OC_CLIENT_VERSION_Y}" -lt "${OC_CLIENT_VERSION_Y_REQUIRED}" ] || [ "${OC
     exit 1
 fi
 
-if [ "$(oc get stf default -o=jsonpath='{.spec.transports.qdr.auth}')" != "none" ]; then
-    echo "*** QDR authentication is currently not supported in smoketests."
-    echo "To disable it, use: oc patch stf default --patch '{\"spec\":{\"transports\":{\"qdr\":{\"auth\":\"none\"}}}}' --type=merge"
-    echo "For more info: https://github.com/infrawatch/service-telemetry-operator/pull/492"
-    exit 1
-fi
-
 CLEANUP=${CLEANUP:-true}
 SMOKETEST_VERBOSE=${SMOKETEST_VERBOSE:-true}
 
@@ -57,17 +50,22 @@ ELASTICSEARCH_AUTH_PASS=$(oc get secret elasticsearch-es-elastic-user -ogo-templ
 echo "*** [INFO] Getting Prometheus authentication password"
 PROMETHEUS_AUTH_PASS=$(oc get secret default-prometheus-htpasswd -ogo-template='{{ .data.password | base64decode }}')
 
-echo "*** [INFO] Setting namepsace for collectd-sensubility config"
-sed "s/<<NAMESPACE>>/${OCP_PROJECT}/g" "${REL}/collectd-sensubility.conf" > /tmp/collectd-sensubility.conf
-
 echo "*** [INFO] Creating configmaps..."
 oc delete configmap/stf-smoketest-healthcheck-log configmap/stf-smoketest-collectd-config configmap/stf-smoketest-sensubility-config configmap/stf-smoketest-collectd-entrypoint-script configmap/stf-smoketest-ceilometer-publisher configmap/stf-smoketest-ceilometer-entrypoint-script job/stf-smoketest || true
 oc create configmap stf-smoketest-healthcheck-log --from-file "${REL}/healthcheck.log"
 oc create configmap stf-smoketest-collectd-config --from-file "${REL}/minimal-collectd.conf.template"
-oc create configmap stf-smoketest-sensubility-config --from-file /tmp/collectd-sensubility.conf
+oc create configmap stf-smoketest-sensubility-config --from-file "${REL}/collectd-sensubility.conf"
 oc create configmap stf-smoketest-collectd-entrypoint-script --from-file "${REL}/smoketest_collectd_entrypoint.sh"
 oc create configmap stf-smoketest-ceilometer-publisher --from-file "${REL}/ceilometer_publish.py"
 oc create configmap stf-smoketest-ceilometer-entrypoint-script --from-file "${REL}/smoketest_ceilometer_entrypoint.sh"
+
+echo "*** [INFO] Creating Mock OSP Metrics QDR router..."
+oc delete pod qdr-test
+oc delete service qdr-test
+oc delete configmap qdr-test-config
+AMQP_PASS=$(oc get secret default-interconnect-users -o json | jq -r .data.guest | base64 -d)
+oc create -f <(sed -e "s/<<AMQP_PASS>>/${AMQP_PASS}/;" ./qdr-test.conf.yaml.template)
+oc create -f qdr-test.yaml
 
 echo "*** [INFO] Creating smoketest jobs..."
 oc delete job -l app=stf-smoketest

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -64,8 +64,8 @@ oc delete pod qdr-test
 oc delete service qdr-test
 oc delete configmap qdr-test-config
 AMQP_PASS=$(oc get secret default-interconnect-users -o json | jq -r .data.guest | base64 -d)
-oc create -f <(sed -e "s/<<AMQP_PASS>>/${AMQP_PASS}/;" ./qdr-test.conf.yaml.template)
-oc create -f qdr-test.yaml
+oc create -f <(sed -e "s/<<AMQP_PASS>>/${AMQP_PASS}/;" "${REL}/qdr-test.conf.yaml.template")
+oc create -f "${REL}/qdr-test.yaml"
 
 echo "*** [INFO] Creating smoketest jobs..."
 oc delete job -l app=stf-smoketest

--- a/tests/smoketest/smoketest_ceilometer_entrypoint.sh
+++ b/tests/smoketest/smoketest_ceilometer_entrypoint.sh
@@ -13,11 +13,11 @@ POD=$(hostname)
 echo "*** [INFO] My pod is: ${POD}"
 
 # Run ceilometer_publisher script
-python3 /ceilometer_publish.py default-interconnect:5671 'driver=amqp&topic=cloud1-metering' 'driver=amqp&topic=cloud1-event'
+python3 /ceilometer_publish.py qdr-test:5672 'driver=amqp&topic=cloud1-metering' 'driver=amqp&topic=cloud1-event'
 
 # Sleeping to produce data
-echo "*** [INFO] Sleeping for 20 seconds to produce all metrics and events"
-sleep 20
+echo "*** [INFO] Sleeping for 30 seconds to produce all metrics and events"
+sleep 30
 
 echo "*** [INFO] List of metric names for debugging..."
 curl -sk -u "internal:${PROMETHEUS_AUTH_PASS}" -g "${PROMETHEUS}/api/v1/label/__name__/values" 2>&2 | tee /tmp/label_names


### PR DESCRIPTION
* Added qdr-test as a mock of the OSP-side QDR
* Connection from qdr-test -> default-interconnect is TLS+Auth
* Collectors point at qdr-test instead of default-interconnect directly
* Much more realistic than the existing setup
* Eliminated a substitution in sensubility config

```
OLD: [collectors ===clear+anon===> default-interconnect ===> SG]
NEW: [collectors ===clear+anon===> qdr-test ===TLS+auth===> default-interconnect ===> SG] 
```