### PR TITLE
Fix env var naming issue (#581)

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -297,7 +297,7 @@ spec:
                   value: <<RELATED_IMAGE_OAUTH_PROXY>>:<<RELATED_IMAGE_OAUTH_PROXY_TAG>>
                 - name: RELATED_IMAGE_PROMETHEUS_IMAGE
                   value: <<RELATED_IMAGE_PROMETHEUS>>:<<RELATED_IMAGE_PROMETHEUS_TAG>>
-                - name: RELATED_IMAGE_ALERTMANAGER
+                - name: RELATED_IMAGE_ALERTMANAGER_IMAGE
                   value: <<RELATED_IMAGE_ALERTMANAGER>>:<<RELATED_IMAGE_ALERTMANAGER_TAG>>
                 image: <<OPERATOR_IMAGE>>:<<OPERATOR_TAG>>
                 imagePullPolicy: Always

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -39,7 +39,7 @@ spec:
               value: <<RELATED_IMAGE_OAUTH_PROXY>>:<<RELATED_IMAGE_OAUTH_PROXY_TAG>>
             - name: RELATED_IMAGE_PROMETHEUS_IMAGE
               value: <<RELATED_IMAGE_PROMETHEUS>>:<<RELATED_IMAGE_PROMETHEUS_TAG>>
-            - name: RELATED_IMAGE_ALERTMANAGER
+            - name: RELATED_IMAGE_ALERTMANAGER_IMAGE
               value: <<RELATED_IMAGE_ALERTMANAGER>>:<<RELATED_IMAGE_ALERTMANAGER_TAG>>
       volumes:
         - name: runner


### PR DESCRIPTION
* Fix env var naming issue

Fix an environment variable naming issue in the CSV for STO when
attempting to install alertmanager disconnected. The env var being
looked up should have a postfix of _IMAGE to match the other env vars.

Found in testing by vkmc.

* Run operator-sdk generate bundle

Run the generate bundle command to make sure everything is in sync.
Fixes CI found issue in previous commit.

(cherry-picked from commit 6568039b83e0caaa557af0a462407077e3c1176c)