### PR TITLE
Support OCP v4.12 through v4.14 (#535)

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
+++ b/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.11-v4.14"
+LABEL com.redhat.openshift.versions="v4.12-v4.14"
 LABEL com.redhat.delivery.backport=false
 
 LABEL com.redhat.component="service-telemetry-operator-bundle-container" \


### PR DESCRIPTION
Support STF 1.5.3 starting at OpenShift version 4.12 due to
incompatibility with 4.11 due to dependency requirements. Our primary
target is support of OCP EUS releases.

Closes: STF-1632
(cherry picked from cba3874b69a20e72ce8939ac49c9616c16711392)
Depends-on: https://github.com/infrawatch/smart-gateway-operator/pull/153
