### PR TITLE
Harden SNMP webhook and Prometheus workload security

### DIFF
--- a/roles/servicetelemetry/defaults/main.yml
+++ b/roles/servicetelemetry/defaults/main.yml
@@ -140,6 +140,13 @@ servicetelemetry_defaults:
 # auto-detected by the role and are not meant to be set by the user. However,
 # for debugging purposes you can change these.
 
+sto_resource_defaults:
+  snmp_webhook:
+    cpu_limit: "100m"
+    memory_limit: "128Mi"
+    cpu_request: "10m"
+    memory_request: "32Mi"
+
 is_k8s: false
 is_openshift: false
 

--- a/roles/servicetelemetry/tasks/component_snmp_traps.yml
+++ b/roles/servicetelemetry/tasks/component_snmp_traps.yml
@@ -1,3 +1,44 @@
+- name: Check for existing resource limits ConfigMap
+  k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: 'snmp-webhook-resource-limits'
+  register: snmp_resource_limits_cm
+
+- name: Create resource limits ConfigMap
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: 'snmp-webhook-resource-limits'
+        namespace: '{{ ansible_operator_meta.namespace }}'
+      data:
+        snmp_webhook_cpu_limit: "{{ sto_resource_defaults.snmp_webhook.cpu_limit }}"
+        snmp_webhook_memory_limit: "{{ sto_resource_defaults.snmp_webhook.memory_limit }}"
+        snmp_webhook_cpu_request: "{{ sto_resource_defaults.snmp_webhook.cpu_request }}"
+        snmp_webhook_memory_request: "{{ sto_resource_defaults.snmp_webhook.memory_request }}"
+  when: snmp_resource_limits_cm.resources | length == 0
+
+- name: Set resource limits from ConfigMap
+  vars:
+    cm_data: "{{ snmp_resource_limits_cm.resources[0].data }}"
+  set_fact:
+    sto_resources:
+      snmp_webhook:
+        cpu_limit: "{{ cm_data.snmp_webhook_cpu_limit | default(sto_resource_defaults.snmp_webhook.cpu_limit) }}"
+        memory_limit: "{{ cm_data.snmp_webhook_memory_limit | default(sto_resource_defaults.snmp_webhook.memory_limit) }}"
+        cpu_request: "{{ cm_data.snmp_webhook_cpu_request | default(sto_resource_defaults.snmp_webhook.cpu_request) }}"
+        memory_request: "{{ cm_data.snmp_webhook_memory_request | default(sto_resource_defaults.snmp_webhook.memory_request) }}"
+  when: snmp_resource_limits_cm.resources | length > 0
+
+- name: Set resource limits from defaults
+  set_fact:
+    sto_resources:
+      snmp_webhook: "{{ sto_resource_defaults.snmp_webhook }}"
+  when: snmp_resource_limits_cm.resources | length == 0
+
 - name: Lookup template
   debug:
     msg: "{{ lookup('template', './manifest_snmp_traps.j2') | from_yaml }}"

--- a/roles/servicetelemetry/templates/manifest_prometheus.j2
+++ b/roles/servicetelemetry/templates/manifest_prometheus.j2
@@ -15,7 +15,6 @@ spec:
 {% endif %}
   replicas: {{ servicetelemetry_vars.backends.metrics.prometheus.deployment_size }}
   ruleSelector: {}
-  securityContext: {}
   serviceAccountName: prometheus-stf
   scrapeConfigSelector:
     matchLabels:

--- a/roles/servicetelemetry/templates/manifest_snmp_traps.j2
+++ b/roles/servicetelemetry/templates/manifest_snmp_traps.j2
@@ -13,11 +13,38 @@ spec:
       labels:
         app: '{{ ansible_operator_meta.name }}-snmp-webhook'
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: 'prometheus-webhook-snmp'
           image: '{{ prometheus_webhook_snmp_container_image_path }}'
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 9099
+          resources:
+            requests:
+              cpu: '{{ sto_resources.snmp_webhook.cpu_request }}'
+              memory: '{{ sto_resources.snmp_webhook.memory_request }}'
+            limits:
+              cpu: '{{ sto_resources.snmp_webhook.cpu_limit }}'
+              memory: '{{ sto_resources.snmp_webhook.memory_limit }}'
+          livenessProbe:
+            tcpSocket:
+              port: 9099
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 9099
+            initialDelaySeconds: 3
+            periodSeconds: 10
           env:
             - name: SNMP_COMMUNITY
               value: "{{ servicetelemetry_vars.alerting.alertmanager.receivers.snmp_traps.community }}"


### PR DESCRIPTION
Add pod/container securityContext, ConfigMap-based resource limits, and health probes to the SNMP webhook Deployment template. Remove the empty securityContext: {} override from the Prometheus CR so the Prometheus operator's own defaults apply.

The resource limits follow the same ConfigMap pattern used in smart-gateway-operator (PR #217): defaults ship in defaults/main.yml, a ConfigMap is created on first reconcile, and users can tune values without rebuilding the operator or modifying the CRD.

Related-To: OSPRH-33076

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>