### PR TITLE
Set a default image for ElasticSearch to use

### DIFF
--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -37,7 +37,7 @@ default_operator_registry_image_base: registry.redhat.io/openshift4/ose-operator
 default_operator_registry_image_tag: v4.13
 
 elasticsearch_version: 7.17.20
-elasticsearch_image: "registry.redhat.io/elastic/elasticsearch:7.17.20"
+elasticsearch_image: registry.connect.redhat.com/elastic/elasticsearch
 
 sgo_image_tag: latest
 sto_image_tag: latest

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -36,7 +36,8 @@ __smart_gateway_bundle_image_path: "quay.io/infrawatch-operators/smart-gateway-o
 default_operator_registry_image_base: registry.redhat.io/openshift4/ose-operator-registry
 default_operator_registry_image_tag: v4.13
 
-elasticsearch_version: 7.16.1
+elasticsearch_version: 7.17.20
+elasticsearch_image: "registry.redhat.io/elastic/elasticsearch:7.17.20"
 
 sgo_image_tag: latest
 sto_image_tag: latest

--- a/build/stf-run-ci/templates/manifest_elasticsearch.j2
+++ b/build/stf-run-ci/templates/manifest_elasticsearch.j2
@@ -50,4 +50,4 @@ spec:
   updateStrategy:
     changeBudget: {}
   version: {{ elasticsearch_version }}
-  image: {{ elasticsearch_image }}
+  image: {{ elasticsearch_image }}:{{ elasticsearch_version }}

--- a/build/stf-run-ci/templates/manifest_elasticsearch.j2
+++ b/build/stf-run-ci/templates/manifest_elasticsearch.j2
@@ -50,3 +50,4 @@ spec:
   updateStrategy:
     changeBudget: {}
   version: {{ elasticsearch_version }}
+  image: {{ elasticsearch_image }}


### PR DESCRIPTION
Currently we are not selecting the image for ElasticSearch that the ElasticSearch Operator pulls, we are allowing the default (in ElasticSearch registry) to be used

Add the option to select the ElasticSearch image to use

Also bumps the version to ElasticSearch 7.17.20, since 7.16.1 has several vulnerabilities