### PR TITLE
Update selector to get builder-dockercfg secret name

### DIFF
--- a/build/stf-run-ci/tasks/create_catalog.yml
+++ b/build/stf-run-ci/tasks/create_catalog.yml
@@ -115,7 +115,7 @@
         sgo_bundle_image_path: "{{ __internal_registry_path }}/{{ namespace }}/smart-gateway-operator-bundle:{{ sgo_bundle_info.operator_bundle_tag }}"
 
 - name: Get the builder-dockercfg Secret name
-  ansible.builtin.command: oc get secret -n {{ namespace }} --field-selector='type==kubernetes.io/dockercfg' -ojsonpath='{.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="builder")].metadata.name}'
+  ansible.builtin.command: oc get secret -n {{ namespace }} --field-selector='type=kubernetes.io/dockercfg' -ojsonpath='{.items[?(@.metadata.annotations.openshift\.io/internal-registry-auth-token\.service-account=="builder")].metadata.name}'
   register: secret_builder_dockercfg_name
 
 - name: Get contents of builder Secret


### PR DESCRIPTION
Fix the step to properly gather the builder-dockercfg secret name. This is required to correctly set up the auth when building the index image

Depends-On: https://github.com/infrawatch/service-telemetry-operator/pull/675