### PR TITLE
Prefer Grafana 9 workload

### DIFF
--- a/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
+++ b/deploy/crds/infra.watch_v1beta1_servicetelemetry_cr.yaml
@@ -81,7 +81,7 @@ spec:
     grafana:
       ingressEnabled: true
       disableSignoutMenu: false
-      baseImage: registry.redhat.io/rhel8/grafana:7
+      baseImage: registry.redhat.io/rhel8/grafana:9
       dashboards:
         enabled: true
   transports:

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -117,7 +117,7 @@ metadata:
             "graphing": {
               "enabled": false,
               "grafana": {
-                "baseImage": "registry.redhat.io/rhel8/grafana:7",
+                "baseImage": "registry.redhat.io/rhel8/grafana:9",
                 "dashboards": {
                   "enabled": true
                 },

--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -84,7 +84,7 @@ servicetelemetry_defaults:
     grafana:
       ingress_enabled: true
       disable_signout_menu: false
-      base_image: registry.redhat.io/rhel8/grafana:7
+      base_image: registry.redhat.io/rhel8/grafana:9
       dashboards:
         enabled: true
 


### PR DESCRIPTION
Prefer usage of Grafana 9 container image from RHCC. Grafana 7 is EOL
upstream and receives no security support. Prefer use of Grafana 9 which
is still supported.
