### PR TITLE
Parse JSON after base64 decode in create_index_image

### DIFF
--- a/build/stf-run-ci/tasks/create_index_image.yml
+++ b/build/stf-run-ci/tasks/create_index_image.yml
@@ -134,7 +134,7 @@
 
 - name: Get builder-dockercfg authentication contents
   ansible.builtin.set_fact:
-    builder_dockercfg_auth_results: "{{ secret_builder_dockercfg_results.resources[0].data['.dockercfg'] | b64decode }}"
+    builder_dockercfg_auth_results: "{{ secret_builder_dockercfg_results.resources[0].data['.dockercfg'] | b64decode | from_json }}"
 
 - name: Set internal registry authentication
   ansible.builtin.set_fact:


### PR DESCRIPTION
Fix Ansible template error when accessing builder-dockercfg authentication. The b64decode filter returns a string, not a dict. Added from_json filter to parse the decoded JSON before accessing dict keys.