### PR TITLE
Fail earlier when registry creds are not set

### DIFF
--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -55,7 +55,7 @@
   tags:
     - pre-clean
 
-- name: Set up internal registry credentials (deploy from bundles)
+- name: Set up bundle registry credentials (deploy from bundles)
   ansible.builtin.include_tasks: setup_registry_auth.yml
   when:
   - __deploy_from_bundles_enabled | bool

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -49,9 +49,7 @@
 
 - name: Set up bundle registry credentials (deploy from bundles)
   ansible.builtin.include_tasks: setup_registry_auth.yml
-  when:
-  - __deploy_from_bundles_enabled | bool
-  - setup_bundle_registry_auth | bool
+  when: __deploy_from_bundles_enabled | bool or setup_bundle_registry_auth | bool
 
 - name: Setup supporting Operator subscriptions
   ansible.builtin.include_tasks: setup_base.yml

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -55,6 +55,12 @@
   tags:
     - pre-clean
 
+- name: Set up internal registry credentials (deploy from bundles)
+  ansible.builtin.include_tasks: setup_registry_auth.yml
+  when:
+  - __deploy_from_bundles_enabled | bool
+  - setup_bundle_registry_auth | bool
+
 - name: Setup supporting Operator subscriptions
   ansible.builtin.include_tasks: setup_base.yml
   tags:

--- a/build/stf-run-ci/tasks/setup_registry_auth.yml
+++ b/build/stf-run-ci/tasks/setup_registry_auth.yml
@@ -82,12 +82,20 @@
     fail_msg: "Bundle path(s) not set. __smart_gateway_bundle_image_path is '{{ __smart_gateway_bundle_image_path }}' and __service_telemetry_bundle_image_path is '{{ __service_telemetry_bundle_image_path }}'. Both values need to be set."
     success_msg: "Bundle paths are defined, are not None and have a non-zero-length"
 
-- name: Check that we can access to the STO bundle
+- name: Try to access to the STO bundle
   ansible.builtin.command: oc image info {{ __service_telemetry_bundle_image_path }}
   register: sto_bundle_info
-  failed_when: sto_bundle_info.rc != 0
+  ignore_errors: true
 
-- name: Check that we can access to the SGO bundle
+- name: Try to access to the SGO bundle
   ansible.builtin.command: oc image info {{ __smart_gateway_bundle_image_path }}
   register: sgo_bundle_info
-  failed_when: sgo_bundle_info.rc != 0
+  ignore_errors: true
+
+- name: Check successful read access to STO and SGO bundles in the internal registry
+  ansible.builtin.assert:
+    that:
+      - sto_bundle_info.rc != 0
+      - sgo_bundle_info.rc != 0
+    fail_msg: "Bundles couldn't be retrieved. Check configuration for the internal registry and retry."
+    success_msg: "Bundles were correctly retrieved from the internal registry."

--- a/build/stf-run-ci/tasks/setup_registry_auth.yml
+++ b/build/stf-run-ci/tasks/setup_registry_auth.yml
@@ -1,4 +1,4 @@
-- name: Update Pull Secret with internal registry credentials
+- name: Update Pull Secret with bundle registry credentials
   block:
   - name: Get existing Pull Secret from openshift config
     kubernetes.core.k8s_info:
@@ -80,7 +80,7 @@
       - '__smart_gateway_bundle_image_path | default("") | length > 0'
       - '__service_telemetry_bundle_image_path | default("") | length > 0'
     fail_msg: "Bundle path(s) not set. __smart_gateway_bundle_image_path is '{{ __smart_gateway_bundle_image_path }}' and __service_telemetry_bundle_image_path is '{{ __service_telemetry_bundle_image_path }}'. Both values need to be set."
-    success_msg: "Bundle paths are defined, are not None and have a non-zero-length"
+    success_msg: "Bundle paths are defined, are not None and have a non-zero-length."
 
 - name: Try to access to the STO bundle
   ansible.builtin.command: oc image info {{ __service_telemetry_bundle_image_path }}
@@ -97,5 +97,5 @@
     that:
       - sto_bundle_info.rc != 0
       - sgo_bundle_info.rc != 0
