### PR TITLE
Add from_json to Decode docker config json step

### DIFF
--- a/build/stf-run-ci/tasks/setup_registry_auth.yml
+++ b/build/stf-run-ci/tasks/setup_registry_auth.yml
@@ -11,7 +11,7 @@
 
   - name: Decode docker config json
     ansible.builtin.set_fact:
-      dockerconfigjson: "{{ pull_secret.resources[0].data['.dockerconfigjson'] | b64decode }}"
+      dockerconfigjson: "{{ pull_secret.resources[0].data['.dockerconfigjson'] | b64decode | from_json }}"
 
   - name: Merge registry creds into auth section of docker config
     ansible.builtin.set_fact:


### PR DESCRIPTION
Add from_json so that the JSON output is parsed into a dictionary

This is required for the next steps when updating the registry secrets

(cherry picked from commit 609e482026757d8d5a8cea0ddc58c3b3972656cf)