### PR TITLE
Update nodesets label in stable-1.5

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,7 +3,7 @@
     name: stf-crc_extracted-ocp412
     nodes:
       - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost
+        label: cloud-centos-9-stream-tripleo
       - name: crc
         label: coreos-crc-extracted-2-19-0-xxl
 
@@ -11,7 +11,7 @@
     name: stf-crc_extracted-ocp414
     nodes:
       - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost
+        label: cloud-centos-9-stream-tripleo
       - name: crc
         label: coreos-crc-extracted-2-30-0-xxl
 


### PR DESCRIPTION
The CI jobs does not need to be force use one cloud provider in the CI. This commit set the label that is defined in multiple cloud provider in Zuul. Available labels you can find [1].

[1] https://review.rdoproject.org/zuul/labels