### PR TITLE
Update COO channel to stable

### DIFF
--- a/build/stf-run-ci/tasks/setup_base.yml
+++ b/build/stf-run-ci/tasks/setup_base.yml
@@ -42,7 +42,7 @@
         name: cluster-observability-operator
         namespace: openshift-operators
       spec:
-        channel: development
+        channel: stable
         installPlanApproval: Automatic
         name: cluster-observability-operator
         source: "{{ redhat_operators }}"


### PR DESCRIPTION
COO 1.0.0 now publishes their artifacts in the stable channel

The development channel that was in use is no longer available

Update stf-run-ci to reflect this