### PR TITLE
Fully disable qdr web by default

### DIFF
--- a/roles/servicetelemetry/tasks/component_qdr.yml
+++ b/roles/servicetelemetry/tasks/component_qdr.yml
@@ -246,9 +246,11 @@
         listeners:
           - port: 5672
             host: 127.0.0.1
-          - expose: {{ servicetelemetry_vars.transports.qdr.web.enabled }}
+      {% if servicetelemetry_vars.transports.qdr.web.enabled == "true" %}
+          - expose: true
             http: true
             port: 8672
+      {% endif %}
         sslProfiles:
           - caCert: {{ ansible_operator_meta.name }}-interconnect-openstack-ca
             credentials: {{ ansible_operator_meta.name }}-interconnect-openstack-credentials


### PR DESCRIPTION
The default config has the http management port listening even when it seemed to be "disabled" (option only affected the route).

We want it truly disabled by default since it doesn't have any oauth-proxy protection.