### PR TITLE
Set insecure flag for ose-operator-registry image

### DIFF
--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -129,7 +129,7 @@
 - name: Create ImageStream for ose-operator-registry, if it doesn't already exist
   ansible.builtin.command:
     cmd: |
-      oc import-image -n {{ namespace }} ose-operator-registry:{{ default_operator_registry_image_tag }} --from={{ operator_registry_image }} --confirm
+      oc import-image -n {{ namespace }} ose-operator-registry:{{ default_operator_registry_image_tag }} --from={{ operator_registry_image }} --confirm --insecure
   when: ose_op_registry_is.rc != 0
   register: create_ose_is
 


### PR DESCRIPTION
--insecure allow push and pull operations to registries to be made over HTTP

This change is required to get the required ose-operator-registry image from a testing registry