### PR TITLE
Update olm.maxOpenShiftVersion to 4.18

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/metadata/properties.yaml
@@ -1,6 +1,6 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: "4.16"
+    value: "4.18"
   - type: olm.constraint
     value:
       failureMessage: Require Smart Gateway for Service Telemetry Framework


### PR DESCRIPTION
olm.maxOpenShiftVersion in STO should be 4.18 instead of 4.16

This wrongly set config is preventing STF users to easily perform upgrades to the latest OCP supported version

Closes-Bug: OSPRH-18670
(cherry picked from commit 69140fddf829a9f5e776723b091ab346b437bcd9)