### PR TITLE
Drop OCP 4.12 from openshift.versions annotation

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
+++ b/deploy/olm-catalog/service-telemetry-operator/Dockerfile.in
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.12-v4.16"
+LABEL com.redhat.openshift.versions="v4.14-v4.16"
 LABEL com.redhat.delivery.backport=false
 
 LABEL com.redhat.component="service-telemetry-operator-bundle-container" \


### PR DESCRIPTION
OCP 4.12 maintenance support has finished, so we should remove OCP 4.12 from the supported versions