### PR TITLE
[zuul] Resolve install_yamls errors by skipping bootstrap tags

### DIFF
--- a/ci/pre-2node.yml
+++ b/ci/pre-2node.yml
@@ -14,7 +14,7 @@
     - name: "Run bootstrap playbook"
       ansible.builtin.shell:
         cmd: |
-          ansible-playbook -e@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml {{ ci_framework_dir }}/playbooks/01-bootstrap.yml
+          ansible-playbook -e@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml {{ ci_framework_dir }}/playbooks/01-bootstrap.yml -t packages
         chdir: "{{ ci_framework_dir }}"
 
     - name: Run ci_framework infra playbook

--- a/ci/pre-2node.yml
+++ b/ci/pre-2node.yml
@@ -14,7 +14,7 @@
     - name: "Run bootstrap playbook"
       ansible.builtin.shell:
         cmd: |
-          ansible-playbook -e@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml {{ ci_framework_dir }}/playbooks/01-bootstrap.yml --skip-tags bootstrap
+          ansible-playbook -e@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml {{ ci_framework_dir }}/playbooks/01-bootstrap.yml --tags packages
         chdir: "{{ ci_framework_dir }}"
 
     - name: Run ci_framework infra playbook

--- a/ci/pre-2node.yml
+++ b/ci/pre-2node.yml
@@ -14,7 +14,7 @@
     - name: "Run bootstrap playbook"
       ansible.builtin.shell:
         cmd: |
-          ansible-playbook -e@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml {{ ci_framework_dir }}/playbooks/01-bootstrap.yml -t packages
+          ansible-playbook -e@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml {{ ci_framework_dir }}/playbooks/01-bootstrap.yml --skip-tags bootstrap
         chdir: "{{ ci_framework_dir }}"
 
     - name: Run ci_framework infra playbook


### PR DESCRIPTION
The ci-framework/playbooks/01-bootstrap.yml uses two tags bootstrap and packages.
the bootstrap tag sets up repos and runs install_yamls for creating the openstack operators. These are not needed for STF as we just want to use the CRC setup

This is an alternative solution to https://github.com/openstack-k8s-operators/ci-framework/pull/1403

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1453
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1461
