### PR TITLE
Restart QDR after changing the password (#530)

### DIFF
--- a/ci/vars-zuul-common.yml
+++ b/ci/vars-zuul-common.yml
@@ -2,6 +2,5 @@
 namespace: "service-telemetry"
 setup_bundle_registry_tls_ca: false
 setup_bundle_registry_auth: false
-__service_telemetry_transports_qdr_auth: none
 base_dir: "{{ sto_dir }}/build"
 logfile_dir: "{{ ansible_user_dir }}/zuul-output/logs/controller"

--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -163,21 +163,41 @@
         namespace: "{{ ansible_operator_meta.namespace }}"
       register: _qdr_basicauth_object
 
-    # Because https://github.com/interconnectedcloud/qdr-operator/blob/576d2b33dac71437ea2b165caaaf6413220767fe/pkg/controller/interconnect/interconnect_controller.go#L634
-    - name: Perform a one-time upgrade to the default generated password for QDR BasicAuth
-      k8s:
-        definition:
-          kind: Secret
-          apiVersion: v1
-          metadata:
-            name: "{{ ansible_operator_meta.name }}-interconnect-users"
+    - when:
+      - _qdr_basicauth_object.resources[0] is defined and _qdr_basicauth_object.resources[0].metadata.labels.stf_one_time_upgrade is not defined
+      block:
+        # Because https://github.com/interconnectedcloud/qdr-operator/blob/576d2b33dac71437ea2b165caaaf6413220767fe/pkg/controller/interconnect/interconnect_controller.go#L634
+        - name: Perform a one-time upgrade to the default generated password for QDR BasicAuth
+          k8s:
+            definition:
+              kind: Secret
+              apiVersion: v1
+              metadata:
+                name: "{{ ansible_operator_meta.name }}-interconnect-users"
+                namespace: "{{ ansible_operator_meta.namespace }}"
+                labels:
+                  stf_one_time_upgrade: "{{ lookup('pipe', 'date +%s') }}"
+              stringData:
+                guest: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
+
+        # label_selectors on the k8s object need kubernetes.core>=2.2.0
+        - name: Get the list of QDR pods
+          k8s_info:
+            api_version: v1
+            kind: Pod
             namespace: "{{ ansible_operator_meta.namespace }}"
-            labels:
-              stf_one_time_upgrade: "{{ lookup('pipe', 'date +%s') }}"
-          stringData:
-            guest: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
-      when:
-        - _qdr_basicauth_object.resources[0] is defined and _qdr_basicauth_object.resources[0].metadata.labels.stf_one_time_upgrade is not defined
+            label_selectors:
+              - application={{ ansible_operator_meta.name }}-interconnect
+          register: _qdr_pod
+
+        - name: Restart QDR pods to pick up new password
+          k8s:
+            state: absent
+            api_version: v1
+            kind: Pod
+            namespace: "{{ ansible_operator_meta.namespace }}"
+            name: "{{ item.metadata.name }}"
+          loop: "{{ _qdr_pod.resources }}"
 
 - name: Set default Interconnect manifest
   set_fact:


### PR DESCRIPTION
* Restart QDR after changing the password
* Fixes bug reported here: https://github.com/infrawatch/service-telemetry-operator/pull/517#issuecomment-1794919985
* Avoids an extra manual step when changing password
* Would affect users who upgrade from earlier STF and subsequently enable basic auth
* Also users who need to change their passwords
* Fixing ansible lint
* Update roles/servicetelemetry/tasks/component_qdr.yml
* Adjust QDR restarts to account for HA
* [smoketest] Wait for qdr-test to be Running
* [smoketest] Wait for QDR password upgrade
* Remove zuul QDR auth override

(cherry picked from commit 16b8197ed3d0413f652c73a8e309f88f46d635ac)