### PR TITLE
Mark ServiceTelemetry CR spec values as unsafe for Ansible templating

### DIFF
--- a/watches.yaml
+++ b/watches.yaml
@@ -3,3 +3,4 @@
   group: infra.watch
   kind: ServiceTelemetry
   role: /opt/ansible/roles/servicetelemetry
+  markUnsafe: true


### PR DESCRIPTION
Set markUnsafe: true in watches.yaml so that CR spec fields are treated as literal strings during Ansible reconciliation, matching the recommended ansible-operator configuration for custom resources.

Related-To: OSPRH-33070