### PR TITLE
Fix Ansible-Core vulnerable to content protections bypass (#664)

### DIFF
--- a/build/stf-run-ci/requirements.txt
+++ b/build/stf-run-ci/requirements.txt
@@ -5,4 +5,4 @@ requests_oauthlib==1.3.0
 oauthlib==3.2.2
 kubernetes==24.2.0
 openshift==0.13.1
-ansible-core==2.17.6
+ansible-core==2.17.8


### PR DESCRIPTION
A flaw was found in Ansible-Core. This vulnerability allows attackers to bypass unsafe content protections using the hostvars object to reference and execute templated content. This issue can lead to arbitrary code execution if remote data or module outputs are improperly templated within playbooks.

Affected versions >= 2.17.0b1, < 2.17.7rc1
Patched version 2.17.7rc1

(cherry picked from commit 29c23be673c35f96d02f5b32d811b3f7d18d79bd)