### PR TITLE
Use role instead of playbook - 01-bootstrap.yml and 02-infra.yml

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -34,6 +34,7 @@
         override-checkout: main
     pre-run:
       - ci/pre-2node.yml
+      - ci/2node.yml
     vars:
       cifmw_deploy_edpm: false
       podified_validation: true

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -40,6 +40,23 @@
     - __deploy_from_index_enabled | bool
     - __deploy_from_catalog | bool
 
+- name: Wait for OpenShift API server rollout to complete
+  ansible.builtin.command: >
+    oc rollout status deployment/apiserver
+    -n openshift-apiserver --timeout=300s
+
+- name: Wait for required OpenShift API groups to be available
+  ansible.builtin.command: >
+    oc api-resources --api-group={{ item }}
+  loop:
+    - build.openshift.io
+    - project.openshift.io
+    - operators.coreos.com
+  register: _api_check
+  until: _api_check.rc == 0 and _api_check.stdout | length > 0
+  retries: 30
+  delay: 10
+
 # -- prepare environment and cleanup
 - name: Clean up any existing global artifacts
   ansible.builtin.include_tasks: pre-clean.yml

--- a/ci/2node.yml
+++ b/ci/2node.yml
@@ -1,0 +1,50 @@
+---
+- name: "Do pre-work to get kubeconfig"
+  hosts: controller
+  gather_facts: true
+  vars:
+    ci_framework_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}"
+    cifmw_use_opn: false
+    cifmw_use_devscripts: false
+    cifmw_openshift_setup_skip_internal_registry_tls_verify: true
+    cifmw_target_host: controller
+  environment:
+    PATH: "~/.crc/bin:~/.crc/bin/oc:~/bin:{{ ansible_env.PATH }}"
+  tasks:
+    - name: "Set the sto_dir if it isn't already set"
+      ansible.builtin.set_fact:
+        sto_dir: '{{ ansible_env.HOME }}/{{ zuul.projects["github.com/infrawatch/service-telemetry-operator"].src_dir }}'
+      when: sto_dir | default('') | length == 0
+
+    - name: Read group_vars all file
+      vars:
+        included_file: "{{ ci_framework_dir }}/group_vars/all.yml"
+      ansible.builtin.include_role:
+        name: cifmw_helpers
+        tasks_from: include_file.yml
+
+    - name: Run bootstrap playbook
+      ansible.builtin.include_role:
+        name: cifmw_setup
+        tasks_from: bootstrap.yml
+
+    - name: Run pre_infra hooks
+      vars:
+        step: pre_infra
+      ansible.builtin.include_role:
+        name: run_hook
+
+    - name: Prepare the platform
+      vars:
+        step: pre_infra
+      ansible.builtin.include_role:
+        name: cifmw_setup
+        tasks_from: infra.yml
+
+    - name: Run make targets for setup
+      community.general.make:
+        chdir: "{{ ci_framework_dir }}"
+        target: "{{ item }}"
+      with_items:
+        - setup_tests
+        - setup_molecule

--- a/ci/pre-2node.yml
+++ b/ci/pre-2node.yml
@@ -1,33 +1,16 @@
 ---
-- name: "Do pre-work to get kubeconfig"
-  hosts: controller
-  vars:
-    ci_framework_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}"
-  environment:
-    PATH: "~/.crc/bin:~/.crc/bin/oc:~/bin:{{ ansible_env.PATH }}"
+- name: Make cifmw collection available on Zuul executor
+  hosts: localhost
   tasks:
-    - name: "Set the sto_dir if it isn't already set"
-      ansible.builtin.set_fact:
-        sto_dir: '{{ ansible_env.HOME }}/{{ zuul.projects["github.com/infrawatch/service-telemetry-operator"].src_dir }}'
-      when: sto_dir | default('') | length == 0
+    - name: Make a symlink to local .ansible collection dir
+      ansible.builtin.include_role:
+        name: cifmw_helpers
+        tasks_from: symlink_cifmw_collection.yml
 
-    - name: "Run bootstrap playbook"
-      ansible.builtin.shell:
-        cmd: |
-          ansible-playbook -e@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml {{ ci_framework_dir }}/playbooks/01-bootstrap.yml
-        chdir: "{{ ci_framework_dir }}"
-
-    - name: Run ci_framework infra playbook
-      ansible.builtin.shell:
-        cmd: |
-          ansible-playbook -e cifmw_use_opn=false -e cifmw_use_devscripts=false -e cifmw_basedir={{ ansible_user_dir }}/ci-framework-data/ -e cifmw_openshift_setup_skip_internal_registry_tls_verify=true playbooks/02-infra.yml
-        chdir: "{{ ci_framework_dir }}"
-
-    - name: Run make targets for setup
-      community.general.make:
-        chdir: '{{ ansible_env.HOME }}/{{ zuul.projects["github.com/openstack-k8s-operators/ci-framework"].src_dir }}'
-        target: "{{ item }}"
-      with_items:
-        - setup_tests
-        - setup_molecule
-
+- name: Make cifmw collection available on controller
+  hosts: controller
+  tasks:
+    - name: Make a symlink to local .ansible collection dir
+      ansible.builtin.include_role:
+        name: cifmw_helpers
+        tasks_from: symlink_cifmw_collection.yml


### PR DESCRIPTION
Playbook usage was deprecated for a while, so now after the playbooks have been removed from CI Framework project [1], the CI raise an error.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3882

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3193