### PR TITLE
Backport "stf-run-ci: get operator info from CSV instead of image metadata"

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-ansible-operator:4.14
+FROM quay.io/operator-framework/ansible-operator:v1.35.0
 
 # temporarily switch to root user to adjust image layers
 USER 0
@@ -11,6 +11,10 @@ RUN bash -c -- 'if [ "${NO_PROXY:-__ZZZZZ}" == "__ZZZZZ" ]; then echo "Applying 
 # -- installs python3-passlib and python3-bcrypt for oauth-proxy interface
 # -- cleans up the cached data from dnf to keep the image as small as possible
 RUN dnf update -y --exclude=ansible* && dnf install -y python3-passlib python3-bcrypt && dnf clean all && rm -rf /var/cache/dnf
+
+COPY requirements.yml ${HOME}/requirements.yml
+RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
+ && chmod -R ug+rwx ${HOME}/.ansible
 
 # switch back to user 1001 when running the base image (non-root)
 USER 1001

--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -129,7 +129,7 @@
 - name: Create ImageStream for ose-operator-registry, if it doesn't already exist
   ansible.builtin.command:
     cmd: |
-      oc import-image -n {{ namespace }} ose-operator-registry:{{ default_operator_registry_image_tag }} --from={{ operator_registry_image }} --confirm
+      oc import-image -n {{ namespace }} ose-operator-registry:{{ default_operator_registry_image_tag }} --from={{ operator_registry_image }} --confirm --insecure
   when: ose_op_registry_is.rc != 0
   register: create_ose_is
 

--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -13,23 +13,62 @@
     sto_bundle_info: "{{ generate_bundle_sto.stdout_lines[-1] | from_json }}"
     sgo_bundle_info: "{{ generate_bundle_sgo.stdout_lines[-1] | from_json }}"
 
+- name: Generate default package names (local build)
+  when: __local_build_enabled | bool and not __deploy_from_bundles_enabled | bool
+  ansible.builtin.set_fact:
+    sto_bundle_info: "{{ sto_bundle_info | combine({'package_name':'service-telemetry-operator.v%s'|format(sto_bundle_info.operator_bundle_version)}) }}"
+    sgo_bundle_info: "{{ sgo_bundle_info | combine({'package_name':'smart-gateway-operator.v%s'|format(sgo_bundle_info.operator_bundle_version)}) }}"
+
 - name: Create info variables from provided pre-built bundles (deploy from bundles)
   when: __deploy_from_bundles_enabled | bool and not __local_build_enabled | bool
   block:
