### PR TITLE
Only require Interconnect and Smart Gateway

### DIFF
--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -170,4 +170,4 @@
           securityContextConfig: legacy
         updateStrategy:
           registryPoll:
-            interval: 1m
+            interval: 5m

--- a/build/stf-run-ci/tasks/pre-clean.yml
+++ b/build/stf-run-ci/tasks/pre-clean.yml
@@ -134,6 +134,7 @@
   loop:
     - openshift-cert-manager-operator
     - cert-manager-operator
+    - cert-manager
 
 - name: Remove Elasticsearch
   ignore_errors: true

--- a/build/stf-run-ci/tasks/pre-clean.yml
+++ b/build/stf-run-ci/tasks/pre-clean.yml
@@ -122,7 +122,6 @@
         name: smart-gateway-operator-catalog
         namespace: "{{ namespace }}"
 
-# Remove the cert manager since we install it as part of the CI/documented pre-install process
 - name: Remove openshift-cert-manager-operator namespace
   kubernetes.core.k8s:
     state: absent
@@ -131,7 +130,10 @@
       apiVersion: project.openshift.io/v1
       kind: Project
       metadata:
-        name: openshift-cert-manager-operator
+        name: "{{ item }}"
+  loop:
+    - openshift-cert-manager-operator
+    - cert-manager-operator
 
 - name: Remove Elasticsearch
   ignore_errors: true

--- a/build/stf-run-ci/tasks/preflight_checks.yml
+++ b/build/stf-run-ci/tasks/preflight_checks.yml
@@ -25,7 +25,7 @@
     - name: "Show service-telemetry-operator CSV information"
       ansible.builtin.debug:
         var: csv_sto.stdout
-            
+
     - name: "Show fail message if CSV isn't Succeeded after the alotted time"
       ansible.builtin.fail:
         msg: "Service Telemetry Operator CSV not Succeeded after 10 minutes. Check {{ logfile_dir }}/oc_get_csv_sto.log for more information"

--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -16,6 +16,7 @@
         - disabled: false
           name: community-operators
 
+# documented procedure: https://infrawatch.github.io/documentation/#deploying-service-telemetry-operator_assembly-installing-the-core-components-of-stf
 - name: Create OperatorGroup for service-telemetry
   kubernetes.core.k8s:
     definition:
@@ -28,57 +29,7 @@
         targetNamespaces:
         - "{{ namespace }}"
 
-- when: not __deploy_from_index_enabled | bool
-  block:
-    - name: Subscribe to Cert Manager for OpenShift Operator
-      kubernetes.core.k8s:
-        definition:
-          apiVersion: operators.coreos.com/v1alpha1
-          kind: Subscription
-          metadata:
-            labels:
-              operators.coreos.com/openshift-cert-manager-operator.service-telemetry: ""
-            name: openshift-cert-manager-operator-stable-v1-redhat-operators-openshift-marketplace
-            namespace: "{{ namespace }}"
-          spec:
-            channel: stable-v1
-            installPlanApproval: Automatic
-            name: openshift-cert-manager-operator
-            source: redhat-operators
-            sourceNamespace: openshift-marketplace
-
-    - name: Subscribe to AMQ Interconnect Operator
-      kubernetes.core.k8s:
-        definition:
-          apiVersion: operators.coreos.com/v1alpha1
-          kind: Subscription
-          metadata:
-            name: amq7-interconnect-operator
-            namespace: "{{ namespace }}"
-          spec:
-            channel: 1.10.x
-            installPlanApproval: Automatic
-            name: amq7-interconnect-operator
-            source: redhat-operators
-            sourceNamespace: openshift-marketplace
-
-    - name: Subscribe to Prometheus Operator
-      kubernetes.core.k8s:
-        definition:
-          apiVersion: operators.coreos.com/v1alpha1
-          kind: Subscription
-          metadata:
-            name: prometheus
-            namespace: "{{ namespace }}"
-          spec:
-            channel: beta
-            installPlanApproval: Automatic
-            name: prometheus
-            source: community-operators
-            sourceNamespace: openshift-marketplace
-      when:
-        - __service_telemetry_observability_strategy == "use_community"
-
+# documented procedure: https://infrawatch.github.io/documentation/#deploying-observability-operator_assembly-installing-the-core-components-of-stf
 - name: Subscribe to Red Hat Obervability Operator
   kubernetes.core.k8s:
     definition:
@@ -98,27 +49,108 @@
   when:
     - __service_telemetry_observability_strategy in ['use_redhat', 'use_hybrid']
 
-- name: Subscribe to Elastic Cloud on Kubernetes Operator
+# undocumented procedure, used for testing updates or old deployment models
+- name: Subscribe to Prometheus Operator
   kubernetes.core.k8s:
     definition:
       apiVersion: operators.coreos.com/v1alpha1
       kind: Subscription
       metadata:
-        name: elasticsearch-eck-operator-certified
+        name: prometheus
         namespace: "{{ namespace }}"
       spec:
-        channel: stable
+        channel: beta
         installPlanApproval: Automatic
-        name: elasticsearch-eck-operator-certified
-        source: certified-operators
+        name: prometheus
+        source: community-operators
         sourceNamespace: openshift-marketplace
+  when:
+    - __service_telemetry_observability_strategy == "use_community"
 
