### PR TITLE
Lower ElasticSearch memory requirements

### DIFF
--- a/build/stf-run-ci/templates/manifest_elasticsearch.j2
+++ b/build/stf-run-ci/templates/manifest_elasticsearch.j2
@@ -33,10 +33,10 @@ spec:
           resources:
             limits:
               cpu: "2"
-              memory: 4Gi
+              memory: 2Gi
             requests:
               cpu: "1"
-              memory: 4Gi
+              memory: 2Gi
         volumes:
         - emptyDir: {}
           name: elasticsearch-data


### PR DESCRIPTION
Lower ES memory reqs so we don't exhaust resources in CI environments.

This is reproducible in OCP 4.12 jobs.