### PR TITLE
Wait a while for OpenShift API server to apply last changes

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -242,5 +242,3 @@
         - stf-crc-ocp_418-local_build-index_deploy
         - stf-crc-ocp_420-local_build-index_deploy
         - stf-crc-ocp_418-nightly_bundles-index_deploy
-        - stf-crc-ocp_418-nightly_bundles-index_deploy
-

--- a/build/stf-run-ci/defaults/main.yml
+++ b/build/stf-run-ci/defaults/main.yml
@@ -81,3 +81,5 @@ base_dir: ''
 clone_repos: true
 setup_bundle_registry_auth: true
 setup_bundle_registry_tls_ca: true
+
+stf_cluster_stable_period: 120

--- a/build/stf-run-ci/tasks/main.yml
+++ b/build/stf-run-ci/tasks/main.yml
@@ -40,22 +40,15 @@
     - __deploy_from_index_enabled | bool
     - __deploy_from_catalog | bool
 
-- name: Wait for OpenShift API server rollout to complete
-  ansible.builtin.command: >
-    oc rollout status deployment/apiserver
-    -n openshift-apiserver --timeout=300s
+- name: Copy script for ensuring if cluster is stable
+  become: true
+  ansible.builtin.template:
+    src: check-cluster-co.sh.j2
+    dest: /usr/local/bin/check-cluster-co.sh
+    mode: "0755"
 
-- name: Wait for OpenShift API server to be available and not progressing
-  kubernetes.core.k8s_info:
-    api_version: config.openshift.io/v1
-    kind: ClusterOperator
-    name: openshift-apiserver
-  register: _co_status
-  until: >
-    (_co_status.resources | length > 0) and
-    (_co_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Available') | map(attribute='status') | first == 'True')
-  retries: 60
-  delay: 10
+- name: Run script to ensure cluster is stable
+  ansible.builtin.command: /usr/local/bin/check-cluster-co.sh
 
 - name: Wait for required OpenShift API groups to be available
   ansible.builtin.command: >

--- a/build/stf-run-ci/templates/check-cluster-co.sh.j2
+++ b/build/stf-run-ci/templates/check-cluster-co.sh.j2
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# NOTE(dpawlik): Normally we will execute command:
+#     oc adm wait-for-stable-cluster --minimum-stable-period=120s --timeout=30m
+# but the CI is based on CRC where some files that are tracked by machineconfigpool
+# would be degraded.
+
+TIMEOUT=600
+STABLE_PERIOD={{ stf_cluster_stable_period }}
+POLL=10
+
+echo "Waiting for cluster operators to stabilize (ignoring machine-config)..."
+
+start_time=$(date +%s)
+stable_since=0
+
+while true; do
+    now=$(date +%s)
+    if ((now - start_time > TIMEOUT)); then
+        echo "Timeout reached"
+        exit 1
+    fi
+
+    # Any watched CO that is NOT Available=True, Progressing=False, Degraded=False
+    unstable=$(oc get clusteroperator --no-headers 2>/dev/null |
+        grep -v '^machine-config ' |
+        awk '$3 != "True" || $4 != "False" || $5 != "False" { print $1 }')
+
+    if [[ -z "$unstable" ]]; then
+        if ((stable_since == 0)); then
+            stable_since=$now
+            echo "All relevant operators stable. Waiting for minimum stable period (${STABLE_PERIOD}s)..."
+        elif ((now - stable_since >= STABLE_PERIOD)); then
+            echo "Cluster is stable (machine-config ignored)."
+            exit 0
+        fi
+    else
+        if ((stable_since != 0)); then
+            echo "Operators became unstable again: ${unstable[*]}"
+        fi
+        stable_since=0
+    fi
+
+    echo "Sleeping $POLL to meet condition..."
+    sleep "$POLL"
+done


### PR DESCRIPTION
In some corner cases, when infrastructure might be overloaded, the OpenShift API is not restarted
immediately, but it is done after a while. From basic check on failing job, it happens from up to 90 seconds.
Making condition that would watch on OpenShift API server that has been finally changed state to to terminating then back to active might be a good alternative here, but can also impact future job if such restart is not needed.

Also remove duplicated line from periodic job in zuul config. 