### PR TITLE
Fix branch co-ordination in stf-run-ci

### DIFF
--- a/build/stf-run-ci/tasks/clone_repos.yml
+++ b/build/stf-run-ci/tasks/clone_repos.yml
@@ -16,7 +16,7 @@
       ansible.builtin.git:
         repo: "{{ sgo_repository }}"
         dest: "{{ sgo_dir }}"
-        version: "{{ version_branches.sgo | default(branch, true) }}"
+        version: "{{ sgo_branch | default(branch, true) }}"
   rescue:
     - name: "Get {{ version_branches.sgo }} upstream branch because specified branch or repository doesn't exist"
       ansible.builtin.git:
@@ -36,7 +36,7 @@
       ansible.builtin.git:
         repo: "{{ sg_core_repository }}"
         dest: "{{ sg_core_dir }}"
-        version: "{{ version_branches.sg_core | default(branch, true) }}"
+        version: "{{ sg_core_branch | default(branch, true) }}"
   rescue:
     - name: "Get {{ version_branches.sg_core }} upstream branch because specified branch or repository doesn't exist"
       ansible.builtin.git:
@@ -56,7 +56,7 @@
       ansible.builtin.git:
         repo: "{{ sg_bridge_repository }}"
         dest: "{{ sg_bridge_dir }}"
-        version: "{{ version_branches.sg_bridge | default(branch, true) }}"
+        version: "{{ sg_bridge_branch | default(branch, true) }}"
   rescue:
     - name: "Get {{ version_branches.sg_bridge }} upstream branch because specified branch or repository doesn't exist"
       ansible.builtin.git:
@@ -76,7 +76,7 @@
       ansible.builtin.git:
         repo: "{{ prometheus_webhook_snmp_repository }}"
         dest: "{{ prometheus_webhook_snmp_dir }}"
-        version: "{{ version_branches.prometheus_webhook_snmp | default(branch, true) }}"
+        version: "{{ prometheus_webhook_snmp_branch | default(branch, true) }}"
   rescue:
     - name: "Get {{ version_branches.prometheus_webhook_snmp }} upstream branch because specified branch or repository doesn't exist"
       ansible.builtin.git:

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -4,7 +4,6 @@
 # -- initial setup
 - name: Setup default values
   ansible.builtin.set_fact:
-    # The branch should be removed, we should assume that everything is checked out to the right place.
     branch: "{{ working_branch | default('master') }}"
     namespace: "{{ namespace if namespace is defined else (working_namespace | default('service-telemetry'))}}"
 


### PR DESCRIPTION
I think it got broken by an oops recently[1].

Since that change, working_branch (`branch` at that point) is never used because version_branches.sgo has a default value.

This breaks the branch co-ordination in Jenkins[2] and in local testing[3].

[1] https://github.com/infrawatch/service-telemetry-operator/pull/512/files#diff-c073fe1e346d08112920aa0bbc8a7453bbd3032b7a9b09ae8cbc70df4db4ea2dR19
[2] https://github.com/infrawatch/service-telemetry-operator/blob/0f94fd577617aee6a85fc4141f98ebdfc49a9f92/Jenkinsfile#L157
[3] https://github.com/infrawatch/service-telemetry-operator/blob/0f94fd577617aee6a85fc4141f98ebdfc49a9f92/README.md?plain=1#L62