### PR TITLE
Backport "Get tag from the name instead of the metadata" to stable-1.5

### DIFF
--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -24,10 +24,15 @@
       ansible.builtin.command: oc image info {{ __smart_gateway_bundle_image_path }}
       register: sgo_prebuilt_image_info
 
-    - name: Get STO and SGO bundle versions
+    - name: Get STO and SGO bundle versions (from metadata)
       ansible.builtin.set_fact:
         sto_prebuilt_bundle_version: "{{ sto_prebuilt_image_info.stdout_lines[-1] | split('=') | last }}"
         sgo_prebuilt_bundle_version: "{{ sgo_prebuilt_image_info.stdout_lines[-1] | split('=') | last }}"
+
+    - name: Get STO and SGO bundle tags (from name)
+      ansible.builtin.set_fact:
+        sto_prebuilt_bundle_tag: "{{ __service_telemetry_bundle_image_path | split(':') | last }}"
+        sgo_prebuilt_bundle_tag: "{{ __smart_gateway_bundle_image_path | split(':') | last }}"
 
     - name: Set info variables from provided pre-built bundles
       ansible.builtin.set_fact:
@@ -35,10 +40,12 @@
           'bundle_default_channel': "{{ stf_channel }}"
           'bundle_channels': "{{ stf_channel }}"
           'operator_bundle_version': "{{ sto_prebuilt_bundle_version }}"
+          'operator_bundle_tag': "{{ sto_prebuilt_bundle_tag }}"
         sgo_bundle_info:
           'bundle_default_channel': "{{ stf_channel }}"
           'bundle_channels': "{{ stf_channel }}"
           'operator_bundle_version': "{{ sgo_prebuilt_bundle_version }}"
+          'operator_bundle_tag': "{{ sgo_prebuilt_bundle_tag }}"
 
 - name: Show STO and SGO bundle info that will used in the index image
   ansible.builtin.debug:
@@ -52,19 +59,19 @@
     - name: Create ImageStream for STO
       ansible.builtin.command:
         cmd: |
-          oc import-image -n {{ namespace }} service-telemetry-operator-bundle:{{ sto_bundle_info.operator_bundle_version }} --from={{ __service_telemetry_bundle_image_path }} --confirm --insecure
+          oc import-image -n {{ namespace }} service-telemetry-operator-bundle:{{ sto_bundle_info.operator_bundle_tag }} --from={{ __service_telemetry_bundle_image_path }} --confirm --insecure
       register: sto_is
 
     - name: Create ImageStream for SGO
       ansible.builtin.command:
         cmd: |
-          oc import-image -n {{ namespace }} smart-gateway-operator-bundle:{{ sgo_bundle_info.operator_bundle_version }} --from={{ __smart_gateway_bundle_image_path }} --confirm --insecure
+          oc import-image -n {{ namespace }} smart-gateway-operator-bundle:{{ sgo_bundle_info.operator_bundle_tag }} --from={{ __smart_gateway_bundle_image_path }} --confirm --insecure
       register: sgo_is
 
     - name: Set correct STO and SGO bundle paths when deploying from index with pre-built bundles
       ansible.builtin.set_fact:
-        sto_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-operator-bundle:{{ sto_bundle_info.operator_bundle_version }}"
-        sgo_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/smart-gateway-operator-bundle:{{ sgo_bundle_info.operator_bundle_version }}"
+        sto_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-operator-bundle:{{ sto_bundle_info.operator_bundle_tag }}"
+        sgo_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/smart-gateway-operator-bundle:{{ sgo_bundle_info.operator_bundle_tag }}"
 
 - name: Get the builder-dockercfg Secret name
   ansible.builtin.command: oc get secret -n {{ namespace }} --field-selector='type==kubernetes.io/dockercfg' -ojsonpath='{.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="builder")].metadata.name}'

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -15,10 +15,14 @@
     sg_bridge_image_path: "{{ __internal_registry_path }}/{{ namespace }}/sg-bridge:{{ sg_bridge_image_tag }}"
     prometheus_webhook_snmp_image_path: "{{ __internal_registry_path }}/{{ namespace }}/prometheus-webhook-snmp:{{ prometheus_webhook_snmp_image_tag }}"
 
-- name: Set default image paths for bundle and index builds
+- name: Set default image paths for bundle builds
+  when: __local_build_enabled | bool
   ansible.builtin.set_fact:
     sgo_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/smart-gateway-operator-bundle:{{ sgo_bundle_image_tag }}"
     sto_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-operator-bundle:{{ sto_bundle_image_tag }}"
+
+- name: Set default image paths for index builds
+  ansible.builtin.set_fact:
     stf_index_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-framework-index:{{ stf_index_image_tag }}"
 
 - name: Fail on mutually exclusive flags


### PR DESCRIPTION
Backport of https://github.com/infrawatch/service-telemetry-operator/pull/640

Downstream CVP uses the stable-1.5 branch and breaks without this.

(cherry picked from commit 804b49ecaae48ef5167ae7889d2c159322fe1cdd)