### PR TITLE
Skip installing deps when installing from bundles

### DIFF
--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -30,7 +30,7 @@
         - "{{ namespace }}"
 
 # documented procedure: https://infrawatch.github.io/documentation/#deploying-observability-operator_assembly-installing-the-core-components-of-stf
-- name: Subscribe to Red Hat Obervability Operator
+- name: Subscribe to Red Hat Observability Operator
   kubernetes.core.k8s:
     definition:
       apiVersion: operators.coreos.com/v1alpha1
@@ -111,7 +111,7 @@
           sourceNamespace: openshift-marketplace
 
 # installed by properties.yaml definition as of STF 1.5.3
-- when: not __deploy_from_index_enabled | bool
+- when: __local_build_enabled | bool
   block:
     - name: Subscribe to AMQ Interconnect Operator
       kubernetes.core.k8s:


### PR DESCRIPTION
Dependencies for STF are being handled by OLM since STF 1.5.3.

Related change https://github.com/infrawatch/service-telemetry-operator/pull/423

Except for Prometheus/COO and cert-manager (since
those are scoped cluster-wide and OLM cannot
automatically resolve conflicts)

Related change https://github.com/infrawatch/service-telemetry-operator/pull/472

So there is no need to pre subscribe to those when deploying for index or bundles.

It is required, though, for local installs.

The only operator that was on this condition is
the AMQ Interconnect operator.
So this change updates the check to reflect this.