-    fail_msg: "Bundles couldn't be retrieved. Check configuration for the internal registry and retry."
-    success_msg: "Bundles were correctly retrieved from the internal registry."
+    fail_msg: "Bundles couldn't be retrieved. Check configuration for the bundles registry and retry."
+    success_msg: "Bundles were correctly retrieved from the registry."

--- a/build/stf-run-ci/tasks/setup_registry_auth.yml
+++ b/build/stf-run-ci/tasks/setup_registry_auth.yml
@@ -1,4 +1,5 @@
 - name: Update Pull Secret with bundle registry credentials
+  when: setup_bundle_registry_auth | bool
   block:
   - name: Get existing Pull Secret from openshift config
     kubernetes.core.k8s_info:
@@ -51,6 +52,7 @@
           .dockerconfigjson: "{{ new_dockerconfigjson | tojson | b64encode }}"
 
 - name: Create registry CA Cert
+  when: setup_bundle_registry_tls_ca | bool
   kubernetes.core.k8s:
     state: present
     definition:
@@ -64,6 +66,7 @@
         cert.pem: "{{ lookup('file', 'CA.pem') | b64encode }}"
 
 - name: Patch the default service account to use our pull secret
+  when: setup_bundle_registry_tls_ca | bool
   kubernetes.core.k8s_json_patch:
     kind: ServiceAccount
     namespace: "{{ namespace }}"

--- a/build/stf-run-ci/tasks/setup_registry_auth.yml
+++ b/build/stf-run-ci/tasks/setup_registry_auth.yml
@@ -1,0 +1,93 @@
+- name: Update Pull Secret with internal registry credentials
+  block:
+  - name: Get existing Pull Secret from openshift config
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: Secret
+      namespace: openshift-config
+      name: pull-secret
+    register: pull_secret
+
+  - name: Decode docker config json
+    ansible.builtin.set_fact:
+      dockerconfigjson: "{{ pull_secret.resources[0].data['.dockerconfigjson'] | b64decode }}"
+
+  - name: Merge registry creds into auth section of docker config
+    ansible.builtin.set_fact:
+      new_dockerauths: "{{ dockerconfigjson['auths'] | combine( {
+        pull_secret_registry:{
+              'auth': (pull_secret_user ~ ':' ~ pull_secret_pass) | b64encode
+            }
+        }) }}"
+
+  - name: Create new docker config
+    ansible.builtin.set_fact:
+      new_dockerconfigjson: "{{ dockerconfigjson | combine({'auths': new_dockerauths}) }}"
+
+  - name: Create Pull Secret for bundle registry access (in the local namespace)
+    kubernetes.core.k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Secret
+        type: kubernetes.io/dockerconfigjson
+        metadata:
+          name: pull-secret
+          namespace: "{{ namespace }}"
+        data:
+          .dockerconfigjson: "{{ new_dockerconfigjson | tojson | b64encode }}"
+
+  - name: Create Pull Secret for bundle registry access (in the global namespace)
+    kubernetes.core.k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Secret
+        type: kubernetes.io/dockerconfigjson
+        metadata:
+          name: pull-secret
+          namespace: openshift-config
+        data:
+          .dockerconfigjson: "{{ new_dockerconfigjson | tojson | b64encode }}"
+
+- name: Create registry CA Cert
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: registry-tls-ca
+        namespace: "{{ namespace }}"
+      data:
+        cert.pem: "{{ lookup('file', 'CA.pem') | b64encode }}"
+
+- name: Patch the default service account to use our pull secret
+  kubernetes.core.k8s_json_patch:
+    kind: ServiceAccount
+    namespace: "{{ namespace }}"
+    name: default
+    patch:
+      - op: add
+        path: /imagePullSecrets
+        value:
+          - name: pull-secret
+
+- name: Ensure that the bundle paths are set
+  ansible.builtin.assert:
+    that:
+      - '__smart_gateway_bundle_image_path | default("") | length > 0'
+      - '__service_telemetry_bundle_image_path | default("") | length > 0'
+    fail_msg: "Bundle path(s) not set. __smart_gateway_bundle_image_path is '{{ __smart_gateway_bundle_image_path }}' and __service_telemetry_bundle_image_path is '{{ __service_telemetry_bundle_image_path }}'. Both values need to be set."
+    success_msg: "Bundle paths are defined, are not None and have a non-zero-length"
+
+- name: Check that we can access to the STO bundle
+  ansible.builtin.command: oc image info {{ __service_telemetry_bundle_image_path }}
+  register: sto_bundle_info
+  failed_when: sto_bundle_info.rc != 0
+
+- name: Check that we can access to the SGO bundle
+  ansible.builtin.command: oc image info {{ __smart_gateway_bundle_image_path }}
+  register: sgo_bundle_info
+  failed_when: sgo_bundle_info.rc != 0

