### PR TITLE
Enable QDR port 5671 to listen on both IPv4 and IPv6

### DIFF
--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -227,7 +227,7 @@
             prefix: ceilometer
         edgeListeners:
           - expose: true
-            host: 0.0.0.0
+            host: ''
             port: 5671
       {% if servicetelemetry_vars.transports.qdr.auth == "basic" %}
             saslMechanisms: PLAIN

--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -227,7 +227,6 @@
             prefix: ceilometer
         edgeListeners:
           - expose: true
-            host: ''
             port: 5671
       {% if servicetelemetry_vars.transports.qdr.auth == "basic" %}
             saslMechanisms: PLAIN


### PR DESCRIPTION
### Summary
This PR updates the Qpid Dispatch Router (QDR) configuration to allow port 5671 to listen on all local addresses, both IPv4 and IPv6. Previously, the port was configured to listen only on IPv4 addresses. With this change, QDR can now support single stack IPv6 clusters as well as dual stack configurations.

### Changes
- Modified the Ansible task in `component_qdr.yml` to configure QDR to listen on all interfaces (both IPv4 and IPv6) on port 5671.
- Updated the listener configuration to use host: '', which is the standard way to specify all interfaces for both IPv4 and IPv6.

### Testing
- **Dual Stack OCP 4.12.6:** Verified that QDR is listening on both IPv4 and IPv6 addresses on port 5671.
- **Single Stack IPv6 OCP 4.14.0:** Confirmed that QDR is correctly listening on IPv6 addresses.
- Connected OpenStack clusters to ensure proper connectivity and functionality.

### Motivation and Context
This change is necessary to ensure compatibility with IPv6-only Kubernetes clusters, which are becoming more common as organizations prepare for the future of networking. Supporting both IPv4 and IPv6 ensures broader compatibility and future-proofs the service telemetry operator.

### Related Issues
- None

![image](https://github.com/infrawatch/service-telemetry-operator/assets/63336082/a5100364-670c-44a1-a499-7cb2f9ffcbc3)