### PR TITLE
Use crc-cloud image for OCP 4.18 jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -13,7 +13,7 @@
       - name: controller
         label: cloud-centos-9-stream-tripleo-vexxhost
       - name: crc
-        label: coreos-crc-extracted-2-48-0-3xl
+        label: crc-cloud-ocp-4-18-1-3xl
 
 - job:
     name: stf-base-2node


### PR DESCRIPTION
coreos-crc-extracted-2-48-0-3xl is deprecated, the replacement for it is crc-cloud-ocp-4-18-1-3xl

Available images are in https://review.rdoproject.org/zuul/labels