### PR TITLE
Update ansible-core in CI (#662)

### DIFF
--- a/build/stf-run-ci/requirements.txt
+++ b/build/stf-run-ci/requirements.txt
@@ -5,4 +5,4 @@ requests_oauthlib==1.3.0
 oauthlib==3.2.2
 kubernetes==24.2.0
 openshift==0.13.1
-ansible-core==2.15.9
+ansible-core==2.17.6

--- a/ci/README.md
+++ b/ci/README.md
@@ -9,13 +9,14 @@ The playbooks in this directory are used by zuul jobs, which are defined in ../.
 There are 6 jobs run on every PR that is targeting `master`.
 These are reported under the `rdoproject.org/github-check` check.
 
-Two scenarios run:
+Three scenarios run:
 - `local_build`, which builds the STF images and deploys by creating a STF object.
-- `local_build-index_deploy`, which builds the images and does an index-based deployment
+- `local_build-index_deploy`, which builds the images and does an index-based deployment.
+- `nightly_bundles-index_deploy`, which retrieves the nightly bundles and does an index-based deployment.
 
 Each of these scenarios run across the following OCP versions:
-- 4.14
 - 4.16
+- 4.18
 
 ### Periodic jobs
 

--- a/ci/prepare.yml
+++ b/ci/prepare.yml
@@ -5,24 +5,34 @@
     - name: "Setup play vars"
       ansible.builtin.include_tasks: "common-tasks.yml"
 
+    - name: "Install Python 3.12"
+      ansible.builtin.package:
+        name:
+          - python3.12
+          - python3.12-pip 
+        state: latest
+      become: true
+
     - name: "Update pip"
       ansible.builtin.pip:
         name: pip
         state: latest
         extra_args: "-U"
+        executable: pip3.12
 
     - name: "Install pre-reqs from pip"
       ansible.builtin.pip:
         requirements: "{{ sto_dir }}/build/stf-run-ci/requirements.txt"
         chdir: "{{ sto_dir }}"
         state: present
+        executable: pip3.12
 
     - name: "Install ansible collections"
       community.general.ansible_galaxy_install:
         type: collection
         name: "{{ item }}"
       with_items:
-        - "kubernetes.core:2.3.2"
+        - "kubernetes.core:5.0.0"
         - "community.general"
 
     - name: "Log into the cluster"


### PR DESCRIPTION
* Update ansible-core version

Updates the ansible-core version to 2.17.6 to fix several vulnerabilities existing in the current version (ansible-core==2.15.9).

By default, Python3.9 is available in Centos 9 Stream. Unfortunately, newer versions of ansible-core are not available for Python3.9, so this change also updates our CI to install and consume Python 3.12.

Also use kubernetes.core 5.0.0 in CI, we are already building STO with this version. Related commit a2ec3840033e8cdd327710b4751fddd3a930a394

* Fix CI readme

Jobs now run on OCP 4.16 and OCP 4.18. And we were missing the nighly bundles + index deploy jobs index description

(cherry picked from commit 57b2dbeb0c57c5b6fc39ca16d193a6235e6578fd)