### PR TITLE
[stf-collect-logs] Add ignore_errors to task

### DIFF
--- a/build/stf-collect-logs/tasks/main.yml
+++ b/build/stf-collect-logs/tasks/main.yml
@@ -47,6 +47,7 @@
       oc -n {{ namespace }} get csv | grep service-telemetry-operator >> {{ logfile_dir }}/post_question_deployment.log 2>&1
       oc -n {{ namespace }} get csv $(oc -n {{ namespace }} get csv | grep "service-telemetry-operator" | awk '{ print $1}') -oyaml >> {{ logfile_dir }}/post_question_deployment.log 2>&1
   register: output
+  ignore_errors: true
   retries: 3
   delay: 10
 


### PR DESCRIPTION
The "Question the deployment" task didn't have
ignore_errors: true set, so when the task fails, the play is finished. This means that we don't get to the
"copy logs" task and can't see the job logs in zuul.

ignore_errors is set to true to be consistent with other tasks