### PR TITLE
Adjust Alertmanager SAR to be more specific

### DIFF
--- a/roles/servicetelemetry/tasks/component_prometheus.yml
+++ b/roles/servicetelemetry/tasks/component_prometheus.yml
@@ -42,12 +42,6 @@
         - subjectaccessreviews
         verbs:
         - create
-      - apiGroups:
-        - ""
-        resources:
-        - namespaces
-        verbs:
-        - get
 
 - name: Setup ClusterRoleBinding for Prometheus
   block:
@@ -123,6 +117,18 @@
         - securitycontextconstraints
         verbs:
         - use
+      - apiGroups:
+        - '{{ prometheus_operator_api_string | replace("/v1","") }}'
+        resources:
+        - alertmanagers
+        verbs:
+        - get
+      - apiGroups:
+        - smartgateway.infra.watch
+        resources:
+        - smartgateways
+        verbs:
+        - get
 
 - name: Setup RoleBinding for Prometheus
   block:

--- a/roles/servicetelemetry/templates/manifest_alertmanager.j2
+++ b/roles/servicetelemetry/templates/manifest_alertmanager.j2
@@ -26,8 +26,8 @@ spec:
     - -upstream=http://localhost:9093/
     - -cookie-secret-file=/etc/proxy/secrets/session_secret
     - -openshift-service-account=alertmanager-stf
-    - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
-    - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+    - '-openshift-sar={"namespace":"{{ ansible_operator_meta.namespace }}", "resource": "alertmanagers", "group":"{{ prometheus_operator_api_string | replace("/v1","") }}", "verb":"get"}'
+    - '-openshift-delegate-urls={"/": {"namespace":"{{ ansible_operator_meta.namespace }}", "resource": "alertmanagers", "group":"{{ prometheus_operator_api_string | replace("/v1","") }}", "verb":"get"}}'
     ports:
       - containerPort: 9095
         name: https


### PR DESCRIPTION
* This matches recent changes in prometheus[1] and grafana[2]
* Also adds the required permission for prometheus-stf to query smart gateways

[1] https://github.com/infrawatch/service-telemetry-operator/pull/549/files#diff-2cf84bcf66f12393c86949ec0d3f16c473a650173d55549bb02556d23aa22bd2R46
[2] https://github.com/infrawatch/service-telemetry-operator/pull/550/files#diff-ae71801975adb4f8dd4aa5479a66ad46e46f17de40f9d147b2e09e13ce26633eR45

Depends-on: https://github.com/infrawatch/smart-gateway-operator/pull/154
Depends-on: https://github.com/infrawatch/service-telemetry-operator/pull/549