### PR TITLE
Testing 2032

### DIFF
--- a/ci/common-tasks.yml
+++ b/ci/common-tasks.yml
@@ -1,4 +1,5 @@
 ---
+# foo
 - name: "Set the sto_dir if it isn't already set"
   ansible.builtin.set_fact:
     sto_dir: '{{ ansible_env.HOME }}/{{ zuul.projects["github.com/infrawatch/service-telemetry-operator"].src_dir }}'


### PR DESCRIPTION
Dumb patch to test a CRC bootstrap change.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2032
