### PR TITLE
Fix oauth SARs for interactive login

### DIFF
--- a/roles/servicetelemetry/tasks/component_prometheus_reader.yml
+++ b/roles/servicetelemetry/tasks/component_prometheus_reader.yml
@@ -21,7 +21,7 @@
       - apiGroups:
         - '{{ prometheus_operator_api_string | replace("/v1","") }}'
         resources:
-        - prometheus
+        - prometheuses
         verbs:
         - get
         namespaces:

--- a/roles/servicetelemetry/templates/manifest_alertmanager.j2
+++ b/roles/servicetelemetry/templates/manifest_alertmanager.j2
@@ -29,7 +29,7 @@ spec:
     - -upstream=http://localhost:9093/
     - -cookie-secret-file=/etc/proxy/secrets/session_secret
     - -openshift-service-account=alertmanager-stf
-    - '-openshift-sar={"namespace":"{{ ansible_operator_meta.namespace }}", "resource": "alertmanagers", "group":"{{ prometheus_operator_api_string | replace("/v1","") }}", "verb":"get"}'
+    - '-openshift-sar={"namespace":"{{ ansible_operator_meta.namespace }}", "resource": "alertmanagers", "resourceAPIGroup":"{{ prometheus_operator_api_string | replace("/v1","") }}", "verb":"get"}'
     - '-openshift-delegate-urls={"/": {"namespace":"{{ ansible_operator_meta.namespace }}", "resource": "alertmanagers", "group":"{{ prometheus_operator_api_string | replace("/v1","") }}", "verb":"get"}}'
     ports:
       - containerPort: 9095

--- a/roles/servicetelemetry/templates/manifest_grafana.j2
+++ b/roles/servicetelemetry/templates/manifest_grafana.j2
@@ -42,7 +42,7 @@ spec:
     - -upstream=http://localhost:3000
     - -cookie-secret-file=/etc/proxy/secrets/session_secret
     - -openshift-service-account=grafana-serviceaccount
-    - '-openshift-sar={"namespace":"{{ ansible_operator_meta.namespace }}","resource": "grafana", "group":"integreatly.org", "verb":"get"}'
+    - '-openshift-sar={"namespace":"{{ ansible_operator_meta.namespace }}","resource": "grafanas", "resourceAPIGroup":"integreatly.org", "verb":"get"}'
     - -openshift-ca=/etc/pki/tls/cert.pem
     - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     ports:

--- a/roles/servicetelemetry/templates/manifest_grafana_v5.j2
+++ b/roles/servicetelemetry/templates/manifest_grafana_v5.j2
@@ -61,7 +61,7 @@ spec:
             - '-https-address=:3002'
             - '-http-address='
             - '-email-domain=*'
-            - '-openshift-sar={"namespace":"{{ ansible_operator_meta.namespace }}","resource": "grafana", "group":"grafana.integreatly.org", "verb":"get"}'
+            - '-openshift-sar={"namespace":"{{ ansible_operator_meta.namespace }}","resource": "grafanas", "resourceAPIGroup":"grafana.integreatly.org", "verb":"get"}'
             - '-upstream=http://localhost:3000'
             - '-tls-cert=/etc/tls/private/tls.crt'
             - '-tls-key=/etc/tls/private/tls.key'

--- a/roles/servicetelemetry/templates/manifest_prometheus.j2
+++ b/roles/servicetelemetry/templates/manifest_prometheus.j2
@@ -48,8 +48,8 @@ spec:
     - -upstream=http://localhost:9090/
     - -cookie-secret-file=/etc/proxy/secrets/session_secret
     - -openshift-service-account=prometheus-stf
-    - '-openshift-sar={"namespace":"{{ ansible_operator_meta.namespace }}","resource": "prometheus", "group":"{{ prometheus_operator_api_string | replace("/v1","") }}", "verb":"get"}'
-    - '-openshift-delegate-urls={"/":{"namespace":"{{ ansible_operator_meta.namespace }}","resource": "prometheus", "group":"{{ prometheus_operator_api_string | replace("/v1","") }}", "verb":"get"}}'
+    - '-openshift-sar={"namespace":"{{ ansible_operator_meta.namespace }}","resource": "prometheuses", "resourceAPIGroup":"{{ prometheus_operator_api_string | replace("/v1","") }}", "verb":"get"}'
+    - '-openshift-delegate-urls={"/":{"namespace":"{{ ansible_operator_meta.namespace }}","resource": "prometheuses", "group":"{{ prometheus_operator_api_string | replace("/v1","") }}", "verb":"get"}}'
 
     ports:
       - containerPort: 9092


### PR DESCRIPTION
- Doesn't work unless resource name is plural form
- The "group" property is called "resourceAPIGroup" in SAR
  - "to avoid confusion with the 'groups' field when inlined"[1]

[1] https://docs.openshift.com/container-platform/4.14/rest_api/authorization_apis/subjectaccessreview-authorization-openshift-io-v1.html