### PR TITLE
[zuul] Add PR jobs to the periodic lines

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -210,3 +210,10 @@
       jobs:
         - stf-crc-ocp_416-nightly_bundles
         - stf-crc-ocp_418-nightly_bundles
+        - stf-crc-ocp_416-local_build
+        - stf-crc-ocp_418-local_build
+        - stf-crc-ocp_416-local_build-index_deploy
+        - stf-crc-ocp_418-local_build-index_deploy
+        - stf-crc-ocp_416-nightly_bundles-index_deploy
+        - stf-crc-ocp_418-nightly_bundles-index_deploy
+


### PR DESCRIPTION
Since there is less development in STF now, we don't run the PR jobs as often. Running the jobs reqularly helps to find issues that crop up due to changing deps, etc and make sure the jobs still work.

This change adds the jobs from the github-check pipeline into the periodic line, ensuring that they run regularly.