### PR TITLE
Ensure OpenShift API is available after rollout

### DIFF
--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -45,6 +45,18 @@
     oc rollout status deployment/apiserver
     -n openshift-apiserver --timeout=300s
 
+- name: Wait for OpenShift API server to be available and not progressing
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ClusterOperator
+    name: openshift-apiserver
+  register: _co_status
+  until: >
+    (_co_status.resources | length > 0) and
+    (_co_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Available') | map(attribute='status') | first == 'True')
+  retries: 60
+  delay: 10
+
 - name: Wait for required OpenShift API groups to be available
   ansible.builtin.command: >
     oc api-resources --api-group={{ item }}


### PR DESCRIPTION
It seems that on the OCP 4.18 after doing rollout on openshift-apiserver, the server might not be up-and-ready, where the returned status is marked as accomplished. By adding one more task that verify if the OpenShift API server is "Available", it seems to solve the issue.

This commit is a post continuation after merging change [1]

[1] 7cb3196bfc68f7b9362837cbce0591acc97d92f8

PR for master: https://github.com/infrawatch/service-telemetry-operator/pull/707

(cherry picked from commit 4383cd5f7dc9616ff08d77b7f9bc7bd61af0e954)