-    - name: Get STO operator bundle info
-      ansible.builtin.command: oc image info {{ __service_telemetry_bundle_image_path }}
-      register: sto_prebuilt_image_info
+    - name: Get STO operator bundle CSV file
+      ansible.builtin.command: oc image extract {{ __service_telemetry_bundle_image_path }} --file /manifests/*clusterserviceversion.yaml
+      args:
+        chdir: "{{ base_dir }}/working/service-telemetry-framework-index/"
 
-    - name: Get SGO operator bundle info
-      ansible.builtin.command: oc image info {{ __smart_gateway_bundle_image_path }}
-      register: sgo_prebuilt_image_info
+    - name: Get SGO operator bundle CSV file
+      ansible.builtin.command: oc image extract {{ __smart_gateway_bundle_image_path }}  --file /manifests/*clusterserviceversion.yaml
+      args:
+        chdir: "{{ base_dir }}/working/service-telemetry-framework-index/"
 
-    - name: Get STO and SGO bundle versions (from metadata)
+    - name: Set the csv_dest based on whether zuul is used or not
       ansible.builtin.set_fact:
-        sto_prebuilt_bundle_version: "{{ sto_prebuilt_image_info.stdout_lines[-1] | split('=') | last }}"
-        sgo_prebuilt_bundle_version: "{{ sgo_prebuilt_image_info.stdout_lines[-1] | split('=') | last }}"
+        csv_dest: "{{ zuul.executor.work_root if zuul is defined else base_dir + '/working/service-telemetry-framework-index/' }}"
 
-    - name: Get STO and SGO bundle tags (from name)
+    - name: "Put the CSV files onto the ansible controller, so we can include_vars"
+      ansible.builtin.fetch:
+        src: "{{ base_dir }}/working/service-telemetry-framework-index/service-telemetry-operator.clusterserviceversion.yaml"
+        dest: "{{ csv_dest }}/"
+        flat: yes
+
+    - name: "Put the CSV files onto the ansible controller, so we can include_vars"
+      ansible.builtin.fetch:
+         src: "{{ base_dir }}/working/service-telemetry-framework-index/smart-gateway-operator.clusterserviceversion.yaml"
+         dest: "{{ csv_dest }}/"
+         flat: yes
+
+    - name: Read STO bundle CSV file contents
+      ansible.builtin.include_vars:
+        file: "{{ csv_dest }}/service-telemetry-operator.clusterserviceversion.yaml"
+        name: sto_prebuilt_bundle_csv
+
+    - name: Read SGO bundle CSV file contents
+      ansible.builtin.include_vars:
+        file: "{{ csv_dest }}/smart-gateway-operator.clusterserviceversion.yaml"
+        name: sgo_prebuilt_bundle_csv
+
+    - name: Get STO and SGO bundle package names (from CSV)
+      ansible.builtin.set_fact:
+        sto_prebuilt_bundle_package_name: "{{ sto_prebuilt_bundle_csv.metadata.name }}"
+        sgo_prebuilt_bundle_package_name: "{{ sgo_prebuilt_bundle_csv.metadata.name }}"
+
+    - name: Get STO and SGO bundle versions (from CSV)
+      ansible.builtin.set_fact:
+        sto_prebuilt_bundle_version: "{{ sto_prebuilt_bundle_csv.spec.version }}"
+        sgo_prebuilt_bundle_version: "{{ sgo_prebuilt_bundle_csv.spec.version }}"
+
+    - name: Get STO and SGO bundle image tags (from name)
       ansible.builtin.set_fact:
         sto_prebuilt_bundle_tag: "{{ __service_telemetry_bundle_image_path | split(':') | last }}"
         sgo_prebuilt_bundle_tag: "{{ __smart_gateway_bundle_image_path | split(':') | last }}"
@@ -37,11 +76,13 @@
     - name: Set info variables from provided pre-built bundles
       ansible.builtin.set_fact:
         sto_bundle_info:
+          'package_name': "{{ sto_prebuilt_bundle_package_name }}"
           'bundle_default_channel': "{{ stf_channel }}"
           'bundle_channels': "{{ stf_channel }}"
           'operator_bundle_version': "{{ sto_prebuilt_bundle_version }}"
           'operator_bundle_tag': "{{ sto_prebuilt_bundle_tag }}"
         sgo_bundle_info:
+          'package_name': "{{ sgo_prebuilt_bundle_package_name }}"
           'bundle_default_channel': "{{ stf_channel }}"
           'bundle_channels': "{{ stf_channel }}"
           'operator_bundle_version': "{{ sgo_prebuilt_bundle_version }}"

--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -24,10 +24,15 @@
       ansible.builtin.command: oc image info {{ __smart_gateway_bundle_image_path }}
       register: sgo_prebuilt_image_info
 
-    - name: Get STO and SGO bundle versions
+    - name: Get STO and SGO bundle versions (from metadata)
       ansible.builtin.set_fact:
         sto_prebuilt_bundle_version: "{{ sto_prebuilt_image_info.stdout_lines[-1] | split('=') | last }}"
         sgo_prebuilt_bundle_version: "{{ sgo_prebuilt_image_info.stdout_lines[-1] | split('=') | last }}"
+
+    - name: Get STO and SGO bundle tags (from name)
+      ansible.builtin.set_fact:
+        sto_prebuilt_bundle_tag: "{{ __service_telemetry_bundle_image_path | split(':') | last }}"
+        sgo_prebuilt_bundle_tag: "{{ __smart_gateway_bundle_image_path | split(':') | last }}"
 
     - name: Set info variables from provided pre-built bundles
       ansible.builtin.set_fact:
@@ -35,10 +40,12 @@
           'bundle_default_channel': "{{ stf_channel }}"
           'bundle_channels': "{{ stf_channel }}"
           'operator_bundle_version': "{{ sto_prebuilt_bundle_version }}"
+          'operator_bundle_tag': "{{ sto_prebuilt_bundle_tag }}"
         sgo_bundle_info:
           'bundle_default_channel': "{{ stf_channel }}"
           'bundle_channels': "{{ stf_channel }}"
           'operator_bundle_version': "{{ sgo_prebuilt_bundle_version }}"
+          'operator_bundle_tag': "{{ sgo_prebuilt_bundle_tag }}"
 
 - name: Show STO and SGO bundle info that will used in the index image
   ansible.builtin.debug:
@@ -52,19 +59,19 @@
     - name: Create ImageStream for STO
       ansible.builtin.command:
         cmd: |
-          oc import-image -n {{ namespace }} service-telemetry-operator-bundle:{{ sto_bundle_info.operator_bundle_version }} --from={{ __service_telemetry_bundle_image_path }} --confirm --insecure
+          oc import-image -n {{ namespace }} service-telemetry-operator-bundle:{{ sto_bundle_info.operator_bundle_tag }} --from={{ __service_telemetry_bundle_image_path }} --confirm --insecure
       register: sto_is
 
     - name: Create ImageStream for SGO
       ansible.builtin.command:
         cmd: |
-          oc import-image -n {{ namespace }} smart-gateway-operator-bundle:{{ sgo_bundle_info.operator_bundle_version }} --from={{ __smart_gateway_bundle_image_path }} --confirm --insecure
+          oc import-image -n {{ namespace }} smart-gateway-operator-bundle:{{ sgo_bundle_info.operator_bundle_tag }} --from={{ __smart_gateway_bundle_image_path }} --confirm --insecure
       register: sgo_is
 
     - name: Set correct STO and SGO bundle paths when deploying from index with pre-built bundles
       ansible.builtin.set_fact:
-        sto_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-operator-bundle:{{ sto_bundle_info.operator_bundle_version }}"
-        sgo_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/smart-gateway-operator-bundle:{{ sgo_bundle_info.operator_bundle_version }}"
+        sto_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-operator-bundle:{{ sto_bundle_info.operator_bundle_tag }}"
+        sgo_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/smart-gateway-operator-bundle:{{ sgo_bundle_info.operator_bundle_tag }}"
 
 - name: Get the builder-dockercfg Secret name
   ansible.builtin.command: oc get secret -n {{ namespace }} --field-selector='type==kubernetes.io/dockercfg' -ojsonpath='{.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="builder")].metadata.name}'

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -15,10 +15,14 @@
     sg_bridge_image_path: "{{ __internal_registry_path }}/{{ namespace }}/sg-bridge:{{ sg_bridge_image_tag }}"
     prometheus_webhook_snmp_image_path: "{{ __internal_registry_path }}/{{ namespace }}/prometheus-webhook-snmp:{{ prometheus_webhook_snmp_image_tag }}"
 
-- name: Set default image paths for bundle and index builds
+- name: Set default image paths for bundle builds
+  when: __local_build_enabled | bool
   ansible.builtin.set_fact:
     sgo_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/smart-gateway-operator-bundle:{{ sgo_bundle_image_tag }}"
     sto_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-operator-bundle:{{ sto_bundle_image_tag }}"
+
+- name: Set default image paths for index builds
+  ansible.builtin.set_fact:
     stf_index_image_path: "{{ __internal_registry_path }}/{{ namespace }}/service-telemetry-framework-index:{{ stf_index_image_tag }}"
 
 - name: Fail on mutually exclusive flags

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -28,11 +28,6 @@
     - __local_build_enabled | bool
     - __deploy_from_bundles_enabled | bool
 
-- name: Get the list of nodes
-  kubernetes.core.k8s_info:
-    kind: Node
-  register: node_info
-
 # -- prepare environment and cleanup
 - name: Clean up any existing global artifacts
   ansible.builtin.include_tasks: pre-clean.yml

--- a/build/stf-run-ci/tasks/setup_stf_local_build.yml
+++ b/build/stf-run-ci/tasks/setup_stf_local_build.yml
@@ -17,6 +17,8 @@
         RELATED_IMAGE_BRIDGE_SMARTGATEWAY_TAG={{ sg_bridge_image_path | parse_tag | quote }} \
         OPERATOR_IMAGE={{ sgo_image_path | parse_image | quote }} \
         OPERATOR_TAG={{ sgo_image_path | parse_tag | quote }} \
+        BUNDLE_CHANNELS={{ stf_channel }} \
+        BUNDLE_DEFAULT_CHANNEL={{ stf_channel }} \
         ./generate_bundle.sh
     register: generate_bundle_sgo
   rescue:
@@ -67,6 +69,8 @@
         RELATED_IMAGE_PROMETHEUS_WEBHOOK_SNMP_TAG={{ prometheus_webhook_snmp_image_path | parse_tag | quote }} \
         OPERATOR_IMAGE={{ sto_image_path | parse_image | quote }} \
         OPERATOR_TAG={{ sto_image_path | parse_tag | quote }} \
+        BUNDLE_CHANNELS={{ stf_channel }} \
+        BUNDLE_DEFAULT_CHANNEL={{ stf_channel }} \
         ./generate_bundle.sh
     register: generate_bundle_sto
   rescue:

--- a/build/stf-run-ci/templates/index-yaml.j2
+++ b/build/stf-run-ci/templates/index-yaml.j2
@@ -7,7 +7,7 @@ schema: olm.channel
 package: service-telemetry-operator
 name: {{ sto_bundle_info.bundle_channels }}
 entries:
-  - name: service-telemetry-operator.v{{ sto_bundle_info.operator_bundle_version }}
+  - name: {{ sto_bundle_info.package_name }}
 ---
 defaultChannel: {{ sgo_bundle_info.bundle_default_channel }}
 name: smart-gateway-operator
@@ -17,4 +17,4 @@ schema: olm.channel
 package: smart-gateway-operator
 name: {{ sgo_bundle_info.bundle_channels }}
 entries:
-  - name: smart-gateway-operator.v{{ sgo_bundle_info.operator_bundle_version }}
+  - name: {{ sgo_bundle_info.package_name }}

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,41 @@
+# NOTE(vkmc) Great docs from https://github.com/jmazzitelli/kiali-operator/blob/master/requirements.yml
+#
+# This is the Ansible Galaxy requirements that need to be installed locally to be able to run
+# the operator Ansible playbook locally.
+#
+# To install these into your local Ansible environment:
+#   ansible-galaxy collection install -r requirements.yml --force-with-deps
+#
+# Make sure these collections match that which is inside the Ansible Operator SDK base image.
+# You can determine what collections are installed by looking in the base image like this:
+#
+# podman run \
+#   -it --rm --entrypoint '' \
+#   quay.io/openshift/origin-ansible-operator:4.13 \
+#   ls /opt/ansible/.ansible/collections/ansible_collections
+#
+# To determine the version of a specific collection, look at the MANIFEST.json:
+#
+# podman run \
+#   -it --rm --entrypoint '' \
+#   quay.io/openshift/origin-ansible-operator:4.13 \
+#   cat /opt/ansible/.ansible/collections/ansible_collections/kubernetes/core/MANIFEST.json | grep version
+#
+# It is best if you have the same version of Ansible installed locally as found in the base image. You can determine
+# the version of Ansible in the base image via:
+#
+# podman run \
+#   -it --rm --entrypoint '' \
+#   quay.io/openshift/origin-ansible-operator:4.13 \
+#   ansible --version
+#
+# To install that version locally, you can git clone the source via:
+#   git clone -b v<ansible version> --depth 1 https://github.com/ansible/ansible.git
+# and then set up your environment via:
+#   source ./ansible/hacking/env-setup -q
+
+collections:
+- name: kubernetes.core
+  version: 2.2.3
+- name: operator_sdk.util
+  version: 0.4.0


### PR DESCRIPTION
Backport of https://github.com/infrawatch/service-telemetry-operator/pull/643
    
Downstream CVP uses the stable-1.5 branch and breaks without this.
    
(cherry picked from commit e67d43b9beef2128650561174fab294a6c4050b2)
