### PR TITLE
[stf-run-ci] Explicitly check the validate_daployment was successful

### DIFF
--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -220,7 +220,8 @@
     args:
       executable: /bin/bash
     register: validate_deployment
+    failed_when: validate_deployment.stdout_lines[-1] != "* [info] CI Build complete. You can now run tests."
 
   - name: Show the result of the validate_deployment script
     ansible.builtin.debug:
-      var: validate_deployment.stdout
+      var: validate_deployment.stdout_lines[-1]


### PR DESCRIPTION
In [1], the validate_deployment step is successful, despite the deployment not being successful.
This causes the job to timeout because the following steps continue to run despite an invalid state.

To get the expected behaviour, the output should be checked for a string indicating success.
i.e. * [info] CI Build complete. You can now run tests. [2] shows the output for a successful run.

[1] https://review.rdoproject.org/zuul/build/245ae63e41884dc09353d938ec9058d7/console#5/0/144/controller
[2] https://review.rdoproject.org/zuul/build/802432b23da24649b818985b7b1633bb/console#5/0/82/controller