--- a/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
+++ b/build/stf-run-ci/tasks/setup_stf_from_bundles.yml
@@ -1,81 +1,3 @@
-- when: setup_bundle_registry_auth | bool
-  block:
-  - name: Get existing Pull Secret from openshift config
-    kubernetes.core.k8s_info:
-      api_version: v1
-      kind: Secret
-      namespace: openshift-config
-      name: pull-secret
-    register: pull_secret
-
-  - name: Decode docker config json
-    ansible.builtin.set_fact:
-      dockerconfigjson: "{{ pull_secret.resources[0].data['.dockerconfigjson'] | b64decode }}"
-
-  - name: Merge registry creds into auth section of docker config
-    ansible.builtin.set_fact:
-      new_dockerauths: "{{ dockerconfigjson['auths'] | combine( {
-        pull_secret_registry:{
-              'auth': (pull_secret_user ~ ':' ~ pull_secret_pass) | b64encode
-            }
-        }) }}"
-
-  - name: Create new docker config
-    ansible.builtin.set_fact:
-      new_dockerconfigjson: "{{ dockerconfigjson | combine({'auths': new_dockerauths}) }}"
-
-  - name: Create Pull Secret for bundle registry access (in the local namespace)
-    kubernetes.core.k8s:
-      state: present
-      definition:
-        apiVersion: v1
-        kind: Secret
-        type: kubernetes.io/dockerconfigjson
-        metadata:
-          name: pull-secret
-          namespace: "{{ namespace }}"
-        data:
-          .dockerconfigjson: "{{ new_dockerconfigjson | tojson | b64encode }}"
-
-  - name: Create Pull Secret for bundle registry access (in the global namespace)
-    kubernetes.core.k8s:
-      state: present
-      definition:
-        apiVersion: v1
-        kind: Secret
-        type: kubernetes.io/dockerconfigjson
-        metadata:
-          name: pull-secret
-          namespace: openshift-config
-        data:
-          .dockerconfigjson: "{{ new_dockerconfigjson | tojson | b64encode }}"
-
-- when: setup_bundle_registry_tls_ca | bool
-  name: Create registry CA Cert
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      type: Opaque
-      metadata:
-        name: registry-tls-ca
-        namespace: "{{ namespace }}"
-      data:
-        cert.pem: "{{ lookup('file', 'CA.pem') | b64encode }}"
-
-- when: setup_bundle_registry_tls_ca | bool
-  name: Patch the default service account to use our pull secret
-  kubernetes.core.k8s_json_patch:
-    kind: ServiceAccount
-    namespace: "{{ namespace }}"
-    name: default
-    patch:
-      - op: add
-        path: /imagePullSecrets
-        value:
-          - name: pull-secret
-
   # When the task is skipped, pull_secret is still defined. It is set to the task output i.e.
   # "pull_secret": {
   #    "changed": false,
@@ -86,14 +8,6 @@
   when: not (setup_bundle_registry_auth | bool)
   ansible.builtin.set_fact:
     pull_secret: ''
-
-- name: "Ensure that the bundle paths are set."
-  ansible.builtin.assert:
-    that:
-      - '__smart_gateway_bundle_image_path | default("") | length > 0'
-      - '__service_telemetry_bundle_image_path | default("") | length > 0'
-    fail_msg: "Bundle path(s) not set. __smart_gateway_bundle_image_path is '{{ __smart_gateway_bundle_image_path }}' and __service_telemetry_bundle_image_path is '{{ __service_telemetry_bundle_image_path }}'. Both values need to be set."
-    success_msg: "Bundle paths are defined, are not None and have a non-zero-length"
 
 - name: Deploy SGO via OLM bundle
   ansible.builtin.shell:


### PR DESCRIPTION
Move the credential setup for the internal registry up in the execution and perform a simple check with the "oc image info" command to fail earlier in case the credentials haven't been set properly

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1403