### PR TITLE
Restrict RBAC permissions

### DIFF
--- a/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-telemetry-operator/manifests/service-telemetry-operator.clusterserviceversion.yaml
@@ -237,9 +237,17 @@ spec:
           - clusterrolebindings
           verbs:
           - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          resourceNames:
+          - prometheus-stf
+          - alertmanager-stf
+          - prometheus-k8s-service-telemetry
+          verbs:
           - get
-          - list
-          - watch
           - update
           - patch
           - delete
@@ -376,16 +384,69 @@ spec:
           - '*'
         - apiGroups:
           - interconnectedcloud.github.io
+          resources:
+          - interconnects
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+        - apiGroups:
           - smartgateway.infra.watch
+          resources:
+          - smartgateways
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+        - apiGroups:
           - monitoring.coreos.com
           - monitoring.rhobs
+          resources:
+          - prometheuses
+          - alertmanagers
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+        - apiGroups:
           - elasticsearch.k8s.elastic.co
+          resources:
+          - elasticsearches
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+        - apiGroups:
           - grafana.integreatly.org
           - integreatly.org
           resources:
-          - '*'
+          - grafanas
+          - grafanadashboards
+          - grafanadatasources
           verbs:
-          - '*'
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
         - apiGroups:
           - monitoring.coreos.com
           resources:
@@ -427,9 +488,17 @@ spec:
         - apiGroups:
           - infra.watch
           resources:
-          - '*'
+          - servicetelemetrys
+          - servicetelemetrys/status
+          - servicetelemetrys/finalizers
           verbs:
-          - '*'
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -437,9 +506,18 @@ spec:
           - rolebindings
           verbs:
           - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          resourceNames:
+          - prometheus-stf
+          - alertmanager-stf
+          - prometheus-reader
+          - stf-prometheus-reader
+          verbs:
           - get
-          - list
-          - watch
           - update
           - patch
         - apiGroups:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -17,9 +17,17 @@ rules:
   - clusterrolebindings
   verbs:
   - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  resourceNames:
+  - prometheus-stf
+  - alertmanager-stf
+  - prometheus-k8s-service-telemetry
+  verbs:
   - get
-  - list
-  - watch
   - update
   - patch
   - delete
@@ -116,16 +124,69 @@ rules:
   - '*'
 - apiGroups:
   - interconnectedcloud.github.io
+  resources:
+  - interconnects
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
   - smartgateway.infra.watch
+  resources:
+  - smartgateways
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
   - monitoring.coreos.com
   - monitoring.rhobs
+  resources:
+  - prometheuses
+  - alertmanagers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
   - elasticsearch.k8s.elastic.co
+  resources:
+  - elasticsearches
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
   - grafana.integreatly.org
   - integreatly.org
   resources:
-  - '*'
+  - grafanas
+  - grafanadashboards
+  - grafanadatasources
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -167,9 +228,17 @@ rules:
 - apiGroups:
   - infra.watch
   resources:
-  - '*'
+  - servicetelemetrys
+  - servicetelemetrys/status
+  - servicetelemetrys/finalizers
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -177,9 +246,18 @@ rules:
   - rolebindings
   verbs:
   - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  resourceNames:
+  - prometheus-stf
+  - alertmanager-stf
+  - prometheus-reader
+  - stf-prometheus-reader
+  verbs:
   - get
-  - list
-  - watch
   - update
   - patch
 - apiGroups:


### PR DESCRIPTION
Add resourceNames scoping to clusterroles, clusterrolebindings, roles, and rolebindings. Replace wildcard resources and verbs on CRD API groups with explicit values.

Assisted-by: Claude
Related-to: OSPRH-33074