### PR TITLE
Mark STO as deprecated (#704)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # service-telemetry-operator
 
+> **⚠️ DEPRECATED**: This operator is deprecated and will no longer receive updates with new features. Changes in this repository are only related to maintenance tasks. Users should migrate to alternative telemetry solutions.
+
 Umbrella Operator to instantiate all required components for Service Telemetry
 Framework.
 

--- a/catalog/service-telemetry-operator/deprecations.yaml
+++ b/catalog/service-telemetry-operator/deprecations.yaml
@@ -1,0 +1,9 @@
+---
+schema: olm.deprecations
+package: service-telemetry-operator
+entries:
+  - reference:
+      schema: olm.package
+    message: |
+      service-telemetry-operator is deprecated and future changes are limited to critical fixes.
+      Please migrate to alternative telemetry solutions.

--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -150,9 +150,12 @@ metadata:
     certified: "false"
     containerImage: <<OPERATOR_IMAGE_PULLSPEC>>
     createdAt: <<CREATED_DATE>>
-    description: Service Telemetry Framework. Umbrella Operator for instantiating
-      the required dependencies and configuration of various components to build a
-      Service Telemetry platform for telco grade monitoring.
+    description: 'DEPRECATED: This operator is deprecated and will no longer receive updates
+      with new features. Users should migrate to alternative telemetry solutions.
+      Service Telemetry Framework. Umbrella Operator for instantiating the required
+      dependencies and configuration of various components to build a Service Telemetry
+      platform for telco grade monitoring.'
+    operators.operatorframework.io/deprecated: "true"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"


### PR DESCRIPTION
Add deprecation notices to indicate this operator will no longer receive feature updates. Changes include CSV deprecated annotation, OLM deprecations file for OperatorHub warnings, and README deprecation banner.

(cherry picked from commit 5b767e062cdbc21ca598f5e0956136a28bc78eb6)