### PR TITLE
[zuul] Remove OCP 4.13 jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -8,14 +8,6 @@
         label: coreos-crc-extracted-2-19-0-xxl
 
 - nodeset:
-    name: stf-crc_extracted-ocp413
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost
-      - name: crc
-        label: coreos-crc-extracted-2-28-0-xxl
-
-- nodeset:
     name: stf-crc_extracted-ocp414
     nodes:
       - name: controller
@@ -137,13 +129,6 @@
     nodeset: stf-crc_extracted-ocp412
 
 - job:
-    name: stf-crc-ocp_413-nightly_bundles
-    parent: stf-crc-nightly_bundles
-    description: |
-      Deploy STF using the nightly bundles on OCP 4.13
-    nodeset: stf-crc_extracted-ocp413
-
-- job:
     name: stf-crc-ocp_414-nightly_bundles
     parent: stf-crc-nightly_bundles
     description: |
@@ -156,13 +141,6 @@
     description: |
       Build images locally and deploy STF on OCP 4.12
     nodeset: stf-crc_extracted-ocp412
-
-- job:
-    name: stf-crc-ocp_413-local_build
-    parent: stf-crc-local_build
-    description: |
-      Build images locally and deploy STF on OCP 4.13
-    nodeset: stf-crc_extracted-ocp413
 
 - job:
     name: stf-crc-ocp_414-local_build
@@ -179,13 +157,6 @@
     nodeset: stf-crc_extracted-ocp412
 
 - job:
-    name: stf-crc-ocp_413-local_build-index_deploy
-    parent: stf-crc-local_build-index_deploy
-    description: |
-      Build STF locally and deploy from index on OCP 4.13
-    nodeset: stf-crc_extracted-ocp413
-
-- job:
     name: stf-crc-ocp_414-local_build-index_deploy
     parent: stf-crc-local_build-index_deploy
     description: |
@@ -199,10 +170,8 @@
     github-check:
       jobs:
         - stf-crc-ocp_412-local_build
-        - stf-crc-ocp_413-local_build
         - stf-crc-ocp_414-local_build
         - stf-crc-ocp_412-local_build-index_deploy
-        - stf-crc-ocp_413-local_build-index_deploy
         - stf-crc-ocp_414-local_build-index_deploy
 
 - project:
@@ -212,5 +181,4 @@
     periodic:
       jobs:
         - stf-crc-ocp_412-nightly_bundles
-        - stf-crc-ocp_413-nightly_bundles
         - stf-crc-ocp_414-nightly_bundles


### PR DESCRIPTION
OCP 4.13 jobs were added as a way to test ocp-latest before 4.14 was released

Backport of: https://github.com/infrawatch/service-telemetry-operator/pull/587