### PR TITLE
Backport "Set insecure flag for ose-operator-registry image" to stable-1.5

### DIFF
--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -129,7 +129,7 @@
 - name: Create ImageStream for ose-operator-registry, if it doesn't already exist
   ansible.builtin.command:
     cmd: |
-      oc import-image -n {{ namespace }} ose-operator-registry:{{ default_operator_registry_image_tag }} --from={{ operator_registry_image }} --confirm
+      oc import-image -n {{ namespace }} ose-operator-registry:{{ default_operator_registry_image_tag }} --from={{ operator_registry_image }} --confirm --insecure
   when: ose_op_registry_is.rc != 0
   register: create_ose_is
 


### PR DESCRIPTION
Backport of !637

Downstream CVP uses the stable-1.5 branch and breaks without this.

(cherry picked from commit e9314cf6ec23c949955fbd7043dd6b7829a06707)