### PR TITLE
Update OCP 4.20 job to use nodeset 4-20-14

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -13,8 +13,7 @@
       - name: controller
         label: cloud-centos-9-stream-tripleo-vexxhost
       - name: crc
-        label: crc-cloud-ocp-4-20-14-3x
-
+        label: crc-cloud-ocp-4-20-14-3xl
 - job:
     name: stf-base-2node
     parent: podified-multinode-edpm-deployment-crc

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -13,7 +13,7 @@
       - name: controller
         label: cloud-centos-9-stream-tripleo-vexxhost
       - name: crc
-        label: crc-cloud-ocp-4-20-1-3xl
+        label: crc-cloud-ocp-4-20-14-3x
 
 - job:
     name: stf-base-2node


### PR DESCRIPTION
This change https://github.com/openstack-k8s-operators/ci-framework/pull/3724/changes updates the nodeset names and labels from 4-20-1 to 4-20-14.

Update STF OCP 4.20 jobs to use the updated nodeset name