### PR TITLE
[stf-run-ci] Update validation check for bundle URLs

### DIFF
--- a/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
+++ b/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
@@ -90,12 +90,8 @@
 - name: "Ensure that the bundle paths are set."
   ansible.builtin.assert:
     that:
-      - '__smart_gateway_bundle_image_path is defined'
-      - '__smart_gateway_bundle_image_path != None'
-      - '__smart_gateway_bundle_image_path | length != 0'
-      - '__service_telemetry_bundle_image_path is defined'
-      - '__service_telemetry_bundle_image_path != None'
-      - '__service_telemetry_bindle_image_path | length != 0'
+      - '__smart_gateway_bundle_image_path | default("") | length > 0'
+      - '__service_telemetry_bindle_image_path | default("") | length > 0'
     fail_msg: "Bundle path(s) not set. __smart_gateway_bundle_image_path is '{{ __smart_gateway_bundle_image_path }}' and __service_telemetry_bundle_image_path is '{{ __service_telemetry_bundle_image_path }}'. Both values need to be set."
     success_msg: "Bundle paths are defined, are not None and have a non-zero-length"
 

--- a/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
+++ b/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
@@ -90,10 +90,14 @@
 - name: "Ensure that the bundle paths are set."
   ansible.builtin.assert:
     that:
-      - '__smart_gateway_bundle_image_path is defined and __smart_gateway_bundle_image_path != None'
-      - '__service_telemetry_bundle_image_path is defined and __service_telemetry_bundle_image_path != None'
+      - '__smart_gateway_bundle_image_path is defined'
+      - '__smart_gateway_bundle_image_path != None'
+      - '__smart_gateway_bundle_image_path | length != 0'
+      - '__service_telemetry_bundle_image_path is defined'
+      - '__service_telemetry_bundle_image_path != None'
+      - '__service_telemetry_bindle_image_path | length != 0'
     fail_msg: "Bundle path(s) not set. __smart_gateway_bundle_image_path is '{{ __smart_gateway_bundle_image_path }}' and __service_telemetry_bundle_image_path is '{{ __service_telemetry_bundle_image_path }}'. Both values need to be set."
-    success_msg: "Bundle paths are defined and not None"
+    success_msg: "Bundle paths are defined, are not None and have a non-zero-length"
 
 - name: Deploy SGO via OLM bundle
   ansible.builtin.shell:


### PR DESCRIPTION
An empty string passed as the bundle URL will pass the existing test of "is defined" and "is not None" and still be invalid.

* add a check for "length != 0"
* assert requires all conditions to be met, the checks can all be listed separately to make the task easier to grok.