### PR TITLE
Remove hard-coded Prometheus version in template

### DIFF
--- a/roles/servicetelemetry/templates/manifest_prometheus.j2
+++ b/roles/servicetelemetry/templates/manifest_prometheus.j2
@@ -7,7 +7,11 @@ metadata:
   name: '{{ ansible_operator_meta.name }}'
   namespace: '{{ ansible_operator_meta.namespace }}'
 spec:
+{% if observability_strategy != "use_community" %}
+  version: null
+{% else %}
   version: v2.43.0
+{% endif %}
   replicas: {{ servicetelemetry_vars.backends.metrics.prometheus.deployment_size }}
   ruleSelector: {}
   securityContext: {}


### PR DESCRIPTION
Remove the hard-coded Prometheus version in the Prometheus template when
using observabilityStrategy use_redhat, which uses Cluster Observability
Operator to manage the Prometheus instance requests.

Previously this value was hard-coded to prevent a potential rollback
when moving from Community Prometheus Operator to Cluster Observability
Operator.

Resolves: JIRA#OSPRH-2140