-- name: Wait for Elasticsearch CRD to appear
-  kubernetes.core.k8s_info:
-    api_version: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    name: elasticsearches.elasticsearch.k8s.elastic.co
-  register: eckCRD
-  until: eckCRD.resources[0] is defined
-  retries: 5
-  delay: 30
+# documented procedure: https://infrawatch.github.io/documentation/#deploying-certificate-manager-for-openshift-operator_assembly-installing-the-core-components-of-stf
+- block:
+  - name: Create project for cert-manager for Red Hat OpenShift
+    kubernetes.core.k8s:
+      definition:
+        apiVersion: project.openshift.io/v1
+        kind: Project
+        metadata:
+          name: cert-manager-operator
+        spec:
+          finalizers:
+          - kubernetes
+
+  - name: Create OperatorGroup for cert-manager for Red hat OpenShift
+    kubernetes.core.k8s:
+      definition:
+        apiVersion: operators.coreos.com/v1
+        kind: OperatorGroup
+        metadata:
+          name: cert-manager-operator
+          namespace: cert-manager-operator
+        spec:
+          targetNamespaces:
+          - cert-manager-operator
+          upgradeStrategy: Default
+
+  - name: Subscribe to cert-manager for Red Hat OpenShift Operator
+    kubernetes.core.k8s:
+      definition:
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          labels:
+            operators.coreos.com/openshift-cert-manager-operator.service-telemetry: ""
+          name: openshift-cert-manager-operator
+          namespace: cert-manager-operator
+        spec:
+          channel: stable-v1
+          installPlanApproval: Automatic
+          name: openshift-cert-manager-operator
+          source: redhat-operators
+          sourceNamespace: openshift-marketplace
+
+# installed by properties.yaml definition as of STF 1.5.3
+- when: not __deploy_from_index_enabled | bool
+  block:
+    - name: Subscribe to AMQ Interconnect Operator
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: amq7-interconnect-operator
+            namespace: "{{ namespace }}"
+          spec:
+            channel: 1.10.x
+            installPlanApproval: Automatic
+            name: amq7-interconnect-operator
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
+
+# undocumented procedure: used for backwards compatilibity verification
+- block:
+    - name: Subscribe to Elastic Cloud on Kubernetes Operator
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: elasticsearch-eck-operator-certified
+            namespace: "{{ namespace }}"
+          spec:
+            channel: stable
+            installPlanApproval: Automatic
+            name: elasticsearch-eck-operator-certified
+            source: certified-operators
+            sourceNamespace: openshift-marketplace
+
+    - name: Wait for Elasticsearch CRD to appear
+      kubernetes.core.k8s_info:
+        api_version: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        name: elasticsearches.elasticsearch.k8s.elastic.co
+      register: eckCRD
+      until: eckCRD.resources[0] is defined
+      retries: 5
+      delay: 30

--- a/build/stf-run-ci/tasks/setup_stf.yml
+++ b/build/stf-run-ci/tasks/setup_stf.yml
@@ -9,7 +9,7 @@
         namespace: openshift-marketplace
       spec:
         displayName: InfraWatch Operators
-        image: quay.io/infrawatch-operators/infrawatch-catalog:unstable
+        image: quay.io/infrawatch-operators/infrawatch-catalog:nightly
         publisher: InfraWatch
         sourceType: grpc
         updateStrategy:
@@ -49,6 +49,14 @@
         sourceNamespace: openshift-marketplace
   when: service_telemetry_operator_subscription_manifest is not defined
 
+# enable catalogsource
+- name: Enable InfraWatch Catalog Source
+  kubernetes.core.k8s:
+    definition:
+      '{{ infrawatch_catalog_source_manifest }}'
+
+# subscribe to the Operators from the defined CatalogSource sources.
+# STO will automatically install SGO via dependencies but pre-subscribe in case deployment from different CatalogSources is specified in an override (for testing purposes).
 - name: Subscribe to Smart Gateway Operator
   kubernetes.core.k8s:
     definition:
@@ -58,8 +66,3 @@
   kubernetes.core.k8s:
     definition:
       '{{ service_telemetry_operator_subscription_manifest }}'
-
-- name: Enable InfraWatch Catalog Source
-  kubernetes.core.k8s:
-    definition:
-      '{{ infrawatch_catalog_source_manifest }}'

--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -19,26 +19,3 @@ properties:
             package:
               packageName: amq7-interconnect-operator
               versionRange: '>=1.10.0'
-  - type: olm.constraint
-    value:
-      failureMessage: Require certificate management for Service Telemetry Framework
-      all:
-        constraints:
-          - failureMessage: Package openshift-cert-manager-operator is needed for AMQ Interconnect setup
-            package:
-              packageName: openshift-cert-manager-operator
-              versionRange: '>=1.7.0'
-  - type: olm.constraint
-    value:
-      failureMessage: Require Prometheus backend for data storage of metrics for Service Telemetry Framework
-      any:
-        constraints:
-          - package:
-              packageName: prometheus
-              versionRange: '>=0.56.0'
-          - package:
-              packageName: observability-operator
-              versionRange: '>=0.0.25'
-          - package:
-              packageName: cluster-observability-operator
-              versionRange: '>=0.1.0'


### PR DESCRIPTION
Update the dependency management within Service Telemetry Operator to
only require AMQ Interconnect and Smart Gateway Operator, which is
enough to deploy STF with observabilityStrategy: none. Other Operators
can be installed in order to satisfy data storage of telemetry and
events.

Installation of cert-manager is also required, but needs to be
pre-installed similar to Cluster Observability Operator, either as a
cluster-scoped operator with the tech-preview channel, or a single time
on the cluster as a namespace scoped operator, which is how the
stable-v1 channel installs.

Documentation will be updated to adjust for this change.

Related: STF-1636
