### PR TITLE
Adjust Operator dependency version requirements

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -27,7 +27,7 @@ properties:
           - failureMessage: Package openshift-cert-manager-operator is needed for AMQ Interconnect setup
             package:
               packageName: openshift-cert-manager-operator
-              versionRange: '>=1.10.0'
+              versionRange: '>=1.7.0'
   - type: olm.constraint
     value:
       failureMessage: Require Prometheus backend for data storage of metrics for Service Telemetry Framework
@@ -38,7 +38,7 @@ properties:
               versionRange: '>=0.56.0'
           - package:
               packageName: observability-operator
-              versionRange: '>=0.0.1'
+              versionRange: '>=0.0.25'
           - package:
               packageName: cluster-observability-operator
-              versionRange: '>=0.0.1'
+              versionRange: '>=0.1.0'


### PR DESCRIPTION
Adjust the operator package dependency requirements to align to known
required versions. Primarily reduce the version of
openshift-cert-manager from 1.10 to 1.7 in order to support the
tech-preview channel which was previously used.

Lowering the version requirement allows for the
openshift-cert-manager-operator installed previously to be used during
the STF 1.5.2 to 1.5.3 update, removing the update from being blocked.

Related: STF-1636
