### PR TITLE
Add optional spec.replaces field to CSV for update graph compliance

### DIFF
--- a/build/generate_bundle.sh
+++ b/build/generate_bundle.sh
@@ -35,6 +35,15 @@ generate_bundle() {
     ${OPERATOR_SDK} generate bundle --verbose --channels ${BUNDLE_CHANNELS} --default-channel ${BUNDLE_DEFAULT_CHANNEL} --manifests --metadata --version "${OPERATOR_BUNDLE_VERSION}" --output-dir "${WORKING_DIR}" >> ${LOGFILE} 2>&1
     popd > /dev/null 2>&1
 
+    # CSVs without a spec.replaces field are valid, so fall back to those if
+    # latest released version is unknown.
+    # Placeholder value is validated by operator-sdk during local bundle
+    # generation and so needs to conform to RFC1123.
+    if [[ -n "$BUNDLE_LATEST_RELEASED_VERSION" ]]; then
+        REPLACE_REGEX="$REPLACE_REGEX;s#---bundle-latest-released-version#${BUNDLE_LATEST_RELEASED_VERSION}#g"
+    else sed -i '/---bundle-latest-released-version/d' "${WORKING_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"
+    fi
+
     sed -i -E "${REPLACE_REGEX}" "${WORKING_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"
 }
 

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -460,4 +460,5 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
+  replaces: service-telemetry-operator.v---bundle-latest-released-version
   version: 1.99.0


### PR DESCRIPTION
The way we generate our CSVs uses OLM's skipRange functionality. This is fine, but using only this leads to older versions becoming unavailable after the fact -- see the warning at [1].

By adding an optional spec.replaces to our CSV we allow update testing as well as actual production updates for downstream builds that leverage it.

Populating the field requires knowledge of the latest-released bundle, so we take it from an environment variable to be provided by the builder. If this is unset we don't include the spec.replaces field at all -- leaving previous behavior unchanged.

Resolves #559
Related: STF-1658

[1] https://olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/#skiprange