### PR TITLE
bundle gen: allow passing in pre-generated bundle version

### DIFF
--- a/build/generate_bundle.sh
+++ b/build/generate_bundle.sh
@@ -81,7 +81,9 @@ build_bundle_instructions() {
 
 # generate templates
 #echo "## Begin bundle creation"
-generate_version
+if [[ -z "${OPERATOR_BUNDLE_VERSION}" ]]; then
+    generate_version
+fi
 create_working_dir
 generate_dockerfile
 generate_bundle


### PR DESCRIPTION
This improves our support for generating bundles as part of multistage container builds, as a single pre-generated bundle version can be fed into the generated bundle and into the bundle container labels.

RELDEL-7554